### PR TITLE
Replace Stetho with Flipper to fix layout inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Firebase and static code analyzers too.
 - `StrictMode` warnings now are logged to Crashlytics instead of the debugging notifier.
 - `LeakCanary` warnings now are logged to Crashlytics.
 - Refactor of Media Player setup for clearness.
+- Replaced Stetho with [Flipper](https://fbflipper.com/).
 
 ### Fixed
 - Sharing buttons issues due to a bad permissions setup.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -98,7 +98,8 @@ dependencies {
 
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.2'
 
-    debugImplementation 'com.facebook.stetho:stetho:1.5.1'
+    debugImplementation 'com.facebook.flipper:flipper:0.33.1'
+    debugImplementation 'com.facebook.soloader:soloader:0.8.2'
 
     testImplementation 'junit:junit:4.13'
 

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -6,6 +6,10 @@
         <meta-data
             android:name="firebase_performance_logcat_enabled"
             android:value="true" />
+
+        <activity
+            android:name="com.facebook.flipper.android.diagnostics.FlipperDiagnosticActivity"
+            android:exported="true" />
     </application>
 
 </manifest>

--- a/app/src/debug/java/com/github/barriosnahuel/vossosunboton/DebugTools.kt
+++ b/app/src/debug/java/com/github/barriosnahuel/vossosunboton/DebugTools.kt
@@ -1,7 +1,6 @@
 package com.github.barriosnahuel.vossosunboton
 
 import android.app.Application
-import com.facebook.stetho.Stetho
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 
 internal object DebugTools {
@@ -9,6 +8,6 @@ internal object DebugTools {
     fun configure(application: Application) {
         StrictModeConfigurator.initializeWithDefaults(Tracker)
         LeakCanaryConfigurator.initializeWithDefaults(Tracker)
-        Stetho.initializeWithDefaults(application)
+        FlipperConfigurator.initializeWithDefaults(application)
     }
 }

--- a/app/src/debug/java/com/github/barriosnahuel/vossosunboton/FlipperConfigurator.kt
+++ b/app/src/debug/java/com/github/barriosnahuel/vossosunboton/FlipperConfigurator.kt
@@ -1,0 +1,18 @@
+package com.github.barriosnahuel.vossosunboton
+
+import android.app.Application
+import com.facebook.flipper.android.AndroidFlipperClient
+import com.facebook.flipper.plugins.inspector.DescriptorMapping
+import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin
+import com.facebook.soloader.SoLoader
+
+internal object FlipperConfigurator {
+
+    fun initializeWithDefaults(application: Application) {
+        SoLoader.init(application, false)
+
+        val flipperClient = AndroidFlipperClient.getInstance(application)
+        flipperClient.addPlugin(InspectorFlipperPlugin(application, DescriptorMapping.withDefaults()))
+        flipperClient.start()
+    }
+}


### PR DESCRIPTION
## Description
- Remove Stetho library (it was on the debug build type)
- Add [Flipper](www.fbflipper.com)

## Reasons to merge these changes
Because layout inspection isn't working with Stetho, and Flipper project is working good and it's also more powerful.