### PR TITLE
Replace synthetic view binding by native view binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Firebase and static code analyzers too.
 - `LeakCanary` warnings now are logged to Crashlytics.
 - Refactor of Media Player setup for clearness.
 - Replaced Stetho with [Flipper](https://fbflipper.com/).
+- Replace usages of synthetic accessors for views in layouts to native view binding.
 
 ### Fixed
 - Sharing buttons issues due to a bad permissions setup.
@@ -52,6 +53,7 @@ Firebase and static code analyzers too.
 ### Removed
 - Library StrictModeNotifier for debug builds.
 - Library [Static Code Analysis](https://github.com/Monits/static-code-analysis-plugin) because it's no longer actively maintained.
+- `kotlin-android-extensions` plugin because it's no longer necessary.
 
 ## \[v1.1.0] - 2017-08-16
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.google.firebase.crashlytics'
 apply plugin: 'com.google.firebase.firebase-perf'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.getkeepsafe.dexcount'
 apply from: "$project.rootProject.projectDir/linters.gradle"
 

--- a/commons_android/build.gradle
+++ b/commons_android/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply from: "$project.rootProject.projectDir/linters.gradle"
 
 android {

--- a/config/android/android-lint.xml
+++ b/config/android/android-lint.xml
@@ -63,7 +63,10 @@
     <issue id="Recycle" severity="error" />
     <issue id="TooDeepLayout" severity="error" />
     <issue id="TooManyViews" severity="error" />
-    <issue id="UnusedIds" severity="error" />
+
+    <!-- Muted till https://issuetracker.google.com/issues/233912817 is fixed -->
+    <issue id="UnusedIds" severity="warning" />
+
     <issue id="UnusedNamespace" severity="error" />
     <issue id="UnusedResources" severity="error">
         <!--

--- a/feature_addbutton/build.gradle
+++ b/feature_addbutton/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.dynamic-feature'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply from: "$project.rootProject.projectDir/linters.gradle"
 
 android {
@@ -25,6 +24,9 @@ android {
             // https://developer.android.com/guide/app-bundle/at-install-delivery#dynamic_feature_proguard
             proguardFiles 'proguard-rules-dynamic-features.pro'
         }
+    }
+    buildFeatures {
+        viewBinding true
     }
 }
 

--- a/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivity.kt
+++ b/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivity.kt
@@ -11,11 +11,10 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.github.barriosnahuel.vossosunboton.commons.android.ui.Feedback
+import com.github.barriosnahuel.vossosunboton.feature.addbutton.databinding.FeatureAddbuttonActivityAddButtonBinding
 import com.github.barriosnahuel.vossosunboton.feature.base.AbstractActivity
 import com.github.barriosnahuel.vossosunboton.feature.base.NavigationSections
 import com.github.barriosnahuel.vossosunboton.feature.base.PermissionsRequest
-import kotlinx.android.synthetic.main.feature_addbutton_activity_add_button.feature_addbutton_saveButton
-import kotlinx.android.synthetic.main.feature_addbutton_activity_add_button.name
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -26,12 +25,15 @@ import kotlinx.coroutines.withContext
  */
 class AddButtonActivity : AbstractActivity() {
 
+    private lateinit var binding: FeatureAddbuttonActivityAddButtonBinding
     private var uri: Uri? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        setContentView(R.layout.feature_addbutton_activity_add_button)
+        binding = FeatureAddbuttonActivityAddButtonBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
         bindToolbar()
 
         /**
@@ -43,7 +45,7 @@ class AddButtonActivity : AbstractActivity() {
             finish()
         }
 
-        name.setOnEditorActionListener { _, actionId, _ ->
+        binding.name.setOnEditorActionListener { _, actionId, _ ->
             val consumedHere = if (actionId == EditorInfo.IME_ACTION_DONE) {
                 saveButton(this@AddButtonActivity)
                 true
@@ -54,7 +56,7 @@ class AddButtonActivity : AbstractActivity() {
             consumedHere
         }
 
-        feature_addbutton_saveButton.setOnClickListener { saveButton(this) }
+        binding.saveButton.setOnClickListener { saveButton(this) }
     }
 
     override fun bindToolbar() {
@@ -75,8 +77,8 @@ class AddButtonActivity : AbstractActivity() {
     }
 
     private fun saveButton(context: Context) {
-        if (name.text.isEmpty()) {
-            name.error = getString(R.string.feature_addbutton_name_is_required_error)
+        if (binding.name.text.isEmpty()) {
+            binding.name.error = getString(R.string.feature_addbutton_name_is_required_error)
         } else {
             checkRequiredPermissions(context)
         }
@@ -101,7 +103,7 @@ class AddButtonActivity : AbstractActivity() {
     }
 
     private fun saveNewButton(context: Context) {
-        val deferredFeedbackMessage = AddButtonFeature.instance.saveNewButtonAsync(context, name.text.toString(), uri!!.toString())
+        val deferredFeedbackMessage = AddButtonFeature.instance.saveNewButtonAsync(context, binding.name.text.toString(), uri!!.toString())
 
         GlobalScope.launch {
             withContext(Dispatchers.Main) {

--- a/feature_addbutton/src/main/res/layout/feature_addbutton_activity_add_button.xml
+++ b/feature_addbutton/src/main/res/layout/feature_addbutton_activity_add_button.xml
@@ -29,7 +29,7 @@
         tools:ignore="UnusedAttribute" />
 
     <Button
-        android:id="@+id/feature_addbutton_saveButton"
+        android:id="@+id/saveButton"
         style="@style/feature_addbutton_MyCustomTheme.Form.Button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION
## Description
- Replace synthetic view binding by native view binding
- That triggered also to stop applying the `kotlin-android-extensions` plugin to all modules 🎉 
- And sadly changing from `error` to `warning` the severity of the Android Lint `UnusedIds` rule till Google fixes https://issuetracker.google.com/issues/233912817

## Reasons to merge these changes
To be one more step closer to try Jetpack Compose 🚀 