### PR TITLE
Better integrations for debug tools (strict mode & leak canary)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,12 +30,17 @@ Firebase and static code analyzers too.
 - Default language to English.
 - Gradle version to [v5.6.2](https://docs.gradle.org/5.6.2/release-notes.html).
 - Better separation of responsibilities.
+- `StrictMode` warnings now are logged to Crashlytics instead of the debugging notifier.
 
 ### Fixed
 - Many SCA suggestions applied.
 - Sharing buttons issues due to a bad permissions setup.
 - Usage of resources like `InputStream`, `OutputStream` and `Cursor`.
 - Stop exposing Firebase API configuration file.
+- Crashes when debugging because of a bug in library StrictModeNotifier
+
+### Removed
+- Library StrictModeNotifier for debug builds.
 
 ## \[v1.1.0] - 2017-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Firebase and static code analyzers too.
 - Gradle version to [v5.6.2](https://docs.gradle.org/5.6.2/release-notes.html).
 - Better separation of responsibilities.
 - `StrictMode` warnings now are logged to Crashlytics instead of the debugging notifier.
+- `LeakCanary` warnings now are logged to Crashlytics.
 
 ### Fixed
 - Many SCA suggestions applied.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -98,8 +98,6 @@ dependencies {
 
     debugImplementation 'com.facebook.stetho:stetho:1.5.1'
 
-    debugImplementation 'com.nshmura:strictmode-notifier:0.9.3'
-
     testImplementation 'junit:junit:4.12'
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,7 +87,6 @@ dependencies {
     implementation 'com.google.android.material:material:1.0.0'
 
     implementation 'com.google.firebase:firebase-core:17.2.0'
-    implementation 'com.crashlytics.sdk.android:crashlytics:2.10.1'
     implementation 'com.google.firebase:firebase-perf:19.0.1'
 
     implementation 'com.jakewharton.timber:timber:4.7.1'

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -6,6 +6,8 @@
         <meta-data
             android:name="firebase_performance_logcat_enabled"
             android:value="true" />
+
+        <service android:name=".MemoryLeakTrackerService" />
     </application>
 
 </manifest>

--- a/app/src/debug/java/com/github/barriosnahuel/vossosunboton/DebugTools.kt
+++ b/app/src/debug/java/com/github/barriosnahuel/vossosunboton/DebugTools.kt
@@ -2,16 +2,13 @@ package com.github.barriosnahuel.vossosunboton
 
 import android.app.Application
 import com.facebook.stetho.Stetho
-import com.squareup.leakcanary.LeakCanary
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 
-internal class DebugTools {
+internal object DebugTools {
 
-    companion object {
-        @JvmStatic
-        fun configure(application: Application) {
-            LeakCanary.install(application)
-            Stetho.initializeWithDefaults(application)
-            StrictModeHelper().initializeWithDefaults()
-        }
+    fun configure(application: Application) {
+        StrictModeConfigurator.initializeWithDefaults(Tracker)
+        LeakCanaryConfigurator.initializeWithDefaults(application, Tracker)
+        Stetho.initializeWithDefaults(application)
     }
 }

--- a/app/src/debug/java/com/github/barriosnahuel/vossosunboton/DebugTools.kt
+++ b/app/src/debug/java/com/github/barriosnahuel/vossosunboton/DebugTools.kt
@@ -11,7 +11,7 @@ internal class DebugTools {
         fun configure(application: Application) {
             LeakCanary.install(application)
             Stetho.initializeWithDefaults(application)
-            StrictModeHelper().initializeWithDefaults(application)
+            StrictModeHelper().initializeWithDefaults()
         }
     }
 }

--- a/app/src/debug/java/com/github/barriosnahuel/vossosunboton/LeakCanaryConfigurator.kt
+++ b/app/src/debug/java/com/github/barriosnahuel/vossosunboton/LeakCanaryConfigurator.kt
@@ -1,0 +1,38 @@
+package com.github.barriosnahuel.vossosunboton
+
+import android.app.Application
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Trackable
+import com.squareup.leakcanary.AnalysisResult
+import com.squareup.leakcanary.DisplayLeakService
+import com.squareup.leakcanary.HeapDump
+import com.squareup.leakcanary.LeakCanary
+import kotlin.reflect.KProperty
+
+
+object LeakCanaryConfigurator {
+
+    private var tracker: Trackable? = null
+
+    fun initializeWithDefaults(application: Application, tracker: Trackable) {
+        LeakCanary.install(application)
+        this.tracker = tracker
+    }
+
+    operator fun getValue(thisRef: MemoryLeakTrackerService, property: KProperty<*>): Trackable = tracker!!
+}
+
+
+class MemoryLeakTrackerService : DisplayLeakService() {
+
+    private val tracker: Trackable by LeakCanaryConfigurator
+
+    override fun afterDefaultHandling(heapDump: HeapDump, result: AnalysisResult, leakInfo: String) {
+        if (!result.leakFound || result.excludedLeak) {
+            return
+        }
+
+        tracker.track(MemoryLeakException(result.leakTraceAsFakeException()))
+    }
+}
+
+private class MemoryLeakException(e: Throwable) : RuntimeException(e)

--- a/app/src/debug/java/com/github/barriosnahuel/vossosunboton/LeakCanaryConfigurator.kt
+++ b/app/src/debug/java/com/github/barriosnahuel/vossosunboton/LeakCanaryConfigurator.kt
@@ -9,7 +9,7 @@ import com.squareup.leakcanary.LeakCanary
 import kotlin.reflect.KProperty
 
 
-object LeakCanaryConfigurator {
+internal object LeakCanaryConfigurator {
 
     private var tracker: Trackable? = null
 
@@ -22,6 +22,9 @@ object LeakCanaryConfigurator {
 }
 
 
+/**
+ * Custom service that reports memory leaks detected by LeakCanary to our error tracking tool.
+ */
 class MemoryLeakTrackerService : DisplayLeakService() {
 
     private val tracker: Trackable by LeakCanaryConfigurator

--- a/app/src/debug/java/com/github/barriosnahuel/vossosunboton/StrictModeConfigurator.kt
+++ b/app/src/debug/java/com/github/barriosnahuel/vossosunboton/StrictModeConfigurator.kt
@@ -2,18 +2,18 @@ package com.github.barriosnahuel.vossosunboton
 
 import android.os.Build
 import android.os.StrictMode
-import com.crashlytics.android.Crashlytics
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Trackable
 import java.util.concurrent.Executors
 
-internal class StrictModeHelper {
+internal object StrictModeConfigurator {
 
-    fun initializeWithDefaults() {
-        setupThreadPolicy()
-        setupVirtualMachinePolicy()
+    fun initializeWithDefaults(trackable: Trackable) {
+        setupThreadPolicy(trackable)
+        setupVirtualMachinePolicy(trackable)
     }
 }
 
-private fun setupThreadPolicy() {
+private fun setupThreadPolicy(trackable: Trackable) {
     val threadPolicyBuilder = StrictMode.ThreadPolicy.Builder()
             .detectCustomSlowCalls()
             .detectNetwork()
@@ -26,14 +26,14 @@ private fun setupThreadPolicy() {
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
         threadPolicyBuilder.penaltyListener(Executors.newSingleThreadExecutor(), StrictMode.OnThreadViolationListener {
-            Crashlytics.logException(StrictModeException(it))
+            trackable.track(StrictModeException(it))
         })
     }
 
     StrictMode.setThreadPolicy(threadPolicyBuilder.build())
 }
 
-private fun setupVirtualMachinePolicy() {
+private fun setupVirtualMachinePolicy(trackable: Trackable) {
     val vmPolicyBuilder = StrictMode.VmPolicy.Builder()
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -55,7 +55,7 @@ private fun setupVirtualMachinePolicy() {
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
         vmPolicyBuilder.penaltyListener(Executors.newSingleThreadExecutor(), StrictMode.OnVmViolationListener {
-            Crashlytics.logException(StrictModeException(it))
+            trackable.track(StrictModeException(it))
         })
     }
 

--- a/app/src/debug/java/com/github/barriosnahuel/vossosunboton/StrictModeHelper.kt
+++ b/app/src/debug/java/com/github/barriosnahuel/vossosunboton/StrictModeHelper.kt
@@ -1,23 +1,15 @@
 package com.github.barriosnahuel.vossosunboton
 
-import android.app.Application
 import android.os.Build
-import android.os.Handler
 import android.os.StrictMode
-import com.nshmura.strictmodenotifier.StrictModeNotifier
+import com.crashlytics.android.Crashlytics
+import java.util.concurrent.Executors
 
 internal class StrictModeHelper {
 
-    /**
-     * More info about the notifier app at [github.com/nshmura/strictmode-notifier](https://github.com/nshmura/strictmode-notifier).
-     */
-    fun initializeWithDefaults(application: Application) {
-        StrictModeNotifier.install(application)
-
-        Handler().post {
-            setupThreadPolicy()
-            setupVirtualMachinePolicy()
-        }
+    fun initializeWithDefaults() {
+        setupThreadPolicy()
+        setupVirtualMachinePolicy()
     }
 }
 
@@ -32,6 +24,12 @@ private fun setupThreadPolicy() {
         threadPolicyBuilder.detectResourceMismatches()
     }
 
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        threadPolicyBuilder.penaltyListener(Executors.newSingleThreadExecutor(), StrictMode.OnThreadViolationListener {
+            Crashlytics.logException(StrictModeException(it))
+        })
+    }
+
     StrictMode.setThreadPolicy(threadPolicyBuilder.build())
 }
 
@@ -41,10 +39,10 @@ private fun setupVirtualMachinePolicy() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
         vmPolicyBuilder.detectAll()
     } else {
-        // Create VmPolicy Builder basing on Android Version because StrictMode does not check properly that GB remove
-        // activity before report an InstanceCountViolation when API version is 21 or older. To avoid this error, we don't
-        // use [StrictMode.VmPolicy.Builder.detectActivityLeaks] (inside [ ][StrictMode.VmPolicy.Builder.detectAll]) and call all other methods
-        // where applicable. More info at: https://github.com/mercadolibre/mobile-android_testing/pull/37#discussion_r72981823
+        // Create VmPolicy Builder basing on Android Version because StrictMode does not check properly that GB remove activity before report an
+        // InstanceCountViolation when API version is 21 or older. To avoid this error, we don't use [StrictMode.VmPolicy.Builder
+        // .detectActivityLeaks] (inside [ ][StrictMode.VmPolicy.Builder.detectAll]) and call all other methods where applicable.
+        // More info at: https://github.com/mercadolibre/mobile-android_testing/pull/37#discussion_r72981823
 
         vmPolicyBuilder.detectLeakedRegistrationObjects()
                 .detectFileUriExposure()
@@ -55,5 +53,13 @@ private fun setupVirtualMachinePolicy() {
     // #penaltyLog call is required for StrictModeNotifier
     vmPolicyBuilder.penaltyLog()
 
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        vmPolicyBuilder.penaltyListener(Executors.newSingleThreadExecutor(), StrictMode.OnVmViolationListener {
+            Crashlytics.logException(StrictModeException(it))
+        })
+    }
+
     StrictMode.setVmPolicy(vmPolicyBuilder.build())
 }
+
+private class StrictModeException(violation: Throwable) : RuntimeException(violation)

--- a/commons_android/build.gradle
+++ b/commons_android/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.monits.staticCodeAnalysis'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 29
@@ -33,4 +35,7 @@ staticCodeAnalysis {
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
+
+    implementation 'com.crashlytics.sdk.android:crashlytics:2.10.1'
+    implementation 'com.jakewharton.timber:timber:4.7.1'
 }

--- a/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/error/Trackable.kt
+++ b/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/error/Trackable.kt
@@ -1,0 +1,16 @@
+package com.github.barriosnahuel.vossosunboton.commons.android.error
+
+import com.crashlytics.android.Crashlytics
+import timber.log.Timber
+
+interface Trackable {
+    fun track(throwable: Throwable)
+}
+
+object Tracker : Trackable {
+
+    override fun track(throwable: Throwable) {
+        Timber.e("Tracking error to Firebase Crashlytics: %s", throwable.message)
+        Crashlytics.logException(throwable)
+    }
+}

--- a/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/error/Trackable.kt
+++ b/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/error/Trackable.kt
@@ -3,10 +3,21 @@ package com.github.barriosnahuel.vossosunboton.commons.android.error
 import com.crashlytics.android.Crashlytics
 import timber.log.Timber
 
+/**
+ * Simple interface to hide the implementation details of our error tracking tool.
+ */
 interface Trackable {
+
+    /**
+     * Report the given `throwable` to our tracking tool.
+     */
     fun track(throwable: Throwable)
 }
 
+/**
+ * Current implementation of the [Trackable] interface.
+ * This tracker should be used along the entire project whenever you want to track some error.
+ */
 object Tracker : Trackable {
 
     override fun track(throwable: Throwable) {


### PR DESCRIPTION
## Description
- Remove library strict mode notifier which is deprecated;
- Refactor of the entire debug build type;
- Added a new `Trackable` concept which actually tracks to Firebase Crashlytics;
- Track also memory leaks detected by LeakCanary to Firebase Crashlytics;

## Why do we need these changes
1. To stop crashing on debug because of the deprecated library strict mode notifier;
2. To see memory leaks directly on Firebase Crashlytics;
3. To have a better separation of concerns in the debug build type;