### PR TITLE
UX: name counter on save, personalized feedback, and animated unfavorite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,20 @@ git update-index --skip-worktree app/google-services.json
 - Release signing requires `nahuelbarrios.keystore-appbundle.pkcs12` and `secure.properties` (with `key.alias`, `key.password`, `store.password`) in the project root — not committed.
 - Debug builds use the included debug keystore and work without the above.
 
+## Android resources naming
+
+Every resource name must start with the `resourcePrefix` defined in the module's `build.gradle`:
+
+| Module | Prefix |
+|---|---|
+| `app` | `app_` |
+| `feature_addbutton` | `feature_addbutton_` |
+| `commons_android` | `commons_android_` |
+| `commons_file` | `commons_file_` |
+| `model` | `model_` |
+
+Android Lint enforces this rule (`ResourceName` check). Violating it causes a build failure.
+
 ## Pre-push checklist
 
 All three linters run on CI and must pass:

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivity.kt
@@ -34,7 +34,8 @@ class LandingActivity : ComponentActivity() {
     private fun handleIntent(intent: Intent) {
         handleDeeplink(intent)
         if (intent.getBooleanExtra(EXTRA_BUTTON_SAVED, false)) {
-            viewModel.onButtonSaved()
+            val name = intent.getStringExtra(EXTRA_BUTTON_NAME) ?: ""
+            viewModel.onButtonSaved(name)
         }
     }
 
@@ -51,5 +52,6 @@ class LandingActivity : ComponentActivity() {
 
     companion object {
         const val EXTRA_BUTTON_SAVED = "extra_button_saved"
+        const val EXTRA_BUTTON_NAME = "extra_button_name"
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -1,6 +1,11 @@
 package com.github.barriosnahuel.vossosunboton.ui.home
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -33,6 +38,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
@@ -42,6 +48,7 @@ import androidx.compose.ui.unit.dp
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.feature.share.ShareFeature
 import com.github.barriosnahuel.vossosunboton.model.Sound
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -81,6 +88,7 @@ fun LandingScreen(viewModel: SoundsViewModel) {
     ) { innerPadding ->
         SoundsList(
             sounds = sounds,
+            selectedTab = selectedTab,
             playbackProgress = playbackProgress,
             listState = listState,
             modifier = Modifier.padding(innerPadding),
@@ -102,8 +110,8 @@ private fun SnackbarEffects(
     val context = LocalContext.current
     val buttonDeletedMessage = stringResource(R.string.app_feedback_button_deleted)
     val undoLabel = stringResource(R.string.app_undo)
-    val buttonSavedMessage = stringResource(R.string.app_feedback_button_saved)
     val playbackErrorMessage = stringResource(R.string.app_error_playback_failed)
+    val buttonSavedTemplate = stringResource(R.string.app_feedback_button_saved)
 
     LaunchedEffect(Unit) {
         viewModel.playbackErrorEvent.collect {
@@ -115,9 +123,9 @@ private fun SnackbarEffects(
     }
 
     LaunchedEffect(Unit) {
-        viewModel.buttonSavedEvent.collect {
+        viewModel.buttonSavedEvent.collect { name ->
             snackbarHostState.showSnackbar(
-                message = buttonSavedMessage,
+                message = String.format(buttonSavedTemplate, name),
                 duration = SnackbarDuration.Short,
             )
         }
@@ -193,9 +201,12 @@ private fun AppBottomBar(
     }
 }
 
+private const val UNFAVORITE_ANIMATION_DURATION_MS = 300
+
 @Composable
 private fun SoundsList(
     sounds: List<Sound>,
+    selectedTab: AppTab,
     playbackProgress: PlaybackProgress?,
     listState: LazyListState,
     modifier: Modifier = Modifier,
@@ -205,21 +216,45 @@ private fun SoundsList(
     onDelete: (Sound) -> Unit,
     onFavoriteClick: (Sound) -> Unit,
 ) {
+    val dismissingFavorites = remember { mutableStateSetOf<String>() }
+    val coroutineScope = rememberCoroutineScope()
+
     Box(modifier = modifier.fillMaxSize()) {
         LazyColumn(
             state = listState,
             contentPadding = PaddingValues(vertical = 8.dp),
         ) {
             itemsIndexed(sounds, key = { _, sound -> sound.name }) { _, sound ->
-                SoundItem(
-                    sound = sound,
-                    playbackProgress = if (sound.isPlaying) playbackProgress else null,
-                    onPlayClick = { onPlayClick(sound) },
-                    onSeek = onSeek,
-                    onShareClick = { onShareClick(sound) },
-                    onDelete = { onDelete(sound) },
-                    onFavoriteClick = { onFavoriteClick(sound) },
-                )
+                AnimatedVisibility(
+                    visible = sound.name !in dismissingFavorites,
+                    enter = EnterTransition.None,
+                    exit =
+                        slideOutVertically(
+                            animationSpec = tween(durationMillis = UNFAVORITE_ANIMATION_DURATION_MS),
+                            targetOffsetY = { -it },
+                        ) + fadeOut(animationSpec = tween(durationMillis = UNFAVORITE_ANIMATION_DURATION_MS)),
+                ) {
+                    SoundItem(
+                        sound = sound,
+                        playbackProgress = if (sound.isPlaying) playbackProgress else null,
+                        onPlayClick = { onPlayClick(sound) },
+                        onSeek = onSeek,
+                        onShareClick = { onShareClick(sound) },
+                        onDelete = { onDelete(sound) },
+                        onFavoriteClick = {
+                            if (selectedTab == AppTab.FAVORITES && sound.isFavorite) {
+                                dismissingFavorites.add(sound.name)
+                                coroutineScope.launch {
+                                    delay(UNFAVORITE_ANIMATION_DURATION_MS.toLong())
+                                    onFavoriteClick(sound)
+                                    dismissingFavorites.remove(sound.name)
+                                }
+                            } else {
+                                onFavoriteClick(sound)
+                            }
+                        },
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.ViewComfyAlt
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -195,8 +195,8 @@ private fun AppBottomBar(
             colors = itemColors,
             selected = selectedTab == AppTab.EXPLORE,
             onClick = { onTabSelected(AppTab.EXPLORE) },
-            icon = { Icon(Icons.Default.Search, contentDescription = stringResource(R.string.app_navigation_menu_item_search)) },
-            label = { Text(stringResource(R.string.app_navigation_menu_item_search)) },
+            icon = { Icon(Icons.Default.ViewComfyAlt, contentDescription = stringResource(R.string.app_navigation_menu_item_explore)) },
+            label = { Text(stringResource(R.string.app_navigation_menu_item_explore)) },
         )
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -45,7 +46,6 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.TimeUnit
-import androidx.compose.ui.platform.LocalResources
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
@@ -36,7 +36,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -46,6 +45,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.TimeUnit
+import androidx.compose.ui.platform.LocalResources
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -257,11 +257,11 @@ private fun formatRelativeDate(epochMs: Long): String {
     val today = startOfDay(System.currentTimeMillis())
     val dateDay = startOfDay(epochMs)
     val diffDays = TimeUnit.MILLISECONDS.toDays(today - dateDay)
-    val resources = LocalContext.current.resources
+    val resources = LocalResources.current
     return when {
-        diffDays == 0L -> stringResource(R.string.date_today)
-        diffDays == 1L -> stringResource(R.string.date_yesterday)
-        diffDays < RELATIVE_DATE_MAX_DAYS -> resources.getQuantityString(R.plurals.date_days_ago, diffDays.toInt(), diffDays.toInt())
+        diffDays == 0L -> stringResource(R.string.app_date_today)
+        diffDays == 1L -> stringResource(R.string.app_date_yesterday)
+        diffDays < RELATIVE_DATE_MAX_DAYS -> resources.getQuantityString(R.plurals.app_date_days_ago, diffDays.toInt(), diffDays.toInt())
         else -> SimpleDateFormat("d MMM", Locale.getDefault()).format(Date(epochMs))
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -56,8 +56,8 @@ class SoundsViewModel(
     private val _deletedSoundEvent = MutableStateFlow<DeletedSoundEvent?>(null)
     val deletedSoundEvent: StateFlow<DeletedSoundEvent?> = _deletedSoundEvent.asStateFlow()
 
-    private val _buttonSavedEvent = Channel<Unit>(Channel.BUFFERED)
-    val buttonSavedEvent: Flow<Unit> = _buttonSavedEvent.receiveAsFlow()
+    private val _buttonSavedEvent = Channel<String>(Channel.BUFFERED)
+    val buttonSavedEvent: Flow<String> = _buttonSavedEvent.receiveAsFlow()
 
     private val _playbackErrorEvent = Channel<Unit>(Channel.BUFFERED)
     val playbackErrorEvent: Flow<Unit> = _playbackErrorEvent.receiveAsFlow()
@@ -73,10 +73,14 @@ class SoundsViewModel(
     }
 
     fun toggleFavorite(sound: Sound) {
-        val updated = sound.copy(isFavorite = !sound.isFavorite)
-        _sounds.update { list -> list.map { if (it.name == sound.name) updated else it } }
+        val nowFavorite = !sound.isFavorite
+        if (_selectedTab.value == AppTab.FAVORITES && !nowFavorite) {
+            _sounds.update { list -> list.filter { it.name != sound.name } }
+        } else {
+            _sounds.update { list -> list.map { if (it.name == sound.name) sound.copy(isFavorite = nowFavorite) else it } }
+        }
         viewModelScope.launch(ioDispatcher) {
-            SoundDao().saveFavorite(getApplication(), sound.name, updated.isFavorite)
+            SoundDao().saveFavorite(getApplication(), sound.name, nowFavorite)
         }
     }
 
@@ -133,9 +137,9 @@ class SoundsViewModel(
         _deletedSoundEvent.value = null
     }
 
-    fun onButtonSaved() {
+    fun onButtonSaved(name: String) {
         selectTab(AppTab.HOME)
-        _buttonSavedEvent.trySend(Unit)
+        _buttonSavedEvent.trySend(name)
     }
 
     private suspend fun loadSounds() {

--- a/app/src/main/res/values-es/plurals.xml
+++ b/app/src/main/res/values-es/plurals.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <plurals name="date_days_ago">
+    <plurals name="app_date_days_ago">
         <item quantity="one">Hace %d día</item>
         <item quantity="other">Hace %d días</item>
+        <item quantity="many">Hace %d días</item>
     </plurals>
 </resources>

--- a/app/src/main/res/values-es/strings-dynamic-features.xml
+++ b/app/src/main/res/values-es/strings-dynamic-features.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_feature_addbutton_activity_label_dynamic_feature">Crear nuevo botón</string>
+    <string name="app_feature_addbutton_activity_label_dynamic_feature">Guardar botón</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -7,13 +7,13 @@
     <string name="app_feedback_button_saved">¡%1$s es tuyo!</string>
     <string name="app_feedback_generic_error_contact_support">Uh! Por favor contactá con soporte</string>
     <string name="app_navigation_menu_item_home">Inicio</string>
-    <string name="app_navigation_menu_item_search">Buscar</string>
+    <string name="app_navigation_menu_item_explore">Explorar</string>
     <string name="app_navigation_menu_item_favourites">Favoritos</string>
     <string name="app_add_to_favorites">Agregar a favoritos</string>
     <string name="app_remove_from_favorites">Quitar de favoritos</string>
     <string name="app_play">Reproducir</string>
     <string name="app_pause">Pausar</string>
-    <string name="date_today">Hoy</string>
-    <string name="date_yesterday">Ayer</string>
+    <string name="app_date_today">Hoy</string>
+    <string name="app_date_yesterday">Ayer</string>
     <string name="app_error_playback_failed">No se pudo reproducir este audio</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_share_chooser_title">Compartir vía</string>
     <string name="app_undo">Deshacer!</string>
     <string name="app_feedback_button_deleted">Botón borrado</string>
-    <string name="app_feedback_button_saved">¡Guardado!</string>
+    <string name="app_feedback_button_saved">¡%1$s es tuyo!</string>
     <string name="app_feedback_generic_error_contact_support">Uh! Por favor contactá con soporte</string>
     <string name="app_navigation_menu_item_home">Inicio</string>
     <string name="app_navigation_menu_item_search">Buscar</string>

--- a/app/src/main/res/values/plurals.xml
+++ b/app/src/main/res/values/plurals.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <plurals name="date_days_ago">
+    <plurals name="app_date_days_ago">
         <item quantity="one">%d day ago</item>
         <item quantity="other">%d days ago</item>
     </plurals>

--- a/app/src/main/res/values/strings-dynamic-features.xml
+++ b/app/src/main/res/values/strings-dynamic-features.xml
@@ -1,4 +1,4 @@
 <resources>
     <string name="app_feature_addbutton_feature_name_dynamic_feature" translatable="false">Save as button</string>
-    <string name="app_feature_addbutton_activity_label_dynamic_feature">Save as button</string>
+    <string name="app_feature_addbutton_activity_label_dynamic_feature">Save button</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_share_chooser_title">Share vía</string>
     <string name="app_undo">Undo!</string>
     <string name="app_feedback_button_deleted">Button deleted</string>
-    <string name="app_feedback_button_saved">Saved!</string>
+    <string name="app_feedback_button_saved">%1$s is now yours!</string>
 <string name="app_feedback_generic_error_contact_support">Oops! I did it again, please contact support</string>
     <string name="app_navigation_menu_item_home">Home</string>
     <string name="app_navigation_menu_item_search">Search</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,13 +7,13 @@
     <string name="app_feedback_button_saved">%1$s is now yours!</string>
 <string name="app_feedback_generic_error_contact_support">Oops! I did it again, please contact support</string>
     <string name="app_navigation_menu_item_home">Home</string>
-    <string name="app_navigation_menu_item_search">Search</string>
+    <string name="app_navigation_menu_item_explore">Explore</string>
     <string name="app_navigation_menu_item_favourites">Favorites</string>
     <string name="app_add_to_favorites">Add to favorites</string>
     <string name="app_remove_from_favorites">Remove from favorites</string>
     <string name="app_play">Play</string>
     <string name="app_pause">Pause</string>
-    <string name="date_today">Today</string>
-    <string name="date_yesterday">Yesterday</string>
+    <string name="app_date_today">Today</string>
+    <string name="app_date_yesterday">Yesterday</string>
     <string name="app_error_playback_failed">Could not play this audio</string>
 </resources>

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerTest.kt
@@ -3,8 +3,8 @@ package com.github.barriosnahuel.vossosunboton.feature.playback
 import android.content.Context
 import android.media.MediaPlayer
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
-import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
+import com.github.barriosnahuel.vossosunboton.model.Sound
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
@@ -238,20 +238,32 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
     fun `onButtonSaved selects HOME tab`() {
         val viewModel = givenAViewModel()
 
-        viewModel.onButtonSaved()
+        viewModel.onButtonSaved("test")
 
         assertThat(viewModel.selectedTab.value).isEqualTo(AppTab.HOME)
     }
 
     @Test
-    fun `onButtonSaved emits buttonSavedEvent`() =
+    fun `onButtonSaved emits buttonSavedEvent with the button name`() =
         runTest {
             val viewModel = givenAViewModel()
 
-            viewModel.onButtonSaved()
+            viewModel.onButtonSaved("Juancho")
 
-            viewModel.buttonSavedEvent.first()
+            assertThat(viewModel.buttonSavedEvent.first()).isEqualTo("Juancho")
         }
+
+    @Test
+    fun `toggleFavorite in FAVORITES tab removes unfavorited sound from list`() {
+        val viewModel = givenAViewModel()
+        val sound = Sound("test", "test.mp3", 0, false, isFavorite = true)
+        viewModel.injectSounds(listOf(sound))
+        viewModel.selectTab(AppTab.FAVORITES)
+
+        viewModel.toggleFavorite(sound)
+
+        assertThat(viewModel.sounds.value.none { it.name == "test" }).isTrue()
+    }
 
     @Test
     fun `deleteSound stops playback and removes sound even when passed a stale copy with isPlaying false`() {

--- a/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivity.kt
+++ b/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivity.kt
@@ -36,11 +36,12 @@ class AddButtonActivity : ComponentActivity() {
                 AddButtonScreen(
                     context = this,
                     uri = uri,
-                    onSaved = {
+                    onSaved = { name ->
                         startActivity(
                             Intent(this, LandingActivity::class.java).apply {
                                 flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
                                 putExtra(LandingActivity.EXTRA_BUTTON_SAVED, true)
+                                putExtra(LandingActivity.EXTRA_BUTTON_NAME, name)
                             },
                         )
                         finishAndRemoveTask()

--- a/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
+++ b/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -43,7 +44,7 @@ import kotlinx.coroutines.withContext
 fun AddButtonScreen(
     context: Context,
     uri: Uri,
-    onSaved: () -> Unit,
+    onSaved: (String) -> Unit,
     onNavigateUp: () -> Unit,
 ) {
     var name by remember { mutableStateOf("") }
@@ -59,7 +60,7 @@ fun AddButtonScreen(
         keyboardController?.hide()
         coroutineScope.launch {
             AddButtonFeature.instance.saveNewButtonAsync(context, name.trim(), uri.toString()).await()
-            withContext(Dispatchers.Main) { onSaved() }
+            withContext(Dispatchers.Main) { onSaved(name.trim()) }
         }
     }
 
@@ -76,13 +77,27 @@ fun AddButtonScreen(
             OutlinedTextField(
                 value = name,
                 onValueChange = {
-                    name = it
+                    name = it.take(MAX_NAME_LENGTH)
                     nameError = null
                 },
                 label = { Text(stringResource(R.string.feature_addbutton_name)) },
                 placeholder = { Text(stringResource(R.string.feature_addbutton_placeholder)) },
                 isError = nameError != null,
-                supportingText = nameError?.let { { Text(it) } },
+                supportingText = {
+                    val error = nameError
+                    Row(modifier = Modifier.fillMaxWidth()) {
+                        if (error != null) {
+                            Text(
+                                text = error,
+                                modifier = Modifier.weight(1f),
+                                color = MaterialTheme.colorScheme.error,
+                            )
+                        } else {
+                            Spacer(modifier = Modifier.weight(1f))
+                        }
+                        Text(text = "${name.length}/$MAX_NAME_LENGTH")
+                    }
+                },
                 singleLine = true,
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                 keyboardActions = KeyboardActions(onDone = { save() }),
@@ -98,6 +113,8 @@ fun AddButtonScreen(
         }
     }
 }
+
+private const val MAX_NAME_LENGTH = 50
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable


### PR DESCRIPTION
### Summary
- **AddButton screen**: enforces a 50-character limit on button names and shows a live `x/50` counter in the text field's supporting area
- **Saved snackbar**: now reads _"Juancho is now yours!"_ / _"¡Juancho es tuyo!"_ instead of the generic "Saved!" — button name is passed via Intent extra through the Activity chain
- **Favorites tab**: unfavoriting now animates the item out with a slide-up + fade (300 ms) before removing it from the list, fixing the bug where the item stayed visible until the user left and re-entered the tab
- **Resource naming**: renames `date_today`, `date_yesterday`, `date_days_ago` → `app_date_*` to satisfy the `resourcePrefix = 'app_'` lint rule; documents the per-module prefix table in `CLAUDE.md`

### Code review tips
- `SoundsViewModel.toggleFavorite`: the new branch for `FAVORITES tab + removing` filters the item out of `_sounds` immediately (instead of mapping it) — this is intentional so the in-memory list stays consistent with the animated removal
- `LandingScreen.SoundsList`: `dismissingFavorites` is a `SnapshotStateSet` scoped to the composable. It **must** be cleared after calling `onFavoriteClick` — if not, the sound name lingers in the set and the item stays invisible when it reappears in the HOME tab
- `buttonSavedEvent` channel type changed from `Channel<Unit>` to `Channel<String>`; callers of `onButtonSaved()` must now pass the name

### Already tested
- [x] Character counter truncates at 50, error message shown on empty submit
- [x] Snackbar message includes button name in EN and ES
- [x] Unfavorite in Favorites tab plays slide-up animation; sound reappears correctly in Home tab
- [x] `./gradlew check -x test && ./gradlew test` passes (lint, ktlint, detekt, unit tests)