### PR TITLE
refactor: migrate material icons from extended to core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Tests for `SoundsViewModel` covering playback state and delete/restore flows.
 
 ### Changed
+- Migrated from `material-icons-extended` to `material-icons-core` following Material 3 1.4.0; icons absent from core (`Pause`, `ViewComfyAlt`) are now local `ImageVector` definitions copied verbatim from the extended sources to preserve visual consistency
 - Resolved all Kotlin compiler and Gradle DSL deprecation warnings for a clean build log
 - `SoundsViewModel` now loads sounds on a background thread (`Dispatchers.IO`) to avoid blocking the main thread on startup.
 - Centralised all dependency and plugin versions in `gradle/libs.versions.toml` (Gradle version catalog).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -102,7 +102,7 @@ dependencies {
     implementation libs.compose.ui
     implementation libs.compose.ui.tooling.preview
     implementation libs.compose.material3
-    implementation libs.compose.material.icons.extended
+    implementation libs.compose.material.icons.core
     implementation libs.androidx.activity.compose
     implementation libs.lifecycle.viewmodel.compose
     implementation libs.lifecycle.runtime.compose

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/AppIcons.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/AppIcons.kt
@@ -1,0 +1,83 @@
+package com.github.barriosnahuel.vossosunboton.ui
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+internal object AppIcons {
+    val Pause: ImageVector by lazy {
+        ImageVector
+            .Builder(
+                name = "Pause",
+                defaultWidth = 24.dp,
+                defaultHeight = 24.dp,
+                viewportWidth = 24f,
+                viewportHeight = 24f,
+            ).apply {
+                path(fill = SolidColor(Color.Black)) {
+                    moveTo(6.0f, 19.0f)
+                    horizontalLineToRelative(4.0f)
+                    lineTo(10.0f, 5.0f)
+                    lineTo(6.0f, 5.0f)
+                    verticalLineToRelative(14.0f)
+                    close()
+                    moveTo(14.0f, 5.0f)
+                    verticalLineToRelative(14.0f)
+                    horizontalLineToRelative(4.0f)
+                    lineTo(18.0f, 5.0f)
+                    horizontalLineToRelative(-4.0f)
+                    close()
+                }
+            }.build()
+    }
+
+    val ViewComfyAlt: ImageVector by lazy {
+        ImageVector
+            .Builder(
+                name = "ViewComfyAlt",
+                defaultWidth = 24.dp,
+                defaultHeight = 24.dp,
+                viewportWidth = 24f,
+                viewportHeight = 24f,
+            ).apply {
+                path(fill = SolidColor(Color.Black)) {
+                    moveTo(20.0f, 4.0f)
+                    horizontalLineTo(4.0f)
+                    curveTo(2.9f, 4.0f, 2.0f, 4.9f, 2.0f, 6.0f)
+                    verticalLineToRelative(12.0f)
+                    curveToRelative(0.0f, 1.1f, 0.9f, 2.0f, 2.0f, 2.0f)
+                    horizontalLineToRelative(16.0f)
+                    curveToRelative(1.1f, 0.0f, 2.0f, -0.9f, 2.0f, -2.0f)
+                    verticalLineTo(6.0f)
+                    curveTo(22.0f, 4.9f, 21.1f, 4.0f, 20.0f, 4.0f)
+                    close()
+                    moveTo(11.0f, 17.0f)
+                    horizontalLineTo(7.0f)
+                    verticalLineToRelative(-4.0f)
+                    horizontalLineToRelative(4.0f)
+                    verticalLineTo(17.0f)
+                    close()
+                    moveTo(11.0f, 11.0f)
+                    horizontalLineTo(7.0f)
+                    verticalLineTo(7.0f)
+                    horizontalLineToRelative(4.0f)
+                    verticalLineTo(11.0f)
+                    close()
+                    moveTo(17.0f, 17.0f)
+                    horizontalLineToRelative(-4.0f)
+                    verticalLineToRelative(-4.0f)
+                    horizontalLineToRelative(4.0f)
+                    verticalLineTo(17.0f)
+                    close()
+                    moveTo(17.0f, 11.0f)
+                    horizontalLineToRelative(-4.0f)
+                    verticalLineTo(7.0f)
+                    horizontalLineToRelative(4.0f)
+                    verticalLineTo(11.0f)
+                    close()
+                }
+            }.build()
+    }
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.ViewComfyAlt
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -50,6 +49,7 @@ import androidx.compose.ui.unit.dp
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.feature.share.ShareFeature
 import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.github.barriosnahuel.vossosunboton.ui.AppIcons
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -228,7 +228,7 @@ private fun AppBottomBar(
             colors = itemColors,
             selected = selectedTab == AppTab.EXPLORE,
             onClick = { onTabSelected(AppTab.EXPLORE) },
-            icon = { Icon(Icons.Default.ViewComfyAlt, contentDescription = stringResource(R.string.app_navigation_menu_item_explore)) },
+            icon = { Icon(AppIcons.ViewComfyAlt, contentDescription = stringResource(R.string.app_navigation_menu_item_explore)) },
             label = { Text(stringResource(R.string.app_navigation_menu_item_explore)) },
         )
     }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
@@ -12,7 +12,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
-import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Card
@@ -42,6 +41,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.github.barriosnahuel.vossosunboton.ui.AppIcons
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -215,7 +215,7 @@ private fun SoundCard(
             ) {
                 IconButton(onClick = onPlayClick) {
                     Icon(
-                        imageVector = if (sound.isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                        imageVector = if (sound.isPlaying) AppIcons.Pause else Icons.Default.PlayArrow,
                         contentDescription = stringResource(if (sound.isPlaying) R.string.app_pause else R.string.app_play),
                     )
                 }

--- a/feature_addbutton/build.gradle
+++ b/feature_addbutton/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation libs.compose.ui
     implementation libs.compose.ui.tooling.preview
     implementation libs.compose.material3
-    implementation libs.compose.material.icons.extended
+    implementation libs.compose.material.icons.core
     implementation libs.androidx.activity.compose
     implementation libs.lifecycle.viewmodel.compose
     implementation libs.lifecycle.runtime.compose

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ compose-ui-tooling-preview        = { module = "androidx.compose.ui:ui-tooling-p
 compose-ui-tooling                = { module = "androidx.compose.ui:ui-tooling" }
 compose-ui-test-manifest          = { module = "androidx.compose.ui:ui-test-manifest" }
 compose-material3                 = { module = "androidx.compose.material3:material3" }
-compose-material-icons-extended   = { module = "androidx.compose.material:material-icons-extended" }
+compose-material-icons-core        = { module = "androidx.compose.material:material-icons-core" }
 
 # ---------- Lifecycle ----------
 lifecycle-viewmodel-compose       = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleCompose" }


### PR DESCRIPTION
### Summary

- Material 3 1.4.0 dropped the transitive dependency on `material-icons-core`, making `material-icons-extended` a no-longer-maintained explicit dependency; this PR replaces it with `material-icons-core`
- Icons absent from core (`Pause`, `ViewComfyAlt`) are defined as local `ImageVector` in the new `AppIcons.kt`, with path data copied verbatim from the `material-icons-extended` 1.7.8 sources — no visual change
- All other icons (`ArrowBack`, `Close`, `Delete`, `Favorite`, `FavoriteBorder`, `Home`, `PlayArrow`, `Search`, `Share`) were already present in core and required no changes

### Code review tips

- `AppIcons.kt` (`ui/AppIcons.kt`): the two `ImageVector` definitions use `lazy` + the public `ImageVector.Builder` + `path {}` DSL — no internal APIs involved; paths are identical to the extended library source
- The icon import swap in `SoundItem.kt` and `LandingScreen.kt` is purely mechanical (`Icons.Default.Pause` / `Icons.Default.ViewComfyAlt` → `AppIcons.*`); no logic changed

### Already tested

- [x] `./gradlew check -x test` — ktlint, detekt, Android lint all pass
- [x] `./gradlew test` — all unit tests pass