### PR TITLE
Setup Android Lint to check dependencies too

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,6 +76,10 @@ android {
         }
     }
 
+    lintOptions {
+        checkDependencies true
+    }
+
     dynamicFeatures = [":feature_addbutton"]
 
 }


### PR DESCRIPTION
## Description
Setup Android Lint to check for instance whether any unused resource from an Android Library should be marked as unused if it's not used in the app module.

## Reasons to merge these changes
To have better checks ==> quality