### PR TITLE
Firebase and Flipper upgrade

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,7 +97,7 @@ dependencies {
 
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.2'
 
-    debugImplementation 'com.facebook.flipper:flipper:0.38.0'
+    debugImplementation 'com.facebook.flipper:flipper:0.39.0'
     debugImplementation 'com.facebook.soloader:soloader:0.9.0'
 
     testImplementation 'junit:junit:4.13'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,8 +90,8 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'com.google.android.material:material:1.1.0'
 
-    implementation 'com.google.firebase:firebase-core:17.3.0'
-    implementation 'com.google.firebase:firebase-perf:19.0.6'
+    implementation 'com.google.firebase:firebase-core:17.4.0'
+    implementation 'com.google.firebase:firebase-perf:19.0.7'
 
     implementation 'com.jakewharton.timber:timber:4.7.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ buildscript {
         classpath 'com.google.firebase:perf-plugin:1.3.1'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72'
 
-        //noinspection GradleDependency
         classpath 'com.monits:static-code-analysis-plugin:2.6.12'
         classpath 'io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.8.0'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:1.0.2'

--- a/config/android/android-lint.xml
+++ b/config/android/android-lint.xml
@@ -9,7 +9,10 @@
     <!-- Correctness -->
     <issue id="DefaultLocale" severity="warning" />
     <issue id="DuplicateIncludedIds" severity="error" />
-    <issue id="GradleDependency" severity="error" />
+
+    <!-- We want to be just a warning because Dependabot bumps them for us -->
+    <issue id="GradleDependency" severity="warning" />
+
     <issue id="InflateParams" severity="error" />
     <issue id="InlinedApi" severity="error" />
     <issue id="InvalidPackage" severity="warning" />


### PR DESCRIPTION
## Description
- Bump both Firebase core and performance. See #126 #127 
- Bump Flipper. See #128
- Change Android Lint policy for dependency updates from error to warning to let Dependabot achieve green pull requests.

## Reasons to merge these changes
To be up to date with latest improvements.