### PR TITLE
refactor: search overlay — reduce visual noise

### DIFF
--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlay.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlay.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -24,8 +23,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.MusicNote
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -44,7 +41,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
@@ -129,15 +125,21 @@ fun SearchOverlay(
                     ) { state ->
                         when (state) {
                             is SearchDisplayState.Initial ->
-                                SearchEmptyStateContent(
-                                    icon = Icons.Default.Search,
-                                    headline = stringResource(R.string.app_search_initial_headline),
-                                    subtext = stringResource(R.string.app_search_initial_subtext),
-                                )
+                                Box(
+                                    modifier = Modifier.fillMaxSize(),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    Text(
+                                        text = stringResource(R.string.app_search_initial_hint),
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
+                                        textAlign = TextAlign.Center,
+                                        modifier = Modifier.padding(horizontal = 32.dp),
+                                    )
+                                }
 
                             is SearchDisplayState.ZeroResults ->
-                                SearchEmptyStateContent(
-                                    icon = Icons.Default.MusicNote,
+                                SearchZeroResultsContent(
                                     headline = stringResource(R.string.app_search_empty_headline),
                                     subtext = stringResource(R.string.app_search_empty_subtext),
                                 )
@@ -161,8 +163,7 @@ fun SearchOverlay(
 }
 
 @Composable
-private fun SearchEmptyStateContent(
-    icon: ImageVector,
+private fun SearchZeroResultsContent(
     headline: String,
     subtext: String,
 ) {
@@ -174,13 +175,6 @@ private fun SearchEmptyStateContent(
             modifier = Modifier.padding(horizontal = 32.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                modifier = Modifier.size(40.dp),
-                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
-            )
-            Spacer(modifier = Modifier.height(16.dp))
             Text(
                 text = headline,
                 style = MaterialTheme.typography.titleMedium,
@@ -212,12 +206,6 @@ private fun SearchField(
                 .fillMaxWidth()
                 .focusRequester(focusRequester),
         placeholder = { Text(stringResource(R.string.app_search_hint)) },
-        leadingIcon = {
-            Icon(
-                imageVector = Icons.Default.Search,
-                contentDescription = null,
-            )
-        },
         trailingIcon = {
             if (query.isNotBlank()) {
                 IconButton(onClick = { onQueryChange("") }) {

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -17,12 +17,11 @@
     <string name="app_date_yesterday">Ayer</string>
     <string name="app_error_playback_failed">No se pudo reproducir este audio</string>
     <string name="app_search">Buscar</string>
-    <string name="app_search_hint">Buscar sonidos…</string>
+    <string name="app_search_hint">Buscar por nombre…</string>
     <string name="app_search_close">Cerrar búsqueda</string>
-    <string name="app_search_initial_headline">¿Qué sonido buscamos?</string>
-    <string name="app_search_initial_subtext">Podés buscar por nombre del audio.</string>
+    <string name="app_search_initial_hint">Escribí para filtrar tus stickers…</string>
     <string name="app_search_empty_headline">Silencio absoluto…</string>
-    <string name="app_search_empty_subtext">Parece que este sticker de audio aún no existe. Tu colección tiene un vacío que solo vos podés llenar.</string>
+    <string name="app_search_empty_subtext">Este sticker aún no existe. Tu colección tiene un vacío que solo vos podés llenar.</string>
     <string name="app_search_origin_home">Inicio</string>
     <string name="app_search_origin_explore">Explorar</string>
     <string name="app_search_origin_home_and_favorites">Inicio · Favoritos</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,12 +17,11 @@
     <string name="app_date_yesterday">Yesterday</string>
     <string name="app_error_playback_failed">Could not play this audio</string>
     <string name="app_search">Search</string>
-    <string name="app_search_hint">Search sounds…</string>
+    <string name="app_search_hint">Search by name…</string>
     <string name="app_search_close">Close search</string>
-    <string name="app_search_initial_headline">What sound are we looking for?</string>
-    <string name="app_search_initial_subtext">You can search by audio name.</string>
+    <string name="app_search_initial_hint">Type to filter your stickers…</string>
     <string name="app_search_empty_headline">Absolute silence…</string>
-    <string name="app_search_empty_subtext">Looks like this audio sticker doesn\'t exist yet. Your collection has a gap only you can fill.</string>
+    <string name="app_search_empty_subtext">This sticker doesn\'t exist yet. Your collection has a gap only you can fill.</string>
     <string name="app_search_origin_home">Home</string>
     <string name="app_search_origin_explore">Explore</string>
     <string name="app_search_origin_home_and_favorites">Home · Favorites</string>


### PR DESCRIPTION
### Summary
- Initial (empty query) state now shows a single subtle caption instead of an icon + headline + subtext, removing instructional copy the user doesn't need
- ZRP (zero results) drops the decorative icon; headline + subtext only
- Leading search icon removed from the input field — redundant next to the back arrow
- Strings updated in both `en` and `es`; two unused string resources removed

### Code review tips
- `SearchEmptyStateContent` was replaced by two focused composables: an inline `Box` for the initial hint and `SearchZeroResultsContent` for the ZRP — no shared abstraction since the two layouts are now structurally different
- String key `app_search_initial_hint` is new; `app_search_initial_headline` and `app_search_initial_subtext` are gone from both locales

### Already tested
- `./gradlew check -x test` — all linters pass (no new errors)
- `./gradlew test` — all unit tests pass

### Closes