### PR TITLE
fix: include SharedPreferences in Auto Backup so custom sounds survive restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - `SoundsViewModel` with `StateFlow` for reactive UI state management.
 - Back press navigates from Home/Favorites to Explore instead of exiting the app.
 - Tapping the already-selected bottom tab scrolls the list back to the top.
-- Explicit backup rules for Android 12+: user audio files are now included in cloud backup and device transfer.
+- Custom audio files and their metadata are backed up and restored via Android Auto Backup (cloud backup and device transfer on all supported API levels)
 - Tests for `SoundsViewModel` covering playback state and delete/restore flows.
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ./gradlew :model:test --tests "com.github.barriosnahuel.vossosunboton.model.SomeTest"
 ```
 
+### Tooling & Environment
+- **Android CLI**: Available. You can use `adb` (Android Debug Bridge), `fastboot`, and `emulator` commands.
+- **Usage**: Use `adb` to manage connected devices, install APKs, and access shell commands.
+
 ## Module Architecture
 
 Push Me is an Android soundboard app with 5 Gradle modules:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ But, before going deeper I suggest you to take a look to the [opensource.guide](
 - [Continuous integration](#continuous-integration-)
 - [Gradle upgrade](#gradle-upgrade)
 - [Firebase config file](#firebase-config-file-)
+- [Backup & restore testing](#backup--restore-testing-)
 - [Logcat](#logcat-)
 - [Resources](#resources-)
 - [Signing](#signing-)
@@ -68,6 +69,24 @@ To prevent future modifications on `app/google-services.json` I run:
     To revert this just:
 
     > git update-index --no-skip-worktree app/google-services.json
+
+## Backup & restore testing 💾
+
+To manually verify Auto Backup saves and restores custom sound metadata, use `bmgr` via `adb`:
+
+1. **Trigger a backup:**
+
+       adb shell bmgr backupnow com.github.barriosnahuel.vossosunboton.debug
+
+2. **List available backup sets** (to find the restore token):
+
+       adb shell bmgr list sets
+
+3. **Restore from a backup set:**
+
+       adb shell bmgr restore <token> com.github.barriosnahuel.vossosunboton.debug
+
+> Requires a device or emulator with Google Mobile Services. Does not work on stock AOSP emulators.
 
 ## Logcat 😿
 

--- a/app/src/main/res/xml/app_backup_rules.xml
+++ b/app/src/main/res/xml/app_backup_rules.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
     <include domain="external" path="Music" />
+    <include domain="sharedpref" path="my-prefs" />
 </full-backup-content>

--- a/app/src/main/res/xml/app_data_extraction_rules.xml
+++ b/app/src/main/res/xml/app_data_extraction_rules.xml
@@ -2,8 +2,10 @@
 <data-extraction-rules>
     <cloud-backup>
         <include domain="external" path="Music" />
+        <include domain="sharedpref" path="my-prefs" />
     </cloud-backup>
     <device-transfer>
         <include domain="external" path="Music" />
+        <include domain="sharedpref" path="my-prefs" />
     </device-transfer>
 </data-extraction-rules>

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/backup/BackupRulesTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/backup/BackupRulesTest.kt
@@ -1,0 +1,83 @@
+package com.github.barriosnahuel.vossosunboton.backup
+
+import android.content.Context
+import android.content.res.XmlResourceParser
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.R
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.xmlpull.v1.XmlPullParser
+
+internal class BackupRulesTest : AbstractRobolectricTest() {
+    @Test
+    fun `app_backup_rules includes both audio files and metadata`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val includes = parseIncludes(context.resources.getXml(R.xml.app_backup_rules))
+
+        assertThat(includes).containsAtLeast("external" to "Music", "sharedpref" to "my-prefs")
+    }
+
+    @Test
+    fun `app_data_extraction_rules cloud-backup includes both audio files and metadata`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val includes =
+            parseIncludes(
+                context.resources.getXml(R.xml.app_data_extraction_rules),
+                parentTag = "cloud-backup",
+            )
+
+        assertThat(includes).containsAtLeast("external" to "Music", "sharedpref" to "my-prefs")
+    }
+
+    @Test
+    fun `app_data_extraction_rules device-transfer includes both audio files and metadata`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val includes =
+            parseIncludes(
+                context.resources.getXml(R.xml.app_data_extraction_rules),
+                parentTag = "device-transfer",
+            )
+
+        assertThat(includes).containsAtLeast("external" to "Music", "sharedpref" to "my-prefs")
+    }
+
+    private fun parseIncludes(
+        parser: XmlResourceParser,
+        parentTag: String? = null,
+    ): List<Pair<String, String>> {
+        val includes = mutableListOf<Pair<String, String>>()
+        var insideParent = parentTag == null
+
+        while (parser.next() != XmlPullParser.END_DOCUMENT) {
+            insideParent = updateParentScope(parser, parentTag, insideParent)
+            if (insideParent) collectInclude(parser, includes)
+        }
+
+        return includes
+    }
+
+    private fun updateParentScope(
+        parser: XmlResourceParser,
+        parentTag: String?,
+        current: Boolean,
+    ): Boolean {
+        if (parentTag == null) return true
+        return when {
+            parser.eventType == XmlPullParser.START_TAG && parser.name == parentTag -> true
+            parser.eventType == XmlPullParser.END_TAG && parser.name == parentTag -> false
+            else -> current
+        }
+    }
+
+    private fun collectInclude(
+        parser: XmlResourceParser,
+        into: MutableList<Pair<String, String>>,
+    ) {
+        if (parser.eventType == XmlPullParser.START_TAG && parser.name == "include") {
+            val domain = parser.getAttributeValue(null, "domain")
+            val path = parser.getAttributeValue(null, "path")
+            if (domain != null && path != null) into += domain to path
+        }
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundDaoTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundDaoTest.kt
@@ -1,0 +1,102 @@
+package com.github.barriosnahuel.vossosunboton.model.data.manager
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.github.barriosnahuel.vossosunboton.model.data.local.Storage
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+
+internal class SoundDaoTest : AbstractRobolectricTest() {
+    private lateinit var context: Context
+    private lateinit var dao: SoundDao
+    private lateinit var storage: Storage
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        context
+            .getSharedPreferences("my-prefs", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+        dao = SoundDao()
+        storage = Storage()
+    }
+
+    @Test
+    fun `save then find returns the saved custom sound`() {
+        dao.save(context, Sound("bell", "bell.mp3"))
+
+        val result = dao.find(context).filter { !it.isBundled() }
+
+        assertThat(result).hasSize(1)
+        assertThat(result.single().name).isEqualTo("bell")
+        assertThat(result.single().file).isEqualTo("bell.mp3")
+    }
+
+    @Test
+    fun `save then clear prefs then find returns no custom sounds`() {
+        dao.save(context, Sound("bell", "bell.mp3"))
+
+        context
+            .getSharedPreferences("my-prefs", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+
+        assertThat(dao.find(context).filter { !it.isBundled() }).isEmpty()
+    }
+
+    @Test
+    fun `after simulated restore find returns the originally saved sound`() {
+        dao.save(context, Sound("bell", "bell.mp3"))
+
+        // Capture what was persisted so we can re-inject it (simulating OS restore)
+        val names = storage.getAll(context, "sounds.name").toSet()
+        val file = storage.get(context, "sounds.file.bell")
+
+        // Simulate OS wiping the data dir before restore
+        context
+            .getSharedPreferences("my-prefs", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+
+        // Simulate OS writing the backed-up prefs back
+        storage.save(context, "sounds.name", names)
+        storage.save(context, "sounds.file.bell", file)
+
+        val result = dao.find(context).filter { !it.isBundled() }
+
+        assertThat(result).hasSize(1)
+        assertThat(result.single().name).isEqualTo("bell")
+        assertThat(result.single().file).isEqualTo("bell.mp3")
+    }
+
+    @Test
+    fun `saveFavorite is preserved across a simulated restore`() {
+        dao.save(context, Sound("bell", "bell.mp3"))
+        dao.saveFavorite(context, "bell", true)
+
+        val names = storage.getAll(context, "sounds.name").toSet()
+        val file = storage.get(context, "sounds.file.bell")
+        val favorite = storage.get(context, "sounds.favorite.bell")
+
+        context
+            .getSharedPreferences("my-prefs", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+
+        storage.save(context, "sounds.name", names)
+        storage.save(context, "sounds.file.bell", file)
+        storage.save(context, "sounds.favorite.bell", favorite)
+
+        val result = dao.find(context).filter { !it.isBundled() }
+
+        assertThat(result.single().isFavorite).isTrue()
+    }
+}


### PR DESCRIPTION
### Summary
- Android Auto Backup excludes everything not explicitly listed when any `<include>` is present; `my-prefs` (custom sound names, file mappings, favorites) was missing from both rule files, so metadata was never backed up
- On restore, audio files came back but the app found empty SharedPreferences and showed no custom sounds
- Added `<include domain="sharedpref" path="my-prefs" />` to `app_backup_rules.xml` (pre-12) and both sections of `app_data_extraction_rules.xml` (Android 12+)

### Code review tips
- `BackupRulesTest` parses the XML resources via Robolectric and asserts both `external/Music` and `sharedpref/my-prefs` are present — removing either include will break the test
- `SoundDaoTest` exercises the save → clear prefs → re-inject prefs → find round-trip, documenting that the data layer correctly reads back what the OS would restore

### Already tested
- [x] `BackupRulesTest` was RED before the XML fix, GREEN after (confirmed via `./gradlew :app:testDebugUnitTest`)
- [x] `SoundDaoTest` round-trip tests pass across all 3 SDK levels
- [x] `./gradlew check` and `./gradlew test` pass cleanly
- [x] Manual `bmgr backupnow` + `bmgr restore` on Pixel 8 — custom sounds reappear after restore