### PR TITLE
Fix share on WhatsApp due to access permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 ### Fixed
 - Many SCA suggestions applied.
+- Sharing buttons issues due to a bad permissions setup.
 
 ## \[v1.1.0] - 2017-08-16
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,16 @@
         android:supportsRtl="true"
         android:theme="@style/feature_base_MyCustomTheme">
 
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_provider_paths" />
+        </provider>
+
         <activity
             android:name=".ui.home.HomeActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsAdapter.java
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsAdapter.java
@@ -18,8 +18,10 @@ import android.widget.ToggleButton;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RawRes;
+import androidx.core.content.FileProvider;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.github.barriosnahuel.vossosunboton.BuildConfig;
 import com.github.barriosnahuel.vossosunboton.R;
 import com.github.barriosnahuel.vossosunboton.commons.android.ui.Feedback;
 import com.github.barriosnahuel.vossosunboton.model.Sound;
@@ -36,6 +38,10 @@ import timber.log.Timber;
  */
 /* default */ class SoundsAdapter extends RecyclerView.Adapter<SoundViewHolder> {
 
+    /**
+     * Check https://developer.android.com/training/secure-file-sharing/setup-sharing for more info.
+     */
+    private static final String FILE_PROVIDER_AUTHORITY = BuildConfig.APPLICATION_ID + ".fileprovider";
     private final int marginPx;
 
     @NonNull
@@ -57,10 +63,11 @@ import timber.log.Timber;
         mediaPlayer = new MediaPlayer();
     }
 
+    @NonNull
     @Override
-    public SoundViewHolder onCreateViewHolder(final ViewGroup parent, final int viewType) {
+    public SoundViewHolder onCreateViewHolder(@NonNull final ViewGroup parent, final int viewType) {
         final ToggleButton button =
-            (ToggleButton) LayoutInflater.from(parent.getContext()).inflate(R.layout.layout_button, parent, false);
+                (ToggleButton) LayoutInflater.from(parent.getContext()).inflate(R.layout.layout_button, parent, false);
 
         final RecyclerView.LayoutParams layoutParams = (RecyclerView.LayoutParams) button.getLayoutParams();
 
@@ -71,7 +78,7 @@ import timber.log.Timber;
     }
 
     @Override
-    public void onBindViewHolder(final SoundViewHolder holder, final int position) {
+    public void onBindViewHolder(@NonNull final SoundViewHolder holder, final int position) {
         final ToggleButton toggleButton = holder.toggleButton;
 
         final RecyclerView.LayoutParams layoutParams = (RecyclerView.LayoutParams) toggleButton.getLayoutParams();
@@ -105,7 +112,8 @@ import timber.log.Timber;
 
             final Intent shareIntent = new Intent();
             shareIntent.setAction(Intent.ACTION_SEND);
-            shareIntent.putExtra(Intent.EXTRA_STREAM, Uri.parse(sound.getFile()));
+            Uri uriForFile = FileProvider.getUriForFile(view.getContext(), FILE_PROVIDER_AUTHORITY, new File(sound.getFile()));
+            shareIntent.putExtra(Intent.EXTRA_STREAM, uriForFile);
             shareIntent.setType("audio/*");
             shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
             view.getContext().startActivity(

--- a/app/src/main/res/xml/file_provider_paths.xml
+++ b/app/src/main/res/xml/file_provider_paths.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <!-- Check https://developer.android.com/training/secure-file-sharing/setup-sharing#DefineMetaData for more info. -->
+    <external-files-path
+        name="buttons"
+        path="." />
+</paths>


### PR DESCRIPTION
## Description
- Sharing on WhatsApp is working now.

## Why do we need these changes
To be able to share files. If not, then WhatsApp throws a Toast saying that: "Sharing audio failed".