### PR TITLE
perf: load sounds on background thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Tests for `SoundsViewModel` covering playback state and delete/restore flows.
 
 ### Changed
+- `SoundsViewModel` now loads sounds on a background thread (`Dispatchers.IO`) to avoid blocking the main thread on startup.
 - Centralised all dependency and plugin versions in `gradle/libs.versions.toml` (Gradle version catalog).
 - Replaced placeholder color palette with a full WCAG 2.2 AA–compliant brand identity (Deep Violet / Vivid Rose / Amber) covering all Material3 color roles for light and dark modes.
 - TopAppBar on the home screen and Add Button screen now shows the brand primary color instead of the default surface color.

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -2,14 +2,18 @@ package com.github.barriosnahuel.vossosunboton.ui.home
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerListener
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.model.data.manager.SoundDao
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 enum class AppTab { HOME, FAVORITES, EXPLORE }
@@ -21,6 +25,7 @@ data class DeletedSoundEvent(
 
 class SoundsViewModel(
     application: Application,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AndroidViewModel(application),
     PlayerControllerListener {
     private val _selectedTab = MutableStateFlow(AppTab.EXPLORE)
@@ -37,12 +42,12 @@ class SoundsViewModel(
 
     init {
         PlayerControllerFactory.instance.setOnStartStopListener(this)
-        loadSounds()
+        viewModelScope.launch(ioDispatcher) { loadSounds() }
     }
 
     fun selectTab(tab: AppTab) {
         _selectedTab.value = tab
-        loadSounds()
+        viewModelScope.launch(ioDispatcher) { loadSounds() }
     }
 
     fun playOrStop(sound: Sound) {
@@ -89,7 +94,7 @@ class SoundsViewModel(
         _deletedSoundEvent.value = null
     }
 
-    private fun loadSounds() {
+    private suspend fun loadSounds() {
         val allSounds = SoundDao().find(getApplication<Application>()).sortedBy { it.name.lowercase() }
         _sounds.update {
             when (_selectedTab.value) {

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
@@ -8,7 +8,6 @@ import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.mockk.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.After
@@ -145,7 +144,6 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
             .let { (it.get(this) as MutableStateFlow<List<Sound>>).value = sounds }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     private fun givenAViewModel(): SoundsViewModel =
         SoundsViewModel(
             androidx.test.core.app.ApplicationProvider

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
@@ -8,7 +8,9 @@ import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.After
 import org.junit.Assume.assumeTrue
 import org.junit.Before
@@ -143,9 +145,11 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
             .let { (it.get(this) as MutableStateFlow<List<Sound>>).value = sounds }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     private fun givenAViewModel(): SoundsViewModel =
         SoundsViewModel(
             androidx.test.core.app.ApplicationProvider
                 .getApplicationContext(),
+            ioDispatcher = UnconfinedTestDispatcher(),
         )
 }


### PR DESCRIPTION
### Summary
- `SoundsViewModel.loadSounds()` was called synchronously in the `init` block, running `SoundDao.find()` on the main thread on every startup and tab switch
- The fix wraps the call in `viewModelScope.launch(ioDispatcher)` using an injectable `CoroutineDispatcher` (default `Dispatchers.IO`)
- Tests pass `UnconfinedTestDispatcher` so coroutines execute eagerly without changing any assertions

### Code review tips
- `loadSounds()` is now `suspend` — any future caller must be inside a coroutine context
- `selectTab()` now returns immediately; `_sounds` updates asynchronously. The existing Compose `collectAsStateWithLifecycle` already handles this correctly since it's reactive
- `UnconfinedTestDispatcher` runs coroutines on the calling thread eagerly, so the `sounds are sorted alphabetically` test still works without `advanceUntilIdle()`

### Test plan
- [x] `./gradlew :app:test` — all `SoundsViewModelTest` cases pass across SDK M / Tiramisu / Vanilla Ice Cream
- [x] `./gradlew check -x test` — KtLint, Detekt, Android Lint all pass