### PR TITLE
Remove deprecated exclude from Robolectric setup

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -110,10 +110,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.1'
 
     testImplementation 'androidx.test:core:1.3.0'
-    testImplementation ('org.robolectric:robolectric:4.5.1'){
-        // https://github.com/robolectric/robolectric/issues/5245
-        exclude group: 'com.google.auto.service', module: 'auto-service'
-    }
+    testImplementation 'org.robolectric:robolectric:4.5.1'
 
     testImplementation 'com.google.truth:truth:1.1'
     testImplementation 'io.mockk:mockk:1.10.2'


### PR DESCRIPTION
## Description
Remove `exclude` from dependency setup because bug https://github.com/robolectric/robolectric/issues/5245 was fixed starting v4.4: https://github.com/robolectric/robolectric/commit/0885c87ba871ce7ee4deea300d8f42b19b8c888d

## Reasons to merge these changes
To cleanup legacy workarounds