### PR TITLE
Change minSdkVersion to 21

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,8 +52,9 @@ You can filter logcat messages by:
 > adb logcat -s FirebasePerformance
 
 ## Resources 🎨
+- Colors selected using: [Material Design palette generator](https://material.io/design/color/the-color-system.html#tools-for-picking-colors)
 - Icon generated using: [romannurik.github.io/AndroidAssetStudio/icons-launcher](http://romannurik.github.io/AndroidAssetStudio/icons-launcher.html)
-- In-App icons using: [Material Design resources](https://material.io/resources/icons/?style=baseline)
+- In-App icons using: [Material Design resources](https://material.io/resources/icons/?style=round)
 
 ## Signing 🔑
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
 
     defaultConfig {
         applicationId "com.github.barriosnahuel.vossosunboton"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 29
         versionCode 5
         versionName '2.0.0'

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="app_colorPrimary">#002b00</color>
-    <color name="app_colorPrimaryDark">#002100</color>
-    <color name="app_colorAccent">#005c00</color>
+    <color name="app_colorPrimary">#90EE02</color>
+    <color name="app_colorPrimaryDark">#61d800</color>
+    <color name="app_colorAccent">#d602ee</color>
     <color name="app_white">#BCFFFFFF</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="app_colorPrimary">#8cdc8c</color>
-    <color name="app_colorPrimaryDark">#39a939</color>
-    <color name="app_colorAccent">#0a730a</color>
+    <color name="app_colorPrimary">#6200EE</color>
+    <color name="app_colorPrimaryDark">#3D00E0</color>
+    <color name="app_colorAccent">#021aee</color>
     <color name="app_white">#FFFFFF</color>
 </resources>

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/AbstractRobolectricTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/AbstractRobolectricTest.kt
@@ -6,5 +6,5 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.KITKAT, Build.VERSION_CODES.P], application = TestApplication::class)
+@Config(sdk = [Build.VERSION_CODES.LOLLIPOP, Build.VERSION_CODES.P], application = TestApplication::class)
 internal abstract class AbstractRobolectricTest

--- a/commons_android/build.gradle
+++ b/commons_android/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 29
     }
 

--- a/commons_file/build.gradle
+++ b/commons_file/build.gradle
@@ -6,7 +6,7 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 29
     }
 

--- a/feature_addbutton/build.gradle
+++ b/feature_addbutton/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 29
     }
 

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -6,7 +6,7 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 29
     }
 


### PR DESCRIPTION
## Description
- Change `minSdkVersion` from 19 to 21;
- Change color palette by using: https://material.io/design/color/the-color-system.html#tools-for-picking-colors

## Reasons to merge these changes
- Improvements in build time, I will rollback this change before publishing. And also change debug builds to use 21;
- Better look & feel;