### PR TITLE
fix: prevent startup crash caused by missing SoundsViewModel.Factory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,3 +120,4 @@ Available labels for this repository. Apply exactly one `a:` label to every PR b
 - Each entry is a single sentence starting with a capital letter, no trailing period
 - For dependency bumps, write one line summarising the overall bump (e.g. "Bumped all dependencies to latest stable"), not one line per library
 - After every commit, check whether the change is user-visible or architecturally significant; if so, update `## [unreleased]` before committing
+- Never add a `Fixed` entry for a bug introduced in the same `[unreleased]` cycle. If end-users never experienced the regression, it has no changelog entry — git history provides the traceability

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,20 @@ Dependency direction: `app` → `model`, `commons_android`, `commons_file`; `fea
 - `feature.share` — Sharing non-packaged audios to other apps
 - `feature.base` — Base classes, runtime permission handling
 
+## Activity smoke tests
+
+Every `Activity` in the `app` module must have a corresponding smoke test that verifies it reaches `Lifecycle.State.RESUMED` without crashing. Place it alongside the Activity in `app/src/test/`, extend `AbstractRobolectricTest`, and use:
+
+```kotlin
+ActivityScenario.launch(MyActivity::class.java).use { scenario ->
+    assertThat(scenario.state).isEqualTo(Lifecycle.State.RESUMED)
+}
+```
+
+Mock any singleton factories (e.g. `PlayerControllerFactory`) that would crash under Robolectric. See `LandingActivityTest` for the canonical example.
+
+**Dynamic feature modules** (e.g. `feature_addbutton`) cannot use Robolectric — Robolectric's `ShadowPackageParser` rejects split APKs (`Expected base APK, but found split`). Activities in those modules require instrumented tests if smoke coverage is needed.
+
 ## Code Quality
 
 All three linters run on CI and must pass:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,20 @@ All UI development and generated assets (store listing, What's New, changelogs) 
 
 Verify contrast when adding or changing colors. Use the [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/) or the Material Theme Builder. The brand palette in `AppTheme.kt` was designed to meet AA across all color roles.
 
+## Labels
+
+Available labels for this repository. Apply exactly one `a:` label to every PR before merging. Do not call `gh label list` — use this table.
+
+| Label | When to use |
+|---|---|
+| `a:bug` | Issue reporting something broken |
+| `a:feature` | PR that adds new user-facing functionality |
+| `a:feature-request` | Issue requesting a feature not yet built |
+| `a:fix` | PR that corrects a reported bug |
+| `an:enhancement` | PR that improves existing functionality without adding new features |
+| `dependencies` | PR that updates library, plugin, or Gradle wrapper versions (applied automatically by Dependabot) |
+| `stale` | Issue or PR with no recent activity — candidate for closing |
+
 ## Changelog
 
 `CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format:

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivity.kt
@@ -10,7 +10,7 @@ import androidx.activity.viewModels
 import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
 
 class LandingActivity : ComponentActivity() {
-    private val viewModel: SoundsViewModel by viewModels()
+    private val viewModel: SoundsViewModel by viewModels { SoundsViewModel.Factory }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         // The TopAppBar is always a dark violet in both light and dark modes, so status

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -2,7 +2,10 @@ package com.github.barriosnahuel.vossosunboton.ui.home
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerListener
 import com.github.barriosnahuel.vossosunboton.model.Sound
@@ -115,5 +118,14 @@ class SoundsViewModel(
         sound.isPlaying = false
         _playingSound.value = null
         _sounds.update { list -> list.map { if (it.name == sound.name) sound else it } }
+    }
+
+    companion object {
+        val Factory: ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer {
+                    SoundsViewModel(application = this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY]!!)
+                }
+            }
     }
 }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivityTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivityTest.kt
@@ -1,0 +1,33 @@
+package com.github.barriosnahuel.vossosunboton.ui.home
+
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+internal class LandingActivityTest : AbstractRobolectricTest() {
+    @Before
+    fun setUp() {
+        mockkObject(PlayerControllerFactory)
+        every { PlayerControllerFactory.instance.setOnStartStopListener(any()) } answers { nothing }
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `LandingActivity reaches RESUMED without crashing`() {
+        ActivityScenario.launch(LandingActivity::class.java).use { scenario ->
+            assertThat(scenario.state).isEqualTo(Lifecycle.State.RESUMED)
+        }
+    }
+}


### PR DESCRIPTION
### Summary

- `SoundsViewModel` was given an `ioDispatcher` constructor parameter (background-thread loading), which broke `AndroidViewModelFactory`'s reflection-based instantiation and caused a crash on startup
- Fixed by adding an explicit `SoundsViewModel.Factory` using the `viewModelFactory` DSL and wiring it in `LandingActivity`
- Added `LandingActivityTest` as a Robolectric smoke test that guards against this class of regression: verifies the Activity reaches `RESUMED` without crashing
- Documented the Activity smoke test practice in `CLAUDE.md`, including the Robolectric limitation for dynamic feature modules (split APK incompatibility)

### Code review tips

- The key change is in `SoundsViewModel.Factory` companion object and `viewModels { SoundsViewModel.Factory }` in `LandingActivity` — the Factory is what prevents the crash
- `LandingActivityTest` mocks `PlayerControllerFactory` (a singleton) to avoid audio-related failures under Robolectric; any future Activity smoke test will need similar treatment for its singleton dependencies
- `feature_addbutton`'s `AddButtonActivity` has no Robolectric coverage — Robolectric rejects split APKs, so that module is untestable with this stack (noted in CLAUDE.md)

### Test plan

- [x] `./gradlew test` — all unit tests pass across API 23 / 33 / 35
- [x] `./gradlew check -x test` — ktlint, detekt, checkstyle, Android lint all clean
- [x] `LandingActivityTest` passes on all three SDK levels