### PR TITLE
Change compile & target SDK versions to API level 32.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 ### Added
 - Let users share packaged buttons too.
 - Let users delete custom audios by swiping horizontally.
-- Support for Android 11 (API Level 30).
+- Support for Android 12L (API Level 32).
 - Pull Requests template for contributors.
 - Firebase Analytics.
 - Firebase Crashlytics including last logs from each error.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,12 +17,12 @@ android {
         jvmTarget = "11"
     }
 
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         applicationId "com.github.barriosnahuel.vossosunboton"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 5
         versionName '2.0.0'
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
         <activity
             android:name=".ui.home.LandingActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"
+            android:exported="true"
             android:launchMode="singleTask">
 
             <intent-filter>

--- a/commons_android/build.gradle
+++ b/commons_android/build.gradle
@@ -9,11 +9,11 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 32
     }
 
     resourcePrefix 'commons_android_'

--- a/commons_file/build.gradle
+++ b/commons_file/build.gradle
@@ -8,11 +8,11 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 32
     }
 
     resourcePrefix 'commons_file_'

--- a/feature_addbutton/build.gradle
+++ b/feature_addbutton/build.gradle
@@ -9,7 +9,7 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21

--- a/feature_addbutton/src/main/AndroidManifest.xml
+++ b/feature_addbutton/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     <application>
         <activity
             android:name="com.github.barriosnahuel.vossosunboton.feature.addbutton.AddButtonActivity"
+            android:exported="true"
             android:label="@string/app_feature_addbutton_activity_label_dynamic_feature"
             android:launchMode="singleTask"
             android:parentActivityName="com.github.barriosnahuel.vossosunboton.ui.home.LandingActivity"

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -8,11 +8,11 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 32
     }
 
     resourcePrefix 'model_'


### PR DESCRIPTION
## Description
Simply that!

## Reasons to merge these changes
To support latest OS, and also to be ready to upgrade Flipper.