### PR TITLE
Many libraries upgrade

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -111,6 +111,8 @@ dependencies {
 
     debugImplementation 'androidx.multidex:multidex:2.0.1'
 
+    // Skipped because it's a major change and I have to make changes to use v2.x. Task added to Trello.
+    // noinspection NewerVersionAvailable
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.6.3'
 
     debugImplementation 'com.facebook.stetho:stetho:1.5.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,7 +105,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.0.0'
 
     implementation 'com.google.firebase:firebase-core:17.2.1'
-    implementation 'com.google.firebase:firebase-perf:19.0.2'
+    implementation 'com.google.firebase:firebase-perf:19.0.4'
 
     implementation 'com.jakewharton.timber:timber:4.7.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 
         classpath 'com.monits:static-code-analysis-plugin:2.6.11'
         classpath 'io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.0.1'
-        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:1.0.0'
+        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:1.0.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -7,13 +7,13 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath 'com.google.gms:google-services:4.3.3'
         classpath 'io.fabric.tools:gradle:1.31.2'
         classpath 'com.google.firebase:perf-plugin:1.3.1'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61'
 
-        classpath 'com.monits:static-code-analysis-plugin:2.6.11'
+        classpath 'com.monits:static-code-analysis-plugin:2.6.12'
         classpath 'io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.0.1'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:1.0.2'
 

--- a/feature_addbutton/build.gradle
+++ b/feature_addbutton/build.gradle
@@ -46,8 +46,8 @@ dependencies {
     implementation project(':model')
 
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.61'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.2'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.3'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.3'
 
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.jakewharton.timber:timber:4.7.1'


### PR DESCRIPTION
## Description
Upgrade of:
- Android's Gradle Build Tools
- Monits' static code analysis plugin
- Kotlin's coroutines (android & core)
- Firebase's performance monitoring plugin
- Dexcount plugin

## Why do we need these changes
To be up to date and let dependabot create green pull requests.