### PR TITLE
Fix memory leak at the PlaybackClickListener<>PlayerController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Firebase and static code analyzers too.
 - Stop exposing Firebase API configuration file.
 - Crashes when debugging because of a bug in library `StrictModeNotifier`.
 - Performance issue when saving a new audio button.
+- Memory leak at the `MediaPlayer` which causes an increment on memory usage.
 
 ### Removed
 - Library StrictModeNotifier for debug builds.

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerImpl.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerImpl.kt
@@ -1,0 +1,53 @@
+package com.github.barriosnahuel.vossosunboton.feature.playback
+
+import android.content.Context
+import android.media.MediaPlayer
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
+import com.github.barriosnahuel.vossosunboton.model.Sound
+import java.io.IOException
+
+internal class PlayerControllerImpl(private val mediaPlayer: MediaPlayer = MediaPlayer()) : PlayerController {
+
+    override fun startPlayingSound(
+        context: Context,
+        sound: Sound,
+        listener: PlayerControllerListener
+    ) {
+        if (mediaPlayer.isPlaying) {
+            // User clicked on a new button while still listening an audio, then we should toggle that running button.
+            listener.onPlayerStop(Reasons.INTERCEPT)
+
+            mediaPlayer.stop()
+        }
+
+        mediaPlayer.reset()
+
+        val ready = if (sound.isBundled()) {
+            MediaPlayerHelper.setupSoundSource(context, mediaPlayer, sound.rawRes)
+        } else {
+            MediaPlayerHelper.setupSoundSource(context, mediaPlayer, sound.file!!)
+        }
+
+        if (ready) {
+            try {
+                mediaPlayer.prepare()
+            } catch (e: IOException) {
+                Tracker.track(RuntimeException("Media player can't be prepared for playback.", e))
+            }
+
+            mediaPlayer.setOnCompletionListener { listener.onPlayerStop(Reasons.SOUND_END) }
+            mediaPlayer.setOnSeekCompleteListener { it.pause() }
+
+            listener.onPlayerStart()
+            mediaPlayer.start()
+        }
+    }
+
+    override fun stopPlayingSound() {
+        // Here sound is on so we have to stop it.
+
+        if (mediaPlayer.isPlaying) {
+            mediaPlayer.stop()
+        }
+    }
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/PlaybackClickListener.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/PlaybackClickListener.kt
@@ -3,6 +3,8 @@ package com.github.barriosnahuel.vossosunboton.ui.home
 import android.view.View
 import android.widget.Checkable
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
+import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerListener
+import com.github.barriosnahuel.vossosunboton.feature.playback.Reasons
 import com.github.barriosnahuel.vossosunboton.model.Sound
 
 internal class PlaybackClickListener(private val homeView: HomeView, private val sound: Sound) : View.OnClickListener {
@@ -12,15 +14,30 @@ internal class PlaybackClickListener(private val homeView: HomeView, private val
 
         if (button.isChecked) {
             // When here sound of the clicked view is off but mediaPlayer can be playing (or not)
+
             PlayerControllerFactory.instance.startPlayingSound(
-                    v.context,
-                    sound,
-                    button::toggle,
-                    { homeView.currentPlayingButton?.toggle() },
-                    { homeView.currentPlayingButton = button }
+                v.context,
+                sound,
+                object : PlayerControllerListener {
+                    override fun onPlayerStop(intercept: Reasons) {
+                        when (intercept) {
+                            Reasons.INTERCEPT -> {
+                                homeView.currentPlayingButton?.toggle()
+                            }
+                            Reasons.SOUND_END -> {
+                                button.toggle()
+                            }
+                        }
+                    }
+
+                    override fun onPlayerStart() {
+                        homeView.currentPlayingButton = button
+                    }
+                }
             )
         } else {
             // Here it should be playing
+
             PlayerControllerFactory.instance.stopPlayingSound()
         }
     }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/PlaybackClickListenerTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/PlaybackClickListenerTest.kt
@@ -31,7 +31,7 @@ internal class PlaybackClickListenerTest {
     }
 
     private fun thenItShouldStartPlayingAnAudio() {
-        verify(exactly = 1) { PlayerControllerFactory.instance.startPlayingSound(any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { PlayerControllerFactory.instance.startPlayingSound(any(), any(), any()) }
     }
 
     private fun thenItShouldStopPlayingTheAudio() {
@@ -40,7 +40,7 @@ internal class PlaybackClickListenerTest {
 
     private fun whenClickingOn(button: View) {
         mockkObject(PlayerControllerFactory)
-        every { PlayerControllerFactory.instance.startPlayingSound(any(), any(), any(), any(), any()) } answers { nothing }
+        every { PlayerControllerFactory.instance.startPlayingSound(any(), any(), any()) } answers { nothing }
         every { PlayerControllerFactory.instance.stopPlayingSound() } answers { nothing }
 
         PlaybackClickListener(mockk(), Sound("a name", null)).onClick(button)


### PR DESCRIPTION
## Description
- Fix a memory leak detected by LeakCanary.
- Refactor `PlayerController` and `PlaybackClickListener` in favor of a better separation of responsibilities

## Trace
```
┬───
│ GC Root: Local variable in native code
│
├─ android.os.HandlerThread instance
│    Leaking: NO (PathClassLoader↓ is not leaking)
│    Thread name: 'queued-work-looper'
│    ↓ HandlerThread.contextClassLoader
├─ dalvik.system.PathClassLoader instance
│    Leaking: NO (PlayerControllerFactory↓ is not leaking and A ClassLoader is never leaking)
│    ↓ PathClassLoader.runtimeInternalObjects
├─ java.lang.Object[] array
│    Leaking: NO (PlayerControllerFactory↓ is not leaking)
│    ↓ Object[].[1089]
├─ com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory class
│    Leaking: NO (a class is never leaking)
│    ↓ static PlayerControllerFactory.instance
│                                     ~~~~~~~~
├─ com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerImpl instance
│    Leaking: UNKNOWN
│    ↓ PlayerControllerImpl.mediaPlayer
│                           ~~~~~~~~~~~
├─ android.media.MediaPlayer instance
│    Leaking: UNKNOWN
│    ↓ MediaPlayer.mOnCompletionListener
│                  ~~~~~~~~~~~~~~~~~~~~~
├─ com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerImpl$startPlayingSound$1 instance
│    Leaking: UNKNOWN
│    Anonymous class implementing android.media.MediaPlayer$OnCompletionListener
│    ↓ PlayerControllerImpl$startPlayingSound$1.$updateRecentlyClickedButtonStatus
│                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
├─ com.github.barriosnahuel.vossosunboton.ui.home.PlaybackClickListener$onClick$1 instance
│    Leaking: UNKNOWN
│    Anonymous subclass of kotlin.jvm.internal.FunctionReference
│    ↓ PlaybackClickListener$onClick$1.receiver
│                                      ~~~~~~~~
├─ androidx.appcompat.widget.AppCompatToggleButton instance
│    Leaking: YES (View.mContext references a destroyed activity)
│    mContext instance of com.github.barriosnahuel.vossosunboton.ui.home.HomeActivity with mDestroyed = true
│    View#mParent is set
│    View#mAttachInfo is null (view detached)
│    View.mWindowAttachCount = 1
│    ↓ AppCompatToggleButton.mContext
╰→ com.github.barriosnahuel.vossosunboton.ui.home.HomeActivity instance
​     Leaking: YES (ObjectWatcher was watching this because com.github.barriosnahuel.vossosunboton.ui.home.HomeActivity received Activity#onDestroy() callback and Activity#mDestroyed is true)
​     key = 7c7fe9ea-f971-4cb1-b567-f4703365b7d6
​     watchDurationMillis = 5388
​     retainedDurationMillis = 385

METADATA

Build.VERSION.SDK_INT: 27
Build.MANUFACTURER: motorola
LeakCanary version: 2.2
App process name: com.github.barriosnahuel.vossosunboton.debug
Analysis duration: 24614 ms
```
## Reasons to merge these changes
To have a leak 0 app, which gives the user a better experience.