### PR TITLE
fix: restore play state after tab switch and fix delete lifecycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,13 +76,6 @@ Mock any singleton factories (e.g. `PlayerControllerFactory`) that would crash u
 
 **Dynamic feature modules** (e.g. `feature_addbutton`) cannot use Robolectric — Robolectric's `ShadowPackageParser` rejects split APKs (`Expected base APK, but found split`). Activities in those modules require instrumented tests if smoke coverage is needed.
 
-## Code Quality
-
-All three linters run on CI and must pass:
-- **KtLint** — style (runs as part of `check`; auto-fix with `ktlintFormat`)
-- **Detekt** — static analysis (config: `config/detekt/detekt-config.yml`; max line length 150)
-- **Android Lint** — lint rules in `config/android/android-lint.xml`
-
 ## Setup Notes
 
 - Replace `app/google-services.json` with a real Firebase config. The included file is a placeholder, excluded from tracking via `git update-index --skip-worktree app/google-services.json`.
@@ -100,20 +93,18 @@ git update-index --skip-worktree app/google-services.json
 
 ## Pre-push checklist
 
+All three linters run on CI and must pass:
+- **KtLint** — style (runs as part of `check`; auto-fix with `ktlintFormat`)
+- **Detekt** — static analysis (config: `config/detekt/detekt-config.yml`; max line length 150)
+- **Android Lint** — lint rules in `config/android/android-lint.xml`
+
 Before pushing any branch, always run:
 
 ```bash
-./gradlew test && ./gradlew check -x test
+./gradlew check -x test && ./gradlew test
 ```
 
-This catches the same failures CI will report (unit tests, ktlint, detekt, checkstyle, Android lint) without waiting for a full CI run.
-
-## CI
-
-CircleCI runs three parallel jobs on PRs:
-1. **test** — `./gradlew test`
-2. **code-analysis** — `./gradlew check -x test` + `app:lintVitalRelease`
-3. **build** — assembles app and bundle (skips checks)
+This catches the same failures CI will report (ktlint, detekt, Android lint, unit tests) without waiting for a full CI run.
 
 ## Handoff notes
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -77,16 +77,16 @@ class SoundsViewModel(
 
     fun deleteSound(sound: Sound) {
         val currentSounds = _sounds.value.toMutableList()
-        val position = currentSounds.indexOf(sound)
-        if (position == -1) return
+        val currentSound = currentSounds.find { it.name == sound.name } ?: return
+        val position = currentSounds.indexOf(currentSound)
 
-        if (sound.isPlaying) {
+        if (_playingSound.value?.name == sound.name) {
             PlayerControllerFactory.instance.stopPlayingSound()
         }
 
         currentSounds.removeAt(position)
         _sounds.value = currentSounds
-        _deletedSoundEvent.value = DeletedSoundEvent(sound.copy(isPlaying = false), position)
+        _deletedSoundEvent.value = DeletedSoundEvent(currentSound.copy(isPlaying = false), position)
     }
 
     fun restoreSound() {
@@ -122,11 +122,19 @@ class SoundsViewModel(
 
     private suspend fun loadSounds() {
         val allSounds = SoundDao().find(getApplication<Application>()).sortedBy { it.name.lowercase() }
+        val playingName = _playingSound.value?.name
+        val deletedName = _deletedSoundEvent.value?.sound?.name
         _sounds.update {
-            when (_selectedTab.value) {
-                AppTab.HOME -> allSounds.filter { !it.isBundled() }
-                AppTab.FAVORITES -> allSounds.filter { it.isFavorite }
-                AppTab.EXPLORE -> allSounds.filter { it.isBundled() }
+            val filtered =
+                when (_selectedTab.value) {
+                    AppTab.HOME -> allSounds.filter { !it.isBundled() }
+                    AppTab.FAVORITES -> allSounds.filter { it.isFavorite }
+                    AppTab.EXPLORE -> allSounds.filter { it.isBundled() }
+                }.filter { it.name != deletedName }
+            if (playingName == null) {
+                filtered
+            } else {
+                filtered.map { if (it.name == playingName) it.copy(isPlaying = true) else it }
             }
         }
     }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
@@ -153,8 +153,9 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
     fun `deleteSound when sound is playing stops playback`() {
         every { PlayerControllerFactory.instance.stopPlayingSound() } answers { nothing }
         val viewModel = givenAViewModel()
-        val sound = Sound("custom", "custom.mp3", 0, isPlaying = true)
+        val sound = Sound("custom", "custom.mp3", 0, isPlaying = false)
         viewModel.injectSounds(listOf(sound))
+        viewModel.onPlayerStart(sound) // establece _playingSound como fuente autoritativa
 
         viewModel.deleteSound(sound)
 
@@ -165,8 +166,9 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
     fun `restoreSound when deleted sound was playing restores it as not playing`() {
         every { PlayerControllerFactory.instance.stopPlayingSound() } answers { nothing }
         val viewModel = givenAViewModel()
-        val sound = Sound("custom", "custom.mp3", 0, isPlaying = true)
+        val sound = Sound("custom", "custom.mp3", 0, isPlaying = false)
         viewModel.injectSounds(listOf(sound))
+        viewModel.onPlayerStart(sound) // establece _playingSound como fuente autoritativa
 
         viewModel.deleteSound(sound)
         viewModel.restoreSound()
@@ -249,6 +251,51 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
             viewModel.onButtonSaved()
 
             viewModel.buttonSavedEvent.first()
+        }
+
+    @Test
+    fun `deleteSound stops playback and removes sound even when passed a stale copy with isPlaying false`() {
+        every { PlayerControllerFactory.instance.stopPlayingSound() } answers { nothing }
+        val viewModel = givenAViewModel()
+        val sound = Sound("custom", "custom.mp3", 0, isPlaying = false)
+        viewModel.injectSounds(listOf(sound.copy(isPlaying = true)))
+        viewModel.onPlayerStart(sound)
+
+        viewModel.deleteSound(sound)
+
+        verify { PlayerControllerFactory.instance.stopPlayingSound() }
+        assertThat(viewModel.sounds.value.none { it.name == sound.name }).isTrue()
+    }
+
+    @Test
+    fun `loadSounds does not restore a soft-deleted sound while its delete is pending`() {
+        val viewModel = givenAViewModel()
+        viewModel.selectTab(AppTab.EXPLORE)
+        val sound = viewModel.sounds.value.first()
+
+        viewModel.deleteSound(sound)
+        viewModel.selectTab(AppTab.FAVORITES)
+        viewModel.selectTab(AppTab.EXPLORE)
+
+        assertThat(viewModel.sounds.value.none { it.name == sound.name }).isTrue()
+    }
+
+    @Test
+    fun `sounds list preserves isPlaying state after switching tabs and returning`() =
+        runTest {
+            val viewModel = givenAViewModel()
+            viewModel.selectTab(AppTab.EXPLORE)
+            val playingSound = viewModel.sounds.value.first()
+
+            viewModel.onPlayerStart(playingSound)
+            viewModel.selectTab(AppTab.FAVORITES)
+            viewModel.selectTab(AppTab.EXPLORE)
+
+            assertThat(
+                viewModel.sounds.value
+                    .single { it.name == playingSound.name }
+                    .isPlaying,
+            ).isTrue()
         }
 
     @Test


### PR DESCRIPTION
## Summary

- **Tab-switch icon state:** `loadSounds()` replaced `_sounds` with fresh DB objects (`isPlaying = false`) on every `selectTab()`, losing the active playback state. Now restores `isPlaying = true` for `_playingSound` after each reload.
- **Delete while playing:** `deleteSound()` used `sound.isPlaying` from the Compose-captured parameter (stale closure) and `indexOf()` with data-class equality (fails when `isPlaying` differs). Now finds the sound by name and checks `_playingSound` — the authoritative source — for the stop decision.
- **Soft-deleted sound reappearance:** switching tabs while the undo snackbar was visible re-fetched the deleted sound from the DB (before `confirmDelete()` wrote the deletion). `loadSounds()` now excludes `_deletedSoundEvent.sound` from every result.

## Code review tips

- `deleteSound()`: the key change is `find { it.name == sound.name }` replacing `indexOf(sound)`, and `_playingSound.value?.name == sound.name` replacing `sound.isPlaying`. Both use the ViewModel's authoritative state instead of a potentially-stale parameter.
- `loadSounds()`: two new read-before-update captures — `playingName` and `deletedName` — applied before `_sounds.update {}`. Order matters: `deletedName` filter runs first, then `playingName` restore.
- Updated existing tests `deleteSound when sound is playing stops playback` and `restoreSound when deleted sound was playing restores it as not playing` to call `onPlayerStart()` before `deleteSound()`, which is now required to set `_playingSound`.

## Already tested

- [ ] All 93 unit tests passing across SDK 23, 33, and latest
- [ ] KtLint, Detekt, and Android Lint all green