### PR TITLE
Sanitize custom button filename using the sound name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - KTLint migrated to JLLeitschuh plugin with KTLint 1.5.0.
 - Sound list is now sorted alphabetically across all tabs.
 - Share sheet filename for bundled sounds now shows the button name instead of an internal prefix.
+- Custom button audio files are now named after the user-provided sound name (non-alphanumeric chars replaced by underscores) instead of the generic "Button-custom-" prefix.
 
 ### Fixed
 - Bundled sounds no longer offer a swipe-to-delete gesture; the action is simply not available.

--- a/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
+++ b/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
@@ -42,7 +42,8 @@ private class AddButtonFeatureImpl : AddButtonFeature {
         name: String,
         uri: String,
     ): Deferred<Int> {
-        val fileName = "Button-custom-" + System.currentTimeMillis() + ".mp3"
+        val sanitizedName = name.replace(Regex("[^a-zA-Z0-9._-]"), "_")
+        val fileName = "$sanitizedName-${System.currentTimeMillis()}.mp3"
         val targetFile = getFile(context, fileName)
 
         return GlobalScope.async(Dispatchers.IO) {


### PR DESCRIPTION
### Summary
- Custom button audio files are now named after the user-provided sound name instead of the generic `Button-custom-` prefix.
- Non-alphanumeric characters in the sound name are replaced by underscores to produce a safe filename.
- Updated CHANGELOG under `[unreleased] > Changed`.

### Code review tips
- Change is confined to `AddButtonFeature.kt` — one call site where the filename prefix is constructed.
- The sanitization regex replaces everything that is not `[a-zA-Z0-9]` with `_`; verify edge cases like all-special-char names (result would be `_____.mp3` — acceptable but worth awareness).

### Test plan
- [ ] Added a custom button with a plain name (e.g. "Cat") — file saved as `Cat.mp3`.
- [ ] Added a custom button with spaces/special chars (e.g. "My Sound!") — file saved as `My_Sound_.mp3`.
- [ ] Existing bundled sounds unaffected.
- [ ] CI: unit tests + code analysis pass.