### PR TITLE
chore: refactor CI pipeline — compile once, parallel linters, quality gates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,11 @@ jobs:
       resource_class: medium+
     steps:
       - checkout
-      - android/restore-gradle-cache
+      - android/restore_gradle_cache
       - run:
           name: "Compile Debug and Release Sources"
           command: ./gradlew compileDebugSources compileReleaseSources
-      - android/save-gradle-cache
+      - android/save_gradle_cache
       - persist_to_workspace:
           root: .
           paths:
@@ -28,7 +28,7 @@ jobs:
       tag: "2026.03"
     steps:
       - checkout
-      - android/restore-gradle-cache
+      - android/restore_gradle_cache
       - attach_workspace:
           at: .
       - run:
@@ -43,7 +43,7 @@ jobs:
       tag: "2026.03"
     steps:
       - checkout
-      - android/restore-gradle-cache
+      - android/restore_gradle_cache
       - attach_workspace:
           at: .
       - run:
@@ -56,7 +56,7 @@ jobs:
       tag: "2026.03"
     steps:
       - checkout
-      - android/restore-gradle-cache
+      - android/restore_gradle_cache
       - attach_workspace:
           at: .
       - run:
@@ -73,7 +73,7 @@ jobs:
       tag: "2026.03"
     steps:
       - checkout
-      - android/restore-gradle-cache
+      - android/restore_gradle_cache
       - attach_workspace:
           at: .
       - run:
@@ -89,7 +89,7 @@ jobs:
       resource_class: medium+
     steps:
       - checkout
-      - android/restore-gradle-cache
+      - android/restore_gradle_cache
       - attach_workspace:
           at: .
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,60 +4,117 @@ orbs:
   android: circleci/android@3.2.0
   # https://circleci.com/developer/orbs/orb/circleci/android for latest version
 jobs:
+  "compile":
+    executor:
+      name: android/android_docker
+      tag: "2026.03"
+      resource_class: medium+
+    steps:
+      - checkout
+      - android/restore-gradle-cache
+      - run:
+          name: "Compile Debug and Release Sources"
+          command: ./gradlew compileDebugSources compileReleaseSources
+      - android/save-gradle-cache
+      - persist_to_workspace:
+          root: .
+          paths:
+            - "*/build"
+            - ".gradle"
+
+  "detekt":
+    executor:
+      name: android/android_docker
+      tag: "2026.03"
+    steps:
+      - checkout
+      - android/restore-gradle-cache
+      - attach_workspace:
+          at: .
+      - run:
+          name: "Run Detekt"
+          command: ./gradlew detekt
+      - store_artifacts:
+          path: "app/build/reports/detekt/detekt.html"
+
+  "ktlint":
+    executor:
+      name: android/android_docker
+      tag: "2026.03"
+    steps:
+      - checkout
+      - android/restore-gradle-cache
+      - attach_workspace:
+          at: .
+      - run:
+          name: "Run ktlint"
+          command: ./gradlew ktlintCheck
+
+  "lint":
+    executor:
+      name: android/android_docker
+      tag: "2026.03"
+    steps:
+      - checkout
+      - android/restore-gradle-cache
+      - attach_workspace:
+          at: .
+      - run:
+          name: "Run Android Lint"
+          command: ./gradlew lint app:lintRelease app:lintVitalRelease
+      - store_artifacts:
+          path: "app/build/reports/lint-results-debug.html"
+      - store_artifacts:
+          path: "app/build/reports/lint-results-release.html"
+
   "test":
     executor:
       name: android/android_docker
       tag: "2026.03"
     steps:
       - checkout
+      - android/restore-gradle-cache
+      - attach_workspace:
+          at: .
       - run:
           name: "Run Tests"
           command: ./gradlew test
       - store_artifacts:
           path: "app/build/reports/tests/"
-  "code-analysis":
-    executor:
-      name: android/android_docker
-      tag: "2026.03"
-    steps:
-      - checkout
-      - run:
-          name: "Run Code Analyzers"
-          command: ./gradlew check -x test
-      - run:
-          name: "Run Release Lint"
-          command: ./gradlew app:lintRelease
-      - store_artifacts:
-          path: "app/build/reports/lint-results-debug.html"
-      - store_artifacts:
-          path: "app/build/reports/lint-results-release.html"
-      - store_artifacts:
-          path: "app/build/reports/detekt/detekt.html"
-  "bundle-debug":
+
+  "bundle":
     executor:
       name: android/android_docker
       tag: "2026.03"
       resource_class: medium+
     steps:
       - checkout
+      - android/restore-gradle-cache
+      - attach_workspace:
+          at: .
       - run:
-          name: "Bundle Debug"
-          command: ./gradlew app:bundleDebug
-  "bundle-release":
-    executor:
-      name: android/android_docker
-      tag: "2026.03"
-      resource_class: medium+
-    steps:
-      - checkout
-      - run:
-          name: "Bundle Release"
-          command: ./gradlew app:bundleRelease -x lintVitalRelease -x uploadCrashlyticsMappingFileRelease
+          name: "Bundle Debug and Release"
+          command: ./gradlew app:bundleDebug app:bundleRelease -x lintVitalRelease -x uploadCrashlyticsMappingFileRelease
+
 workflows:
   version: 2.1
   "Pull Requests Workflow":
     jobs:
-      - test
-      - code-analysis
-      - bundle-debug
-      - bundle-release
+      - compile
+      - detekt:
+          requires:
+            - compile
+      - ktlint:
+          requires:
+            - compile
+      - lint:
+          requires:
+            - compile
+      - test:
+          requires:
+            - detekt
+            - ktlint
+            - lint
+      - bundle:
+          requires:
+            - test


### PR DESCRIPTION
### Summary
- Replaces 4 independent parallel jobs (each recompiling from scratch) with a structured pipeline: `compile → [detekt, ktlint, lint] → test → bundle`
- Compiled artifacts are persisted via CircleCI workspace and reused by downstream jobs, eliminating redundant full recompilation in every step
- Each linter now runs in its own job so failure logs are focused on one tool only
- Quality gates enforced: linters must pass before tests run; tests must pass before bundle is produced

### Code review tips
- The `persist_to_workspace` paths (`*/build`, `.gradle`) must cover all 5 module build dirs — pattern is one level deep and matches `app/build`, `model/build`, etc.
- `android/restore-gradle-cache` is called in every job; `android/save-gradle-cache` only in `compile` — this avoids cache thrashing while still letting all jobs benefit from cached dependencies
- `lint` job runs `lint app:lintRelease app:lintVitalRelease` in one invocation — `lintVitalRelease` was previously excluded from `bundle` but only needs compiled sources (verified via `--dry-run`), so it belongs here
- `bundle` keeps `-x lintVitalRelease` as a safety guard; Gradle will treat it as UP-TO-DATE anyway since the lint job already ran it with the same workspace

### Test plan
- [ ] CI pipeline runs on this PR and shows 6 distinct jobs in the expected dependency order
- [ ] Verify `detekt`, `ktlint`, `lint` run in parallel after `compile` completes
- [ ] Verify `test` only starts after all three linters are green
- [ ] Verify `bundle` only starts after `test` is green
- [ ] Check that Gradle logs in linter/test/bundle jobs show compilation tasks as `UP-TO-DATE` (workspace reuse working)
- [ ] Artifacts present: test reports, lint HTMLs, detekt HTML

### Closes