### PR TITLE
fix: play/pause icon stays stale until scroll

### DIFF
--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -109,15 +109,15 @@ class SoundsViewModel(
     }
 
     override fun onPlayerStart(sound: Sound) {
-        sound.isPlaying = true
-        _playingSound.value = sound
-        _sounds.update { list -> list.map { if (it.name == sound.name) sound else it } }
+        val playingSound = sound.copy(isPlaying = true)
+        _playingSound.value = playingSound
+        _sounds.update { list -> list.map { if (it.name == sound.name) playingSound else it } }
     }
 
     override fun onPlayerStop(sound: Sound) {
-        sound.isPlaying = false
+        val stoppedSound = sound.copy(isPlaying = false)
         _playingSound.value = null
-        _sounds.update { list -> list.map { if (it.name == sound.name) sound else it } }
+        _sounds.update { list -> list.map { if (it.name == sound.name) stoppedSound else it } }
     }
 
     companion object {

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
@@ -75,8 +75,9 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
 
         viewModel.onPlayerStart(sound)
 
-        assertThat(viewModel.playingSound.value).isEqualTo(sound)
-        assertThat(sound.isPlaying).isTrue()
+        assertThat(viewModel.playingSound.value?.name).isEqualTo(sound.name)
+        assertThat(viewModel.playingSound.value?.isPlaying).isTrue()
+        assertThat(sound.isPlaying).isFalse()
     }
 
     @Test
@@ -89,6 +90,38 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
 
         assertThat(viewModel.playingSound.value).isNull()
         assertThat(sound.isPlaying).isFalse()
+    }
+
+    @Test
+    fun `onPlayerStart updates sounds list with isPlaying true without mutating original sound`() {
+        val viewModel = givenAViewModel()
+        val sound = Sound("test", rawRes = 1)
+        viewModel.injectSounds(listOf(sound))
+
+        viewModel.onPlayerStart(sound)
+
+        assertThat(
+            viewModel.sounds.value
+                .single { it.name == "test" }
+                .isPlaying,
+        ).isTrue()
+        assertThat(sound.isPlaying).isFalse()
+    }
+
+    @Test
+    fun `onPlayerStop updates sounds list with isPlaying false without mutating original sound`() {
+        val viewModel = givenAViewModel()
+        val sound = Sound("test", null, 1, isPlaying = true)
+        viewModel.injectSounds(listOf(sound))
+
+        viewModel.onPlayerStop(sound)
+
+        assertThat(
+            viewModel.sounds.value
+                .single { it.name == "test" }
+                .isPlaying,
+        ).isFalse()
+        assertThat(sound.isPlaying).isTrue()
     }
 
     @Test

--- a/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/Sound.kt
+++ b/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/Sound.kt
@@ -9,7 +9,7 @@ data class Sound(
     val name: String,
     val file: String?,
     @RawRes val rawRes: Int,
-    var isPlaying: Boolean,
+    val isPlaying: Boolean,
 ) {
     constructor(name: String, file: String?) : this(name, file, 0, false)
     constructor(


### PR DESCRIPTION
### Summary

- The play/pause icon failed to update immediately when tapping play — it only flipped after scrolling the list
- Root cause: `onPlayerStart`/`onPlayerStop` mutated `sound.isPlaying` in-place before calling `_sounds.update`. Because the same object reference was already in the list, `StateFlow` saw old list == new list (structurally equal) and skipped the emission — Compose never recomposed
- Fixed by switching to `sound.copy(isPlaying = …)` so each state transition produces a new `Sound` instance with a different value, forcing a real `StateFlow` emission
- Made `Sound.isPlaying` a `val` to enforce the immutable-update pattern at compile time

### Code review tips

- `SoundsViewModel.onPlayerStart`/`onPlayerStop`: the key change is `copy()` instead of direct field assignment — the rest of the logic is unchanged
- `Sound.isPlaying: var → val`: any future in-place mutation will now be a compile error, preventing this class of bug from recurring
- Two new tests in `SoundsViewModelTest` assert that after `onPlayerStart`/`onPlayerStop` the original `Sound` object is not mutated — this is the TDD guard that would have caught the bug

### Test plan

- [x] `./gradlew test` — all tests pass including two new regression tests
- [x] `./gradlew check -x test` — ktlint, detekt, Android lint all pass

### Closes