### PR TITLE
API Level changed to 19-29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 ## \[unreleased]
 ### Added
-- Support for Android P (API Level 28).
+- Support for Android Q (API Level 29).
 - Pull Requests template for contributors.
 - Firebase Analytics. 
 - Firebase Crashlytics.
@@ -16,7 +16,8 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Codacy checks integration through GitHub.
 
 ### Changed
--Circle CI config migrated to v2.1 using Orbs.
+- Min Android version required is KitKat (API Level 19).
+- Circle CI config migrated to v2.1 using Orbs.
 - Many dependencies to the latest versions including Gradle, Android Build Tools, AppCompat,
 Firebase and static code analyzers too.
 - Migration to Android X.
@@ -29,6 +30,7 @@ Firebase and static code analyzers too.
 ### Fixed
 - Many SCA suggestions applied.
 - Sharing buttons issues due to a bad permissions setup.
+- Usage of resources like `InputStream`, `OutputStream` and `Cursor`
 
 ## \[v1.1.0] - 2017-08-16
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,13 +12,13 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    compileSdkVersion 28
+    compileSdkVersion 29
     buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "com.github.barriosnahuel.vossosunboton"
-        minSdkVersion 18
-        targetSdkVersion 28
+        minSdkVersion 19
+        targetSdkVersion 29
         versionCode 4
         versionName '2.0.0'
     }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsAdapter.java
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsAdapter.java
@@ -254,20 +254,21 @@ import timber.log.Timber;
                 throws IOException {
 
             final File file = new File(fileInfo);
-            final FileInputStream inputStream = new FileInputStream(file);
-            mediaPlayer.reset();
-            mediaPlayer.setDataSource(inputStream.getFD());
-            inputStream.close();
+            try (FileInputStream inputStream = new FileInputStream(file)) {
+                mediaPlayer.reset();
+                mediaPlayer.setDataSource(inputStream.getFD());
+            }
         }
 
         private String getRingtoneUriFromPath(@NonNull final Context context, @NonNull final String path) {
             final Uri ringtonesUri = MediaStore.Audio.Media.getContentUriForPath(path);
-            final Cursor ringtoneCursor = context.getContentResolver()
-                .query(ringtonesUri, null, MediaStore.Audio.Media.DATA + "='" + path + "'", null, null);
-            ringtoneCursor.moveToFirst();
+            final long id;
+            try (Cursor ringtoneCursor = context.getContentResolver()
+                    .query(ringtonesUri, null, MediaStore.Audio.Media.DATA + "='" + path + "'", null, null)) {
+                ringtoneCursor.moveToFirst();
 
-            final long id = ringtoneCursor.getLong(ringtoneCursor.getColumnIndex(MediaStore.Audio.Media._ID));
-            ringtoneCursor.close();
+                id = ringtoneCursor.getLong(ringtoneCursor.getColumnIndex(MediaStore.Audio.Media._ID));
+            }
 
             if (!ringtonesUri.toString().endsWith(String.valueOf(id))) {
                 return ringtonesUri + "/" + id;
@@ -277,13 +278,12 @@ import timber.log.Timber;
 
         private String getRingtonePathFromContentUri(@NonNull final Context context, @NonNull final Uri contentUri) {
             final String[] projection = { MediaStore.Audio.Media.DATA };
-            final Cursor ringtoneCursor = context.getContentResolver().query(contentUri, projection, null, null, null);
-            ringtoneCursor.moveToFirst();
+            final String path;
+            try (Cursor ringtoneCursor = context.getContentResolver().query(contentUri, projection, null, null, null)) {
+                ringtoneCursor.moveToFirst();
 
-            final String path =
-                ringtoneCursor.getString(ringtoneCursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATA));
-
-            ringtoneCursor.close();
+                path = ringtoneCursor.getString(ringtoneCursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATA));
+            }
             return path;
         }
     }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsAdapter.java
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsAdapter.java
@@ -112,7 +112,8 @@ import timber.log.Timber;
 
             final Intent shareIntent = new Intent();
             shareIntent.setAction(Intent.ACTION_SEND);
-            Uri uriForFile = FileProvider.getUriForFile(view.getContext(), FILE_PROVIDER_AUTHORITY, new File(sound.getFile()));
+            final Uri uriForFile = FileProvider.getUriForFile(view.getContext(),
+                    FILE_PROVIDER_AUTHORITY, new File(sound.getFile()));
             shareIntent.putExtra(Intent.EXTRA_STREAM, uriForFile);
             shareIntent.setType("audio/*");
             shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         classpath 'com.google.firebase:perf-plugin:1.3.1'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50'
 
-        classpath 'com.monits:static-code-analysis-plugin:2.6.10'
+        classpath 'com.monits:static-code-analysis-plugin:2.6.11'
         classpath 'io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.0.1'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.6'
 

--- a/commons_android/build.gradle
+++ b/commons_android/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.monits.staticCodeAnalysis'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 28
+        minSdkVersion 19
+        targetSdkVersion 29
     }
 
     resourcePrefix 'commons_android_'

--- a/feature_addbutton/build.gradle
+++ b/feature_addbutton/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.monits.staticCodeAnalysis'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 28
+        minSdkVersion 19
+        targetSdkVersion 29
     }
 
     resourcePrefix 'feature_addbutton_'

--- a/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivity.java
+++ b/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivity.java
@@ -177,32 +177,26 @@ public class AddButtonActivity extends AbstractActivity {
      */
     @SuppressWarnings("PMD.AvoidFileStream")
     private void saveNewButton() {
-        final String targetPath =
-            getExternalFilesDir(Environment.DIRECTORY_MUSIC) + "Button-" + System.currentTimeMillis() + ".mp3";
-
-        FileOutputStream fileOutputStream;
-        try {
-            fileOutputStream = new FileOutputStream(targetPath);
-        } catch (final FileNotFoundException e) {
-            Timber.e("Can't create new button's path");
-            fileOutputStream = null;
-        }
+        final String targetPath = getExternalFilesDir(Environment.DIRECTORY_MUSIC) + "Button-" + System.currentTimeMillis() + ".mp3";
 
         int feedbackMessage = R.string.feature_base_general_error_contact_support;
-        if (fileOutputStream != null) {
-            try {
-                // TODO: 11/12/16 Run it on another thread
-                final InputStream inputStream = getContentResolver().openInputStream(Uri.parse(uri.toString()));
-                if (inputStream == null) {
-                    Timber.e("Input stream obtained from the specified content URI is null: %s", uri.toString());
-                } else {
-                    FileUtils.copy(inputStream, fileOutputStream);
-                    soundsDao.save(this, new Sound(name.getText().toString(), targetPath));
-                    feedbackMessage = R.string.feature_addbutton_feedback_saved_ok;
-                }
-            } catch (final IOException e) {
-                Timber.e("Can't copy original audio");
+
+        // TODO: 11/12/16 Run it on another thread
+        try (
+                FileOutputStream fileOutputStream = new FileOutputStream(targetPath);
+                InputStream inputStream = getContentResolver().openInputStream(Uri.parse(uri.toString()))
+        ) {
+            if (inputStream == null) {
+                Timber.e("Input stream obtained from the specified content URI is null: %s", uri.toString());
+            } else {
+                FileUtils.copy(inputStream, fileOutputStream);
+                soundsDao.save(this, new Sound(name.getText().toString(), targetPath));
+                feedbackMessage = R.string.feature_addbutton_feedback_saved_ok;
             }
+        } catch (final FileNotFoundException e) {
+            Timber.e("Can't create new button's path");
+        } catch (final IOException e) {
+            Timber.e("Can't copy original audio");
         }
 
         Feedback.send(this, feedbackMessage);

--- a/feature_base/build.gradle
+++ b/feature_base/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.monits.staticCodeAnalysis'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 28
+        minSdkVersion 19
+        targetSdkVersion 29
     }
 
     resourcePrefix 'feature_base_'

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -5,11 +5,11 @@ apply plugin: 'io.gitlab.arturbosch.detekt'
 apply from: '../ktlint.gradle'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 28
+        minSdkVersion 19
+        targetSdkVersion 29
     }
 
     resourcePrefix 'model_'


### PR DESCRIPTION
## Description
- Min API Level to v19.
- Target API Level to v29.
- Use try-with-resources to be sure to close `InputStream`, `OutputStream` and `Cursor`.
- Upgrade SCA to [v2.6.11](https://github.com/Monits/static-code-analysis-plugin/releases/tag/2.6.11)

## Why do we need these changes
To be up-to-date, and also to fix project to be able to merge #22 