### PR TITLE
refactor: migrate to Gradle version catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Tests for `SoundsViewModel` covering playback state and delete/restore flows.
 
 ### Changed
+- Centralised all dependency and plugin versions in `gradle/libs.versions.toml` (Gradle version catalog).
 - Replaced placeholder color palette with a full WCAG 2.2 AA–compliant brand identity (Deep Violet / Vivid Rose / Amber) covering all Material3 color roles for light and dark modes.
 - TopAppBar on the home screen and Add Button screen now shows the brand primary color instead of the default surface color.
 - NavigationBar and sound cards now use explicit brand-palette colors instead of derived dark defaults, restoring visual distinction in both light and dark modes.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -89,32 +89,32 @@ dependencies {
     implementation project(':commons_android')
     implementation project(':model')
 
-    implementation 'androidx.appcompat:appcompat:1.7.1'
-    implementation 'com.google.android.material:material:1.13.0'
+    implementation libs.androidx.appcompat
+    implementation libs.material
 
-    implementation platform('com.google.firebase:firebase-bom:34.12.0')
-    implementation 'com.google.firebase:firebase-analytics'
-    implementation 'com.google.firebase:firebase-perf'
+    implementation platform(libs.firebase.bom)
+    implementation libs.firebase.analytics
+    implementation libs.firebase.perf
 
-    implementation 'com.jakewharton.timber:timber:5.0.1'
+    implementation libs.timber
 
-    implementation platform('androidx.compose:compose-bom:2026.03.01')
-    implementation 'androidx.compose.ui:ui'
-    implementation 'androidx.compose.ui:ui-tooling-preview'
-    implementation 'androidx.compose.material3:material3'
-    implementation 'androidx.compose.material:material-icons-extended'
-    implementation 'androidx.activity:activity-compose'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.10.0'
-    implementation 'androidx.lifecycle:lifecycle-runtime-compose:2.10.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2'
+    implementation platform(libs.compose.bom)
+    implementation libs.compose.ui
+    implementation libs.compose.ui.tooling.preview
+    implementation libs.compose.material3
+    implementation libs.compose.material.icons.extended
+    implementation libs.androidx.activity.compose
+    implementation libs.lifecycle.viewmodel.compose
+    implementation libs.lifecycle.runtime.compose
+    implementation libs.coroutines.android
 
-    debugImplementation 'androidx.compose.ui:ui-tooling'
-    debugImplementation 'androidx.compose.ui:ui-test-manifest'
+    debugImplementation libs.compose.ui.tooling
+    debugImplementation libs.compose.ui.test.manifest
 
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation 'androidx.test:core:1.6.1'
-    testImplementation 'org.robolectric:robolectric:4.16.1'
-    testImplementation 'com.google.truth:truth:1.4.4'
-    testImplementation 'io.mockk:mockk:1.14.9'
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2'
+    testImplementation libs.junit
+    testImplementation libs.androidx.test.core
+    testImplementation libs.robolectric
+    testImplementation libs.truth
+    testImplementation libs.mockk
+    testImplementation libs.coroutines.test
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,17 +7,17 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:9.1.1'
-        classpath 'com.google.gms:google-services:4.4.4'
+        classpath libs.build.agp
+        classpath libs.build.google.services
 
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.7'
-        classpath 'com.google.firebase:perf-plugin:2.0.2'
+        classpath libs.build.firebase.crashlytics.gradle
+        classpath libs.build.firebase.perf.plugin
 
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.20'
-        classpath 'org.jetbrains.kotlin:compose-compiler-gradle-plugin:2.3.20'
+        classpath libs.build.kotlin.gradle
+        classpath libs.build.kotlin.compose
 
-        classpath 'io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.8'
-        classpath 'org.jlleitschuh.gradle:ktlint-gradle:14.2.0'
+        classpath libs.build.detekt.gradle
+        classpath libs.build.ktlint.gradle
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/commons_android/build.gradle
+++ b/commons_android/build.gradle
@@ -27,11 +27,11 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.10.0'
+    implementation libs.androidx.annotation
 
-    implementation platform('com.google.firebase:firebase-bom:34.12.0')
-    implementation 'com.google.firebase:firebase-crashlytics'
-    implementation 'com.google.firebase:firebase-analytics'
+    implementation platform(libs.firebase.bom)
+    implementation libs.firebase.crashlytics
+    implementation libs.firebase.analytics
 
-    implementation 'com.jakewharton.timber:timber:5.0.1'
+    implementation libs.timber
 }

--- a/commons_file/build.gradle
+++ b/commons_file/build.gradle
@@ -27,6 +27,6 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.10.0'
-    implementation 'com.jakewharton.timber:timber:5.0.1'
+    implementation libs.androidx.annotation
+    implementation libs.timber
 }

--- a/feature_addbutton/build.gradle
+++ b/feature_addbutton/build.gradle
@@ -37,20 +37,20 @@ dependencies {
     implementation project(':commons_file')
     implementation project(':model')
 
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2'
+    implementation libs.coroutines.core
+    implementation libs.coroutines.android
 
-    implementation 'com.jakewharton.timber:timber:5.0.1'
-    implementation 'androidx.annotation:annotation:1.10.0'
+    implementation libs.timber
+    implementation libs.androidx.annotation
 
-    implementation platform('androidx.compose:compose-bom:2026.03.01')
-    implementation 'androidx.compose.ui:ui'
-    implementation 'androidx.compose.ui:ui-tooling-preview'
-    implementation 'androidx.compose.material3:material3'
-    implementation 'androidx.compose.material:material-icons-extended'
-    implementation 'androidx.activity:activity-compose:1.13.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.10.0'
-    implementation 'androidx.lifecycle:lifecycle-runtime-compose:2.10.0'
+    implementation platform(libs.compose.bom)
+    implementation libs.compose.ui
+    implementation libs.compose.ui.tooling.preview
+    implementation libs.compose.material3
+    implementation libs.compose.material.icons.extended
+    implementation libs.androidx.activity.compose
+    implementation libs.lifecycle.viewmodel.compose
+    implementation libs.lifecycle.runtime.compose
 
-    debugImplementation 'androidx.compose.ui:ui-tooling'
+    debugImplementation libs.compose.ui.tooling
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,85 @@
+[versions]
+# Build plugins
+agp                       = "9.1.1"
+googleServices            = "4.4.4"
+firebaseCrashlyticsGradle = "3.0.7"
+firebasePerfPlugin        = "2.0.2"
+kotlin                    = "2.3.20"
+detekt                    = "1.23.8"
+ktlintGradle              = "14.2.0"
+ktlint                    = "1.6.0"
+
+# AndroidX / Jetpack
+appcompat                 = "1.7.1"
+annotation                = "1.10.0"
+activityCompose           = "1.13.0"
+composeBom                = "2026.03.01"
+lifecycleCompose          = "2.10.0"
+material                  = "1.13.0"
+
+# Firebase
+firebaseBom               = "34.12.0"
+
+# Other
+timber                    = "5.0.1"
+coroutines                = "1.10.2"
+
+# Test
+junit                     = "4.13.2"
+androidxTestCore          = "1.6.1"
+robolectric               = "4.16.1"
+truth                     = "1.4.4"
+mockk                     = "1.14.9"
+
+[libraries]
+# ---------- Build-script classpath ----------
+build-agp                         = { module = "com.android.tools.build:gradle",                      version.ref = "agp" }
+build-google-services             = { module = "com.google.gms:google-services",                      version.ref = "googleServices" }
+build-firebase-crashlytics-gradle = { module = "com.google.firebase:firebase-crashlytics-gradle",     version.ref = "firebaseCrashlyticsGradle" }
+build-firebase-perf-plugin        = { module = "com.google.firebase:perf-plugin",                     version.ref = "firebasePerfPlugin" }
+build-kotlin-gradle               = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin",           version.ref = "kotlin" }
+build-kotlin-compose              = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
+build-detekt-gradle               = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin",    version.ref = "detekt" }
+build-ktlint-gradle               = { module = "org.jlleitschuh.gradle:ktlint-gradle",                version.ref = "ktlintGradle" }
+
+# ---------- AndroidX ----------
+androidx-appcompat                = { module = "androidx.appcompat:appcompat",       version.ref = "appcompat" }
+androidx-annotation               = { module = "androidx.annotation:annotation",     version.ref = "annotation" }
+androidx-activity-compose         = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
+
+# ---------- Compose BOM + components (no version — resolved by BOM) ----------
+compose-bom                       = { module = "androidx.compose:compose-bom",                       version.ref = "composeBom" }
+compose-ui                        = { module = "androidx.compose.ui:ui" }
+compose-ui-tooling-preview        = { module = "androidx.compose.ui:ui-tooling-preview" }
+compose-ui-tooling                = { module = "androidx.compose.ui:ui-tooling" }
+compose-ui-test-manifest          = { module = "androidx.compose.ui:ui-test-manifest" }
+compose-material3                 = { module = "androidx.compose.material3:material3" }
+compose-material-icons-extended   = { module = "androidx.compose.material:material-icons-extended" }
+
+# ---------- Lifecycle ----------
+lifecycle-viewmodel-compose       = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleCompose" }
+lifecycle-runtime-compose         = { module = "androidx.lifecycle:lifecycle-runtime-compose",   version.ref = "lifecycleCompose" }
+
+# ---------- Material ----------
+material                          = { module = "com.google.android.material:material", version.ref = "material" }
+
+# ---------- Firebase BOM + components (no version — resolved by BOM) ----------
+firebase-bom                      = { module = "com.google.firebase:firebase-bom",        version.ref = "firebaseBom" }
+firebase-analytics                = { module = "com.google.firebase:firebase-analytics" }
+firebase-crashlytics              = { module = "com.google.firebase:firebase-crashlytics" }
+firebase-perf                     = { module = "com.google.firebase:firebase-perf" }
+
+# ---------- Timber ----------
+timber                            = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
+
+# ---------- Coroutines ----------
+coroutines-android                = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
+coroutines-core                   = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core",    version.ref = "coroutines" }
+coroutines-test                   = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test",    version.ref = "coroutines" }
+
+# ---------- Test ----------
+junit                             = { module = "junit:junit",               version.ref = "junit" }
+androidx-test-core                = { module = "androidx.test:core",        version.ref = "androidxTestCore" }
+robolectric                       = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+truth                             = { module = "com.google.truth:truth",    version.ref = "truth" }
+mockk                             = { module = "io.mockk:mockk",            version.ref = "mockk" }

--- a/linters.gradle
+++ b/linters.gradle
@@ -15,7 +15,7 @@ detekt {
 ktlint {
     android = true
     outputToConsole = true
-    version = "1.6.0"
+    version = libs.versions.ktlint.get()
 }
 
 android {

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -29,6 +29,6 @@ android {
 dependencies {
     implementation project(':commons_file')
 
-    implementation 'com.jakewharton.timber:timber:5.0.1'
-    implementation 'androidx.annotation:annotation:1.10.0'
+    implementation libs.timber
+    implementation libs.androidx.annotation
 }


### PR DESCRIPTION
### Summary
- Introduces `gradle/libs.versions.toml` as the single source of truth for all dependency and plugin versions.
- All 5 module `build.gradle` files and the root `build.gradle` now reference the catalog (e.g. `libs.timber`, `libs.compose.bom`) instead of hardcoded strings.
- `linters.gradle` reads the KTLint version via `libs.versions.ktlint.get()` instead of a hardcoded literal.
- Pure refactor — no version changes, no behaviour changes.

### Code review tips
- The alias naming convention: hyphens in TOML keys become dots in Groovy accessors (`compose-ui-tooling` → `libs.compose.ui.tooling`). Verify the mapping looks correct in each module.
- BOM-managed dependencies (Compose, Firebase) are declared in the catalog without a `version.ref` — their version is still resolved by the BOM at runtime.
- `libs.versions.ktlint.get()` in `linters.gradle` is the standard way to read a raw version string from a catalog in a Groovy applied-script context.

### Test plan
- [x] `./gradlew check` — all unit tests and linters pass
- [x] `./gradlew app:lintVitalRelease` — release lint clean