### PR TITLE
Upgrade Flipper to v0.34.0 and Coroutines to v1.3.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -98,7 +98,7 @@ dependencies {
 
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.2'
 
-    debugImplementation 'com.facebook.flipper:flipper:0.33.1'
+    debugImplementation 'com.facebook.flipper:flipper:0.34.0'
     debugImplementation 'com.facebook.soloader:soloader:0.8.2'
 
     testImplementation 'junit:junit:4.13'

--- a/feature_addbutton/build.gradle
+++ b/feature_addbutton/build.gradle
@@ -29,8 +29,8 @@ dependencies {
     implementation project(':model')
 
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.70'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.4'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.4'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.5'
 
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.jakewharton.timber:timber:4.7.1'


### PR DESCRIPTION
## Description
- Upgrade Flipper from v0.33.1 to v0.34.0. closes #99 
- Upgrade coroutines (core/android) from v1.3.4 to v1.3.5. closes #98 closes #101

## Reasons to merge these changes
To be up-to-date with latest dependences.