### PR TITLE
Let user share packaged audio buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,17 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 ## \[unreleased]
 ### Added
+- Let users share packaged buttons too.
+- Let users delete custom audios by swiping horizontally.
 - Support for Android Q (API Level 29).
 - Pull Requests template for contributors.
-- Firebase Analytics. 
+- Firebase Analytics.
 - Firebase Crashlytics.
 - Firebase Performance Monitoring.
 - Added Detekt static code analysis tool, as well as Ktlint for code style conventions.
 - Setup [Stale GitHub app](https://github.com/apps/stale).
 - Codacy checks integration through GitHub.
 - Multidex support for debug builds.
-- Let users delete custom audios by swiping horizontally.
 - Timestamp as suffix on `versionName` for debug builds.
 - Automatic code obfuscation and optimizations on release builds.
 
@@ -36,13 +37,13 @@ Firebase and static code analyzers too.
 - Refactor of Media Player setup for clearness.
 
 ### Fixed
-- Many SCA suggestions applied.
 - Sharing buttons issues due to a bad permissions setup.
-- Usage of resources like `InputStream`, `OutputStream` and `Cursor`.
-- Stop exposing Firebase API configuration file.
 - Crashes when debugging because of a bug in library `StrictModeNotifier`.
 - Performance issue when saving a new audio button.
 - Memory leak at the `MediaPlayer` which causes an increment on memory usage.
+- Many SCA suggestions applied.
+- Usage of resources like `InputStream`, `OutputStream` and `Cursor`.
+- Stop exposing Firebase API configuration file.
 
 ### Removed
 - Library StrictModeNotifier for debug builds.

--- a/app/src/debug/java/com/github/barriosnahuel/vossosunboton/StrictModeConfigurator.kt
+++ b/app/src/debug/java/com/github/barriosnahuel/vossosunboton/StrictModeConfigurator.kt
@@ -15,10 +15,9 @@ internal object StrictModeConfigurator {
 
 private fun setupThreadPolicy(trackable: Trackable) {
     val threadPolicyBuilder = StrictMode.ThreadPolicy.Builder()
-            .detectCustomSlowCalls()
-            .detectNetwork()
-            .permitDiskReads()
-            .penaltyLog() // Required for StrictModeNotifier!
+        .detectCustomSlowCalls()
+        .detectNetwork()
+        .penaltyLog()
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
         threadPolicyBuilder.detectResourceMismatches()
@@ -50,7 +49,6 @@ private fun setupVirtualMachinePolicy(trackable: Trackable) {
                 .detectLeakedClosableObjects()
     }
 
-    // #penaltyLog call is required for StrictModeNotifier
     vmPolicyBuilder.penaltyLog()
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/base/DeepLinks.java
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/base/DeepLinks.java
@@ -28,7 +28,7 @@ public enum DeepLinks {
      * @return The deep-link that must be used to open a specific screen.
      */
     @NonNull
-    public String get() {
+    private String get() {
         return String.format(
                 "%s://%s%s"
                 , "sosunboton"

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
@@ -6,9 +6,11 @@ import android.net.Uri
 import androidx.core.content.FileProvider
 import com.github.barriosnahuel.vossosunboton.BuildConfig
 import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.commons.file.copy
 import com.github.barriosnahuel.vossosunboton.commons.file.getFile
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import timber.log.Timber
+import java.io.FileOutputStream
 
 internal interface ShareFeature {
 
@@ -27,30 +29,49 @@ private class ShareFeatureImpl : ShareFeature {
     private val authority = BuildConfig.APPLICATION_ID + ".fileprovider"
 
     /**
-     * Check https://developer.android.com/training/secure-file-sharing/setup-sharing for more info.
+     * For more info check
+     * [developer.android.com/training/secure-file-sharing/setup-sharing](https://developer.android.com/training/secure-file-sharing/setup-sharing)
      */
     override fun share(context: Context, sound: Sound) {
-        checkNotNull(sound.file) { "File URI is mandatory" }
+        Timber.d("Trying to share button: %s", sound.name)
 
-        Timber.d("Generating chooser Intent for button... %s: %s", sound.name, sound.file)
-
+        val buttonFileContentUri = getContentUriForSound(sound, context)
         val shareIntent = Intent()
         shareIntent.action = Intent.ACTION_SEND
         shareIntent.type = "audio/*"
+        shareIntent.putExtra(Intent.EXTRA_STREAM, buttonFileContentUri)
+        shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
 
-        val file = getFile(context, sound.file!!)
-        val buttonFileContentUri: Uri?
-        try {
-            buttonFileContentUri = FileProvider.getUriForFile(context, authority, file)
-        } catch (e: IllegalArgumentException) {
-            throw IllegalStateException("Button content uri couldn't be created.", e)
+        Timber.d("Starting disambiguation window for: %s: contentUri=%s; URI=%s; rawResId=%s;",
+            sound.name, buttonFileContentUri, sound.file, sound.rawRes)
+
+        context.startActivity(Intent.createChooser(shareIntent, context.getString(R.string.app_share_chooser_title)))
+    }
+
+    private fun getContentUriForSound(sound: Sound, context: Context): Uri? {
+        val fileForSharing = when (sound.file) {
+            null -> {
+                check(sound.rawRes != 0) { "Either file URI or raw resource ID must exist on a given sound" }
+
+                val rawResourceInputStream = context.resources.openRawResource(sound.rawRes)
+
+                val fileForSharing = getFile(context, "Button-packaged-" + sound.name + ".mp3")
+                if (fileForSharing.exists()) {
+                    Timber.d("Packaged audio already copied to share directory: %s", fileForSharing)
+                } else {
+                    Timber.d("Packaged audio is gonna be copied to share directory: %s", fileForSharing)
+                    copy(rawResourceInputStream, FileOutputStream(fileForSharing))
+                }
+
+                fileForSharing
+            }
+            else -> getFile(context, sound.file!!)
         }
 
-        Timber.d("Sharing... %s: %s", sound.name, sound.file)
-        buttonFileContentUri.let {
-            shareIntent.putExtra(Intent.EXTRA_STREAM, it)
-            shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            context.startActivity(Intent.createChooser(shareIntent, context.getString(R.string.app_share_chooser_title)))
+        return try {
+            FileProvider.getUriForFile(context, authority, fileForSharing)
+        } catch (e: IllegalArgumentException) {
+            throw IllegalStateException("Button content uri couldn't be created.", e)
         }
     }
 }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
@@ -19,7 +19,7 @@ import java.io.File
 
 internal class ShareFeatureTest : AbstractRobolectricTest() {
 
-    private val dummyButtonName= "my button name"
+    private val dummyButtonName = "my button name"
 
     @Test
     fun `share when sound Uri and resource are null must throw an exception`() {

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
@@ -7,6 +7,7 @@ import android.os.Environment
 import androidx.core.content.FileProvider
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.model.R
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
@@ -19,7 +20,7 @@ import java.io.File
 internal class ShareFeatureTest : AbstractRobolectricTest() {
 
     @Test
-    fun `share when sound Uri is null must throw an exception`() {
+    fun `share when sound Uri and resource are null must throw an exception`() {
         val sound = givenASoundWithNullUri()
 
         try {
@@ -31,7 +32,16 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
 
     @Test
     fun `share when sound URI is valid show disambiguation window`() {
-        val sound = givenASound()
+        val sound = givenASoundWithUri()
+
+        val generatedIntent = whenSharingThe(sound)
+
+        thenOSShowDisambiguationWindow(generatedIntent)
+    }
+
+    @Test
+    fun `share when sound raw resource ID is valid show disambiguation window`() {
+        val sound = givenASoundWithResourceId()
 
         val generatedIntent = whenSharingThe(sound)
 
@@ -40,7 +50,7 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
 
     @Test
     fun `share when sound URI is valid sends the audio file`() {
-        val sound = givenASound()
+        val sound = givenASoundWithUri()
 
         val generatedIntent = whenSharingThe(sound)
 
@@ -49,7 +59,7 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
 
     @Test
     fun `share should generate a content Uri under Music directory as described in app_file_provider_paths resource`() {
-        val sound = givenASound()
+        val sound = givenASoundWithUri()
 
         val capturedFile = whenSharingTheSoundCapturingThePath(sound)
 
@@ -60,7 +70,9 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
         assertThat(capturedFile.absolutePath.split("/").contains(Environment.DIRECTORY_MUSIC)).isTrue()
     }
 
-    private fun givenASound() = Sound("my button name", "a/dummy/sound/uri")
+    private fun givenASoundWithUri() = Sound("my button name", "a/dummy/sound/uri")
+
+    private fun givenASoundWithResourceId() = Sound("my button name", rawRes = R.raw.model_sample_button_activar)
 
     private fun givenASoundWithNullUri() = Sound("my button name")
 
@@ -94,7 +106,7 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
     }
 
     private fun thenWeThrowAnIllegalStateException(e: IllegalStateException) {
-        assertThat(e.message).isEqualTo("File URI is mandatory")
+        assertThat(e.message).isEqualTo("Either file URI or raw resource ID must exist on a given sound")
     }
 
     private fun thenOSShowDisambiguationWindow(intent: Intent) {

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
@@ -19,6 +19,8 @@ import java.io.File
 
 internal class ShareFeatureTest : AbstractRobolectricTest() {
 
+    private val dummyButtonName= "my button name"
+
     @Test
     fun `share when sound Uri and resource are null must throw an exception`() {
         val sound = givenASoundWithNullUri()
@@ -70,11 +72,11 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
         assertThat(capturedFile.absolutePath.split("/").contains(Environment.DIRECTORY_MUSIC)).isTrue()
     }
 
-    private fun givenASoundWithUri() = Sound("my button name", "a/dummy/sound/uri")
+    private fun givenASoundWithUri() = Sound(dummyButtonName, "a/dummy/sound/uri")
 
-    private fun givenASoundWithResourceId() = Sound("my button name", rawRes = R.raw.model_sample_button_activar)
+    private fun givenASoundWithResourceId() = Sound(dummyButtonName, rawRes = R.raw.model_sample_button_activar)
 
-    private fun givenASoundWithNullUri() = Sound("my button name")
+    private fun givenASoundWithNullUri() = Sound(dummyButtonName)
 
     private fun whenSharingTheSoundCapturingThePath(sound: Sound): File {
         val mockedContext = spyk<Context>(ApplicationProvider.getApplicationContext<Context>())

--- a/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/intent/SafeIntent.java
+++ b/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/intent/SafeIntent.java
@@ -17,20 +17,10 @@ public class SafeIntent extends Intent {
      *
      * @param context The execution context. Required to get the application package to set it by calling {@link
      * #setPackage(String)}.
-     */
-    private SafeIntent(@NonNull final Context context) {
-        setPackage(context.getPackageName());
-    }
-
-    /**
-     * Build an instance of a SafeIntent
-     *
-     * @param context The execution context. Required to get the application package to set it by calling {@link
-     * #setPackage(String)}.
      * @param uri The Uri of the data this intent is now targeting. It is a shortcut to {@link #setData(Uri)}.
      */
     public SafeIntent(@NonNull final Context context, @Nullable final Uri uri) {
-        this(context);
+        setPackage(context.getPackageName());
         setData(uri);
     }
 }

--- a/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
+++ b/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
@@ -35,7 +35,7 @@ interface AddButtonFeature {
 private class AddButtonFeatureImpl : AddButtonFeature {
 
     override fun saveNewButtonAsync(context: Context, name: String, uri: String): Deferred<Int> {
-        val fileName = "Button-" + System.currentTimeMillis() + ".mp3"
+        val fileName = "Button-custom-" + System.currentTimeMillis() + ".mp3"
         val targetFile = getFile(context, fileName)
 
         return GlobalScope.async(Dispatchers.IO) {

--- a/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundDao.java
+++ b/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundDao.java
@@ -33,8 +33,6 @@ public class SoundDao {
         storage = new Storage();
     }
 
-
-
     /**
      * @param context The execution context.
      * @param sound   The sound to save for this user.


### PR DESCRIPTION
## Description
Stop firing an error and let user share packaged audios.
Note that we can't share raw resources directly, we must copy to the custom buttons' directory.

## Reasons to merge these changes
To let users do whatever they want no matter what kind of button is.