### PR TITLE
Upgrade many libraries to its latest versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ We use Circle CI, so if you're gonna change the [config.yml](.circleci/config.ym
 ## Gradle upgrade
 As described at [Gradle docs#Adding wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:adding_wrapper) you must run:
 
-    > ./gradlew wrapper --gradle-version=${desiredVersion}
+    > ./gradlew wrapper --gradle-version ${desiredVersion}
 
 ## Firebase config file ⚙️
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.1.0'
 
     implementation 'com.google.firebase:firebase-core:17.3.0'
-    implementation 'com.google.firebase:firebase-perf:19.0.5'
+    implementation 'com.google.firebase:firebase-perf:19.0.6'
 
     implementation 'com.jakewharton.timber:timber:4.7.1'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,7 +97,7 @@ dependencies {
 
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.2'
 
-    debugImplementation 'com.facebook.flipper:flipper:0.36.0'
+    debugImplementation 'com.facebook.flipper:flipper:0.37.0'
     debugImplementation 'com.facebook.soloader:soloader:0.9.0'
 
     testImplementation 'junit:junit:4.13'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -103,7 +103,10 @@ dependencies {
     testImplementation 'junit:junit:4.13'
 
     testImplementation 'androidx.test:core:1.2.0'
-    testImplementation 'org.robolectric:robolectric:4.3.1'
+    testImplementation ('org.robolectric:robolectric:4.3.1'){
+        // https://github.com/robolectric/robolectric/issues/5245
+        exclude group: 'com.google.auto.service', module: 'auto-service'
+    }
 
     testImplementation 'com.google.truth:truth:1.0.1'
     testImplementation 'io.mockk:mockk:1.9.3'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -98,7 +98,7 @@ dependencies {
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.2'
 
     debugImplementation 'com.facebook.flipper:flipper:0.36.0'
-    debugImplementation 'com.facebook.soloader:soloader:0.8.2'
+    debugImplementation 'com.facebook.soloader:soloader:0.9.0'
 
     testImplementation 'junit:junit:4.13'
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:3.6.3'
         classpath 'com.google.gms:google-services:4.3.3'
         classpath 'io.fabric.tools:gradle:1.31.2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         classpath 'io.fabric.tools:gradle:1.31.2'
 
         classpath 'com.google.firebase:perf-plugin:1.3.1'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.71'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72'
 
         classpath 'com.monits:static-code-analysis-plugin:2.6.12'
         classpath 'io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.7.4'

--- a/commons_file/build.gradle
+++ b/commons_file/build.gradle
@@ -21,7 +21,7 @@ android {
 }
 
 dependencies {
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.71'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72'
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.jakewharton.timber:timber:4.7.1'
 }

--- a/feature_addbutton/build.gradle
+++ b/feature_addbutton/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation project(':commons_file')
     implementation project(':model')
 
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.71'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.5'
 

--- a/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivity.kt
+++ b/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivity.kt
@@ -53,7 +53,7 @@ class AddButtonActivity : AbstractActivity() {
             consumedHere
         }
 
-        saveButton.setOnClickListener { saveButton(this) }
+        feature_addbutton_saveButton.setOnClickListener { saveButton(this) }
     }
 
     override fun bindToolbar() {

--- a/feature_addbutton/src/main/res/layout/feature_addbutton_activity_add_button.xml
+++ b/feature_addbutton/src/main/res/layout/feature_addbutton_activity_add_button.xml
@@ -29,7 +29,7 @@
         tools:ignore="UnusedAttribute" />
 
     <Button
-        android:id="@+id/saveButton"
+        android:id="@+id/feature_addbutton_saveButton"
         style="@style/feature_addbutton_MyCustomTheme.Form.Button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -23,7 +23,7 @@ android {
 dependencies {
     implementation project(':commons_file')
 
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.71'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72'
 
     implementation 'com.jakewharton.timber:timber:4.7.1'
     implementation 'androidx.annotation:annotation:1.1.0'


### PR DESCRIPTION
## Description
Bump:
- Facebook's soloader
- Gradle build tools
- Kotlin
- Fix naming conflict

## Reasons to merge these changes
- https://issuetracker.google.com/issues/67777236#comment2
- To be up-to-date with latest fixes
- To then bump SCA to the new major v3.0.0: https://github.com/Monits/static-code-analysis-plugin/releases/tag/3.0.0