### PR TITLE
Gradle and Android Gradle Plugin upgrade (v7.3.3 and v7.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Firebase and static code analyzers too.
 - New ':commons_file' and ':commons_android' modules.
 - Changelog formatting.
 - Default language to English.
-- Gradle version to [v7.2](https://docs.gradle.org/7.2/release-notes.html).
+- Gradle version to [v7.3.3](https://docs.gradle.org/7.2/release-notes.html).
 - Java compile version to v11.
 - Better separation of responsibilities.
 - `StrictMode` warnings now are logged to Crashlytics instead of the debugging notifier.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,8 @@ apply plugin: 'com.getkeepsafe.dexcount'
 apply from: "$project.rootProject.projectDir/linters.gradle"
 
 android {
+    namespace 'com.github.barriosnahuel.vossosunboton'
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.github.barriosnahuel.vossosunboton">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
         <meta-data

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.github.barriosnahuel.vossosunboton">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath 'com.android.tools.build:gradle:7.2.0'
         classpath 'com.google.gms:google-services:4.3.10'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.8.1'
 

--- a/commons_android/build.gradle
+++ b/commons_android/build.gradle
@@ -4,6 +4,8 @@ apply plugin: 'kotlin-android-extensions'
 apply from: "$project.rootProject.projectDir/linters.gradle"
 
 android {
+    namespace 'com.github.barriosnahuel.vossosunboton.commons.android'
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/commons_android/src/main/AndroidManifest.xml
+++ b/commons_android/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.github.barriosnahuel.vossosunboton.commons.android" />
+<manifest />

--- a/commons_file/build.gradle
+++ b/commons_file/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'kotlin-android'
 apply from: "$project.rootProject.projectDir/linters.gradle"
 
 android {
+    namespace 'com.github.barriosnahuel.vossosunboton.commons.file'
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/commons_file/src/main/AndroidManifest.xml
+++ b/commons_file/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.github.barriosnahuel.vossosunboton.commons.file" />
+<manifest />

--- a/feature_addbutton/build.gradle
+++ b/feature_addbutton/build.gradle
@@ -4,6 +4,8 @@ apply plugin: 'kotlin-android-extensions'
 apply from: "$project.rootProject.projectDir/linters.gradle"
 
 android {
+    namespace 'com.github.barriosnahuel.vossosunboton.feature.addbutton'
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/feature_addbutton/src/main/AndroidManifest.xml
+++ b/feature_addbutton/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:dist="http://schemas.android.com/apk/distribution"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.github.barriosnahuel.vossosunboton.feature.addbutton">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <dist:module
         dist:instant="false"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/linters.gradle
+++ b/linters.gradle
@@ -9,7 +9,7 @@ detekt {
 }
 
 android {
-    lintOptions {
+    lint {
         checkDependencies true
         lintConfig = file("$project.rootProject.projectDir/config/android/android-lint.xml")
     }

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'kotlin-android'
 apply from: "$project.rootProject.projectDir/linters.gradle"
 
 android {
+    namespace 'com.github.barriosnahuel.vossosunboton.model'
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/model/src/main/AndroidManifest.xml
+++ b/model/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.github.barriosnahuel.vossosunboton.model" />
+<manifest />


### PR DESCRIPTION
## Description
- Bump Gradle to 7.3.3
- Apply suggestions from the Android Studio Upgrade Assistant:
  - Use namespace in build files instead of `package` in `AndroidManifest` files;
  - Rename `lintOptions` to `lint`

## Reasons to merge these changes
To honour latest good practices