### PR TITLE
feat: add Favorites tab and push-me:// deeplinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 ## \[unreleased]
 ### Added
+- Favorites: users can mark/unmark any custom button as favorite; a dedicated Favorites tab lists only marked buttons
+- Deeplinks: the app responds to `push-me://open/home`, `push-me://open/favorites`, and `push-me://open/explore` to navigate directly to a tab
+- Back navigation now follows the actual tab history instead of always returning to Explore
 - Jetpack Compose UI replacing all Fragments, RecyclerViews and XML layouts.
 - `SoundsViewModel` with `StateFlow` for reactive UI state management.
 - Back press navigates from Home/Favorites to Explore instead of exiting the app.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,16 @@ Dependency direction: `app` → `model`, `commons_android`, `commons_file`; `fea
 - `feature.share` — Sharing non-packaged audios to other apps
 - `feature.base` — Base classes, runtime permission handling
 
+## Bug fixes — TDD workflow
+
+When the user reports a bug or says we are going to fix a bug, always follow Test-Driven Development:
+
+1. **Write a failing test first** that reproduces the bug. Run it to confirm it fails for the right reason.
+2. **Fix the production code** with the minimum change needed to make the test pass.
+3. **Run the full test suite** (`./gradlew test`) to verify nothing regressed.
+
+Skip TDD only when the bug lives exclusively in UI rendering or platform wiring that cannot be exercised by unit or Robolectric tests (e.g. a pure layout glitch). In that case, note why TDD was skipped.
+
 ## Activity smoke tests
 
 Every `Activity` in the `app` module must have a corresponding smoke test that verifies it reaches `Lifecycle.State.RESUMED` without crashing. Place it alongside the Activity in `app/src/test/`, extend `AbstractRobolectricTest`, and use:

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,13 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="push-me" android:host="open" />
+            </intent-filter>
+
         </activity>
 
     </application>

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivity.kt
@@ -1,5 +1,6 @@
 package com.github.barriosnahuel.vossosunboton.ui.home
 
+import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -22,5 +23,22 @@ class LandingActivity : ComponentActivity() {
                 LandingScreen(viewModel = viewModel)
             }
         }
+        handleDeeplink(intent)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        handleDeeplink(intent)
+    }
+
+    private fun handleDeeplink(intent: Intent) {
+        val uri = intent.data ?: return
+        val tab =
+            when (uri.path) {
+                "/home" -> AppTab.HOME
+                "/favorites" -> AppTab.FAVORITES
+                else -> AppTab.EXPLORE
+            }
+        viewModel.selectTab(tab)
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
@@ -55,9 +56,10 @@ fun LandingScreen(viewModel: SoundsViewModel) {
     val context = LocalContext.current
     val buttonDeletedMessage = stringResource(R.string.app_feedback_button_deleted)
     val undoLabel = stringResource(R.string.app_undo)
+    val tabBackStack = remember { mutableStateListOf<AppTab>() }
 
-    BackHandler(enabled = selectedTab != AppTab.EXPLORE) {
-        viewModel.selectTab(AppTab.EXPLORE)
+    BackHandler(enabled = tabBackStack.isNotEmpty()) {
+        viewModel.selectTab(tabBackStack.removeAt(tabBackStack.lastIndex))
     }
 
     LaunchedEffect(deletedEvent) {
@@ -83,6 +85,7 @@ fun LandingScreen(viewModel: SoundsViewModel) {
                     if (tab == selectedTab) {
                         coroutineScope.launch { listState.animateScrollToItem(0) }
                     } else {
+                        tabBackStack.add(selectedTab)
                         viewModel.selectTab(tab)
                     }
                 },
@@ -97,6 +100,7 @@ fun LandingScreen(viewModel: SoundsViewModel) {
             onPlayClick = { sound -> viewModel.playOrStop(sound) },
             onShareClick = { sound -> ShareFeature.instance.share(context, sound) },
             onDelete = { sound -> viewModel.deleteSound(sound) },
+            onFavoriteClick = { sound -> viewModel.toggleFavorite(sound) },
         )
     }
 }
@@ -164,6 +168,7 @@ private fun SoundsList(
     onPlayClick: (Sound) -> Unit,
     onShareClick: (Sound) -> Unit,
     onDelete: (Sound) -> Unit,
+    onFavoriteClick: (Sound) -> Unit,
 ) {
     Box(modifier = modifier.fillMaxSize()) {
         LazyColumn(
@@ -176,6 +181,7 @@ private fun SoundsList(
                     onPlayClick = { onPlayClick(sound) },
                     onShareClick = { onShareClick(sound) },
                     onDelete = { onDelete(sound) },
+                    onFavoriteClick = { onFavoriteClick(sound) },
                 )
             }
         }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Share
@@ -38,9 +40,10 @@ fun SoundItem(
     onPlayClick: () -> Unit,
     onShareClick: () -> Unit,
     onDelete: () -> Unit,
+    onFavoriteClick: () -> Unit,
 ) {
     if (sound.isBundled()) {
-        SoundCard(sound = sound, onPlayClick = onPlayClick, onShareClick = onShareClick)
+        SoundCard(sound = sound, onPlayClick = onPlayClick, onShareClick = onShareClick, onFavoriteClick = onFavoriteClick)
         return
     }
     val dismissState = rememberSwipeToDismissBoxState()
@@ -53,7 +56,7 @@ fun SoundItem(
         state = dismissState,
         backgroundContent = { SwipeDeleteBackground(dismissState) },
     ) {
-        SoundCard(sound = sound, onPlayClick = onPlayClick, onShareClick = onShareClick)
+        SoundCard(sound = sound, onPlayClick = onPlayClick, onShareClick = onShareClick, onFavoriteClick = onFavoriteClick)
     }
 }
 
@@ -90,6 +93,7 @@ private fun SoundCard(
     sound: Sound,
     onPlayClick: () -> Unit,
     onShareClick: () -> Unit,
+    onFavoriteClick: () -> Unit,
 ) {
     Card(
         modifier =
@@ -121,6 +125,16 @@ private fun SoundCard(
                 )
             }
             if (!sound.isBundled()) {
+                IconButton(onClick = onFavoriteClick) {
+                    Icon(
+                        imageVector = if (sound.isFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                        contentDescription =
+                            stringResource(
+                                if (sound.isFavorite) R.string.app_remove_from_favorites else R.string.app_add_to_favorites,
+                            ),
+                        tint = if (sound.isFavorite) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                }
                 IconButton(onClick = onShareClick) {
                     Icon(
                         imageVector = Icons.Default.Share,

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -53,6 +53,14 @@ class SoundsViewModel(
         viewModelScope.launch(ioDispatcher) { loadSounds() }
     }
 
+    fun toggleFavorite(sound: Sound) {
+        val updated = sound.copy(isFavorite = !sound.isFavorite)
+        _sounds.update { list -> list.map { if (it.name == sound.name) updated else it } }
+        viewModelScope.launch(ioDispatcher) {
+            SoundDao().saveFavorite(getApplication(), sound.name, updated.isFavorite)
+        }
+    }
+
     fun playOrStop(sound: Sound) {
         if (sound.isPlaying) {
             PlayerControllerFactory.instance.stopPlayingSound()
@@ -102,7 +110,7 @@ class SoundsViewModel(
         _sounds.update {
             when (_selectedTab.value) {
                 AppTab.HOME -> allSounds.filter { !it.isBundled() }
-                AppTab.FAVORITES -> allSounds.filter { !it.isBundled() }
+                AppTab.FAVORITES -> allSounds.filter { it.isFavorite }
                 AppTab.EXPLORE -> allSounds.filter { it.isBundled() }
             }
         }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -8,4 +8,6 @@
     <string name="app_navigation_menu_item_home">Inicio</string>
     <string name="app_navigation_menu_item_search">Buscar</string>
     <string name="app_navigation_menu_item_favourites">Favoritos</string>
+    <string name="app_add_to_favorites">Agregar a favoritos</string>
+    <string name="app_remove_from_favorites">Quitar de favoritos</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,6 @@
     <string name="app_navigation_menu_item_home">Home</string>
     <string name="app_navigation_menu_item_search">Search</string>
     <string name="app_navigation_menu_item_favourites">Favorites</string>
+    <string name="app_add_to_favorites">Add to favorites</string>
+    <string name="app_remove_from_favorites">Remove from favorites</string>
 </resources>

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
@@ -160,6 +160,36 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
     }
 
     @Test
+    fun `toggleFavorite marks a sound as favorite`() {
+        val viewModel = givenAViewModel()
+        val sound = Sound("test", file = "test.mp3")
+        viewModel.injectSounds(listOf(sound))
+
+        viewModel.toggleFavorite(sound)
+
+        assertThat(
+            viewModel.sounds.value
+                .single { it.name == "test" }
+                .isFavorite,
+        ).isTrue()
+    }
+
+    @Test
+    fun `toggleFavorite on a favorite sound removes it from favorites`() {
+        val viewModel = givenAViewModel()
+        val sound = Sound("test", "test.mp3", 0, false, isFavorite = true)
+        viewModel.injectSounds(listOf(sound))
+
+        viewModel.toggleFavorite(sound)
+
+        assertThat(
+            viewModel.sounds.value
+                .single { it.name == "test" }
+                .isFavorite,
+        ).isFalse()
+    }
+
+    @Test
     fun `sounds are sorted alphabetically`() {
         val viewModel = givenAViewModel()
         val sounds = viewModel.sounds.value

--- a/config/detekt/detekt-config.yml
+++ b/config/detekt/detekt-config.yml
@@ -1,6 +1,7 @@
 complexity:
   LongParameterList:
-    threshold: 7
+    functionThreshold: 7
+    constructorThreshold: 7
     ignoreDefaultParameters: true
 
 style:

--- a/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/Sound.kt
+++ b/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/Sound.kt
@@ -10,12 +10,13 @@ data class Sound(
     val file: String?,
     @field:RawRes @param:RawRes val rawRes: Int,
     val isPlaying: Boolean,
+    val isFavorite: Boolean = false,
 ) {
-    constructor(name: String, file: String?) : this(name, file, 0, false)
+    constructor(name: String, file: String?) : this(name, file, 0, false, false)
     constructor(
         name: String,
         @RawRes rawRes: Int = 0,
-    ) : this(name, null, rawRes, false)
+    ) : this(name, null, rawRes, false, false)
 
     /**
      * Indicates whether or not this sound is bundled in the app or is a user's custom sound.

--- a/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundDao.java
+++ b/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundDao.java
@@ -24,6 +24,7 @@ public class SoundDao {
 
     private static final String SOUNDS_NAME = "sounds.name";
     private static final String SOUNDS_FILE_NAME_PREFFIX = "sounds.file.";
+    private static final String SOUNDS_FAVORITE_PREFFIX = "sounds.favorite.";
     private final Storage storage;
 
     /**
@@ -55,12 +56,22 @@ public class SoundDao {
 
         for (final String eachSoundName : names) {
             final String fileName = storage.get(context, SOUNDS_FILE_NAME_PREFFIX + eachSoundName);
-            sounds.add(new Sound(eachSoundName, fileName));
+            final boolean isFavorite = "true".equals(storage.get(context, SOUNDS_FAVORITE_PREFFIX + eachSoundName));
+            sounds.add(new Sound(eachSoundName, fileName, 0, false, isFavorite));
         }
 
         sounds.addAll(PackagedAudios.get(context));
 
         return sounds;
+    }
+
+    /**
+     * @param context    The execution context.
+     * @param soundName  Name of the sound to update.
+     * @param isFavorite Whether the sound is a favorite.
+     */
+    public void saveFavorite(final Context context, final String soundName, final boolean isFavorite) {
+        storage.save(context, SOUNDS_FAVORITE_PREFFIX + soundName, String.valueOf(isFavorite));
     }
 
     /**
@@ -82,6 +93,7 @@ public class SoundDao {
             Timber.i("Button file successfully deleted. Button: %s", sound.getName());
             deleteButtonKey(context, sound.getName());
             deleteButtonKeyFileMapping(context, sound.getName());
+            storage.remove(context, SOUNDS_FAVORITE_PREFFIX + sound.getName());
         } else {
             Timber.e("Button could NOT be deleted. Button: %s", sound.getName());
         }


### PR DESCRIPTION
## Summary

- **Favorites tab fixed**: the FAVORITES tab was showing the same content as HOME (identical filter bug). Added `isFavorite: Boolean` to the `Sound` model, persisted per-sound in SharedPreferences (`sounds.favorite.{name}`), and wired a heart toggle button on user-added sound items
- **Deeplinks**: the app now handles `push-me://open/{home,favorites,explore}` via a new `<intent-filter>` in the manifest and `handleDeeplink()` routing in `LandingActivity`
- **Back navigation**: replaced the hardcoded "always go back to Explore" behavior with a proper tab history stack maintained in `LandingScreen`
- **Detekt config cleanup**: migrated deprecated `LongParameterList.threshold` to `functionThreshold`/`constructorThreshold`

## Code review tips

- `SoundDao.java` now reads/writes a `sounds.favorite.{name}` key per sound. Old installs have no such key → `"true".equals(null)` → `false`, so migration is backwards-compatible with no data loss
- The tab back stack (`tabBackStack`) lives in `LandingScreen` composition, not in the ViewModel — intentional, since tab history is a UI-layer concern and doesn't survive process death (same as before)
- `toggleFavorite` in `SoundsViewModel` updates the in-memory list optimistically and persists on `IO` dispatcher; no rollback on failure (same pattern as existing delete)
- Deeplink routing uses `push-me` as scheme (matches repo name); `else -> AppTab.EXPLORE` handles any unknown path gracefully

## Test plan

- [x] `./gradlew test` — all unit tests pass
- [x] `./gradlew check -x test` — ktlint, detekt, and Android Lint clean
- Manual: mark a sound as favorite → switch to Favorites tab → sound appears; unmark → disappears
- Manual: kill app, run `adb shell am start -a android.intent.action.VIEW -d "push-me://open/favorites"` → app opens on Favorites tab
- Manual: navigate HOME → FAVORITES → press back → lands on HOME; press back again → lands on EXPLORE