### PR TITLE
Send log messages to Firebase for better troubleshooting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Support for Android Q (API Level 29).
 - Pull Requests template for contributors.
 - Firebase Analytics.
-- Firebase Crashlytics.
+- Firebase Crashlytics including last logs from each error.
 - Firebase Performance Monitoring.
 - Added Detekt static code analysis tool, as well as Ktlint for code style conventions.
 - Setup [Stale GitHub app](https://github.com/apps/stale).

--- a/app/src/debug/java/com/github/barriosnahuel/vossosunboton/CustomBuildTypeApplication.kt
+++ b/app/src/debug/java/com/github/barriosnahuel/vossosunboton/CustomBuildTypeApplication.kt
@@ -1,12 +1,14 @@
 package com.github.barriosnahuel.vossosunboton
 
 import android.app.Application
+import com.github.barriosnahuel.vossosunboton.commons.android.error.ErrorTrackerTree
 import timber.log.Timber
 
 internal abstract class CustomBuildTypeApplication : Application() {
 
     override fun onCreate() {
         Timber.plant(Timber.DebugTree())
+        Timber.plant(ErrorTrackerTree())
 
         super.onCreate()
 

--- a/app/src/release/java/com/github/barriosnahuel/vossosunboton/CustomBuildTypeApplication.kt
+++ b/app/src/release/java/com/github/barriosnahuel/vossosunboton/CustomBuildTypeApplication.kt
@@ -1,5 +1,16 @@
 package com.github.barriosnahuel.vossosunboton
 
 import android.app.Application
+import com.github.barriosnahuel.vossosunboton.commons.android.error.ErrorTrackerTree
+import timber.log.Timber
 
-internal abstract class CustomBuildTypeApplication : Application()
+internal abstract class CustomBuildTypeApplication : Application() {
+
+    override fun onCreate() {
+        Timber.plant(ErrorTrackerTree())
+
+        super.onCreate()
+
+        Timber.d("Creating RELEASE application...")
+    }
+}

--- a/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/error/Trackable.kt
+++ b/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/error/Trackable.kt
@@ -38,7 +38,7 @@ object Tracker : Trackable {
     }
 }
 
-class ErrorTrackerTree : Timber.Tree() {
+internal class ErrorTrackerTree : Timber.Tree() {
     override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
         Tracker.log(message)
     }

--- a/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/error/Trackable.kt
+++ b/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/error/Trackable.kt
@@ -22,7 +22,7 @@ interface Trackable {
 
 /**
  * Current implementation of the [Trackable] interface.
- * This tracker should be used along the entire project whenever you want to track some error.
+ * This tracker should be used along the entire project whenever you want to track some error or log something to the error platform.
  */
 object Tracker : Trackable {
 
@@ -38,7 +38,10 @@ object Tracker : Trackable {
     }
 }
 
-internal class ErrorTrackerTree : Timber.Tree() {
+/**
+ * Tree to plant on Timber to be able to log messages to the error tracking platform.
+ */
+class ErrorTrackerTree : Timber.Tree() {
     override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
         Tracker.log(message)
     }

--- a/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/error/Trackable.kt
+++ b/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/error/Trackable.kt
@@ -12,6 +12,12 @@ interface Trackable {
      * Report the given `throwable` to our tracking tool.
      */
     fun track(throwable: Throwable)
+
+    /**
+     * Log the given `message` to our error tracking platform. Each log must be useful to give us more context when troubleshooting.
+     * @param message the message to upload.
+     */
+    fun log(message: String)
 }
 
 /**
@@ -22,6 +28,18 @@ object Tracker : Trackable {
 
     override fun track(throwable: Throwable) {
         Timber.e("Tracking error to Firebase Crashlytics: %s", throwable.message)
+        throwable.printStackTrace()
+
         Crashlytics.logException(throwable)
+    }
+
+    override fun log(message: String) {
+        Crashlytics.log(message)
+    }
+}
+
+class ErrorTrackerTree : Timber.Tree() {
+    override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+        Tracker.log(message)
     }
 }


### PR DESCRIPTION
## Description
Add a new `Tree` to `Timber` that will send log messages to Firebase.
It's configured for both debug and release builds.

## Reasons to merge these changes
Because troubleshooting is gonna be easier having more context info.

## Screenshots
![image](https://user-images.githubusercontent.com/196234/75614247-99bd9200-5b15-11ea-93fb-11279759ff4d.png)

## Raw
```
# Crashlytics - Custom logs
# Application: com.github.barriosnahuel.vossosunboton.debug
# Platform: android
# Version: 2.0.0-DEBUG 2020-02-29 13:48:59 (5)
# Issue: e949a2bc23d443b0cb505193bdb17f52
# Session: 5E5A962A019800011B74337F50266ED1_DNE_2_v2
# Date: Sat Feb 29 2020 14:44:00 GMT-0300 (Argentina Standard Time)

0 | Sat Feb 29 2020 14:44:40 GMT-0300 (Argentina Standard Time) | session_start
1 | Sat Feb 29 2020 14:44:41 GMT-0300 (Argentina Standard Time) | D/CrashlyticsCore ShareClickListener#onLongClick
2 | Sat Feb 29 2020 14:44:41 GMT-0300 (Argentina Standard Time) | D/CrashlyticsCore Trying to share button: Activar
3 | Sat Feb 29 2020 14:44:41 GMT-0300 (Argentina Standard Time) | D/CrashlyticsCore Packaged audio is gonna be copied to share directory: /storage/emulated/0/Android/data/com.github.barriosnahuel.vossosunboton.debug/files/Music/Button-packaged-Activar.mp3
4 | Sat Feb 29 2020 14:44:42 GMT-0300 (Argentina Standard Time) | D/CrashlyticsCore Tracking error to Firebase Crashlytics: Audio button couldn't be shared.
```