### PR TITLE
Add multidex support for debug builds only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Added Detekt static code analysis tool, as well as Ktlint for code style conventions.
 - Setup [Stale GitHub app](https://github.com/apps/stale).
 - Codacy checks integration through GitHub.
+- Multidex support for debug builds.
 
 ### Changed
 - Min Android version required is KitKat (API Level 19).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,6 +51,7 @@ android {
         debug {
             applicationIdSuffix ".debug"
             versionNameSuffix '-DEBUG'
+            multiDexEnabled true
         }
 
         release {
@@ -89,6 +90,8 @@ dependencies {
     implementation 'com.google.firebase:firebase-perf:19.0.0'
 
     implementation 'com.jakewharton.timber:timber:4.7.1'
+
+    debugImplementation 'androidx.multidex:multidex:2.0.1'
 
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.6.3'
 

--- a/app/src/debug/java/com/github/barriosnahuel/vossosunboton/CustomBuildTypeApplication.kt
+++ b/app/src/debug/java/com/github/barriosnahuel/vossosunboton/CustomBuildTypeApplication.kt
@@ -1,9 +1,9 @@
 package com.github.barriosnahuel.vossosunboton
 
-import android.app.Application
+import androidx.multidex.MultiDexApplication
 import timber.log.Timber
 
-internal abstract class CustomBuildTypeApplication : Application() {
+internal abstract class CustomBuildTypeApplication : MultiDexApplication() {
 
     override fun onCreate() {
         Timber.plant(Timber.DebugTree())


### PR DESCRIPTION
## Description
- turn `true` the flag `multiDexEnabled` for the `debug` build type

## Why do we need these changes
To be able to add new libraries like: `com.google.android.material:material:1.0.0` (it's gonna be added in a future PR when adding the remove button feature)