### PR TITLE
Bump Firebase Crashlytics to the latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
           command: ./gradlew app:build -x check -x lintVitalRelease -x uploadCrashlyticsMappingFileRelease
       - run:
           name: "Run App Bundle"
-          command: ./gradlew app:bundle
+          command: ./gradlew app:bundle -x uploadCrashlyticsMappingFileRelease
 workflows:
   version: 2.1
   "Pull Requests Workflow":

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - checkout
       - run:
           name: "Run App Build"
-          command: ./gradlew app:build -x check -x lintVitalRelease
+          command: ./gradlew app:build -x check -x lintVitalRelease -x uploadCrashlyticsMappingFileRelease
       - run:
           name: "Run App Bundle"
           command: ./gradlew app:bundle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 ### Added
 - Let users share packaged buttons too.
 - Let users delete custom audios by swiping horizontally.
-- Support for Android Q (API Level 29).
+- Support for Android 11 (API Level 30).
 - Pull Requests template for contributors.
 - Firebase Analytics.
 - Firebase Crashlytics including last logs from each error.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,13 +12,13 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    compileSdkVersion 29
-    buildToolsVersion '28.0.3'
+    compileSdkVersion 30
+    buildToolsVersion '30.0.1'
 
     defaultConfig {
         applicationId "com.github.barriosnahuel.vossosunboton"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 5
         versionName '2.0.0'
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.application'
-apply plugin: 'io.fabric'
+apply plugin: 'com.google.gms.google-services'
+apply plugin: 'com.google.firebase.crashlytics'
 apply plugin: 'com.google.firebase.firebase-perf'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
@@ -115,5 +116,3 @@ dependencies {
     testImplementation 'com.google.truth:truth:1.0.1'
     testImplementation 'io.mockk:mockk:1.10.0'
 }
-
-apply plugin: 'com.google.gms.google-services'

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,69 +1,34 @@
 {
   "project_info": {
     "project_number": "103845390903",
-    "firebase_url": "https://push-me-044.firebaseio.com",
-    "project_id": "push-me-044",
-    "storage_bucket": "push-me-044.appspot.com"
+    "project_id": "push-me-044"
   },
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:103845390903:android:fb571ecf2ebb1552b7edb2",
-        "android_client_info": {
-          "package_name": "com.github.barriosnahuel.vossosunboton"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "103845390903-m8es4nbmrcqkds9kqcg9tn0tspels9ln.apps.googleusercontent.com",
-          "client_type": 3
-        }
-      ],
-      "api_key": [
-        {
-          "current_key": "AIzaSyD4BVICNKBSe7ms6bmHni0vgXQzVjnuJFw"
-        }
-      ],
-      "services": {
-        "appinvite_service": {
-          "other_platform_oauth_client": [
-            {
-              "client_id": "103845390903-m8es4nbmrcqkds9kqcg9tn0tspels9ln.apps.googleusercontent.com",
-              "client_type": 3
-            }
-          ]
-        }
-      }
-    },
-    {
-      "client_info": {
-        "mobilesdk_app_id": "1:103845390903:android:193f8a620d0cab38b7edb2",
+        "mobilesdk_app_id": "1:999999999:android:dummydummydummy",
         "android_client_info": {
           "package_name": "com.github.barriosnahuel.vossosunboton.debug"
         }
       },
-      "oauth_client": [
-        {
-          "client_id": "103845390903-m8es4nbmrcqkds9kqcg9tn0tspels9ln.apps.googleusercontent.com",
-          "client_type": 3
-        }
-      ],
       "api_key": [
         {
-          "current_key": "AIzaSyD4BVICNKBSe7ms6bmHni0vgXQzVjnuJFw"
+          "current_key": "a-really-dummy-value"
         }
-      ],
-      "services": {
-        "appinvite_service": {
-          "other_platform_oauth_client": [
-            {
-              "client_id": "103845390903-m8es4nbmrcqkds9kqcg9tn0tspels9ln.apps.googleusercontent.com",
-              "client_type": 3
-            }
-          ]
+      ]
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:999999999:android:dummydummydummy",
+        "android_client_info": {
+          "package_name": "com.github.barriosnahuel.vossosunboton"
         }
-      }
+      },
+      "api_key": [
+        {
+          "current_key": "a-really-dummy-value"
+        }
+      ]
     }
-  ],
-  "configuration_version": "1"
+  ]
 }

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,34 +1,69 @@
 {
   "project_info": {
     "project_number": "103845390903",
-    "project_id": "push-me-044"
+    "firebase_url": "https://push-me-044.firebaseio.com",
+    "project_id": "push-me-044",
+    "storage_bucket": "push-me-044.appspot.com"
   },
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:999999999:android:dummydummydummy",
-        "android_client_info": {
-          "package_name": "com.github.barriosnahuel.vossosunboton.debug"
-        }
-      },
-      "api_key": [
-        {
-          "current_key": "a-really-dummy-value"
-        }
-      ]
-    },
-    {
-      "client_info": {
-        "mobilesdk_app_id": "1:999999999:android:dummydummydummy",
+        "mobilesdk_app_id": "1:103845390903:android:fb571ecf2ebb1552b7edb2",
         "android_client_info": {
           "package_name": "com.github.barriosnahuel.vossosunboton"
         }
       },
+      "oauth_client": [
+        {
+          "client_id": "103845390903-m8es4nbmrcqkds9kqcg9tn0tspels9ln.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
       "api_key": [
         {
-          "current_key": "a-really-dummy-value"
+          "current_key": "AIzaSyD4BVICNKBSe7ms6bmHni0vgXQzVjnuJFw"
         }
-      ]
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "103845390903-m8es4nbmrcqkds9kqcg9tn0tspels9ln.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:103845390903:android:193f8a620d0cab38b7edb2",
+        "android_client_info": {
+          "package_name": "com.github.barriosnahuel.vossosunboton.debug"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "103845390903-m8es4nbmrcqkds9kqcg9tn0tspels9ln.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyD4BVICNKBSe7ms6bmHni0vgXQzVjnuJFw"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "103845390903-m8es4nbmrcqkds9kqcg9tn0tspels9ln.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
     }
-  ]
+  ],
+  "configuration_version": "1"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,16 +3,13 @@ buildscript {
         jcenter()
         google()
         maven {
-            url 'https://maven.fabric.io/public'
-        }
-        maven {
             url 'https://plugins.gradle.org/m2/'
         }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.3'
         classpath 'com.google.gms:google-services:4.3.3'
-        classpath 'io.fabric.tools:gradle:1.31.2'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.2.0'
 
         classpath 'com.google.firebase:perf-plugin:1.3.1'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72'

--- a/commons_android/build.gradle
+++ b/commons_android/build.gradle
@@ -24,6 +24,8 @@ android {
 dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
 
-    implementation 'com.crashlytics.sdk.android:crashlytics:2.10.1'
+    implementation 'com.google.firebase:firebase-crashlytics:17.1.1'
+    implementation 'com.google.firebase:firebase-analytics:17.4.4'
+
     implementation 'com.jakewharton.timber:timber:4.7.1'
 }

--- a/commons_android/build.gradle
+++ b/commons_android/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'kotlin-android-extensions'
 apply from: "$project.rootProject.projectDir/linters.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
     }
 
     resourcePrefix 'commons_android_'

--- a/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/error/Trackable.kt
+++ b/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/error/Trackable.kt
@@ -1,6 +1,6 @@
 package com.github.barriosnahuel.vossosunboton.commons.android.error
 
-import com.crashlytics.android.Crashlytics
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import timber.log.Timber
 
 /**
@@ -30,11 +30,11 @@ object Tracker : Trackable {
         Timber.e("Tracking error to Firebase Crashlytics: %s", throwable.message)
         throwable.printStackTrace()
 
-        Crashlytics.logException(throwable)
+        FirebaseCrashlytics.getInstance().recordException(throwable)
     }
 
     override fun log(message: String) {
-        Crashlytics.log(message)
+        FirebaseCrashlytics.getInstance().log(message)
     }
 }
 

--- a/commons_file/build.gradle
+++ b/commons_file/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'kotlin-android'
 apply from: "$project.rootProject.projectDir/linters.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
     }
 
     resourcePrefix 'commons_file_'

--- a/feature_addbutton/build.gradle
+++ b/feature_addbutton/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'kotlin-android-extensions'
 apply from: "$project.rootProject.projectDir/linters.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
     }
 
     resourcePrefix 'feature_addbutton_'

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'kotlin-android'
 apply from: "$project.rootProject.projectDir/linters.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
     }
 
     resourcePrefix 'model_'
@@ -17,6 +17,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 


### PR DESCRIPTION
## Description
That's it!

Also, I have to exclude the task `:app:uploadCrashlyticsMappingFileRelease` whenn running `:build` and `:bundle` to workaround a 400 Bad Request from Firebase when trying to upload the mapping files with a dummy `google-services.json`

## Reasons to merge these changes
Because Crashlytics is no longer maintained