### PR TITLE
Use Firebase BoM instead of per-library version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,8 +95,10 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'com.google.android.material:material:1.2.1'
 
-    implementation 'com.google.firebase:firebase-core:18.0.0'
-    implementation 'com.google.firebase:firebase-perf:19.0.10'
+    implementation platform ('com.google.firebase:firebase-bom:26.1.0')
+
+    implementation 'com.google.firebase:firebase-core'
+    implementation 'com.google.firebase:firebase-perf'
 
     implementation 'com.jakewharton.timber:timber:4.7.1'
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,10 @@
         android:supportsRtl="true"
         android:theme="@style/app_MyCustomTheme">
 
+        <meta-data
+            android:name="firebase_performance_collection_enabled"
+            android:value="true" />
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/commons_android/build.gradle
+++ b/commons_android/build.gradle
@@ -29,8 +29,9 @@ android {
 dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
 
-    implementation 'com.google.firebase:firebase-crashlytics:17.3.0'
-    implementation 'com.google.firebase:firebase-analytics:18.0.0'
+    implementation platform ('com.google.firebase:firebase-bom:26.1.0')
+    implementation 'com.google.firebase:firebase-crashlytics'
+    implementation 'com.google.firebase:firebase-analytics'
 
     implementation 'com.jakewharton.timber:timber:4.7.1'
 }


### PR DESCRIPTION
## Description
Use latest Firebase BoM instead of using a per-library version strategy

## Reasons to merge these changes
To simplify and prevent version conflicts