### PR TITLE
feat: pin UX, gesture resilience tests, and icon migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 ## \[unreleased] (v2.0.0)
 ### Added
+- Swipe right on any custom sound to pin/favorite it (PrimaryContainer background); swipe left to delete (ErrorContainer background) — replaces the old single-direction swipe
+- Edit custom sounds: long-press any card to rename it; the existing audio stays, only the name changes
+- Sorting: custom sounds now order by date added (newest first), with alphabetical fallback for bundled sounds
+- Haptic feedback on swipe actions: CONFIRM pulse for pin, REJECT double-pulse for delete (API 30+)
+- Delete animation: removed items scale and fade to zero before the list collapses ("Void Shrink")
+- List reflow: remaining items animate smoothly into place after any removal (animateItem)
+- Edit button screen: reuses the Add Button flow with pre-loaded name, audio preview, and "Save changes" CTA
 - Search overlay: tap the new FAB to search across all tabs at once; results show the same play/favorite/share/delete actions as the main list plus a subtle origin badge
 - Favorites: users can mark/unmark any custom button as favorite; a dedicated Favorites tab lists only marked buttons
 - Deeplinks: the app responds to `push-me://open/home`, `push-me://open/favorites`, and `push-me://open/explore` to navigate directly to a tab

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -117,4 +117,6 @@ dependencies {
     testImplementation libs.truth
     testImplementation libs.mockk
     testImplementation libs.coroutines.test
+    testImplementation platform(libs.compose.bom)
+    testImplementation libs.compose.ui.test.junit4
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/AppIcons.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/AppIcons.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
 
-internal object AppIcons {
+public object AppIcons {
     val Pause: ImageVector by lazy {
         ImageVector
             .Builder(
@@ -28,6 +28,41 @@ internal object AppIcons {
                     horizontalLineToRelative(4.0f)
                     lineTo(18.0f, 5.0f)
                     horizontalLineToRelative(-4.0f)
+                    close()
+                }
+            }.build()
+    }
+
+    val PushPin: ImageVector by lazy {
+        ImageVector
+            .Builder(
+                name = "PushPin",
+                defaultWidth = 24.dp,
+                defaultHeight = 24.dp,
+                viewportWidth = 24f,
+                viewportHeight = 24f,
+            ).apply {
+                path(fill = SolidColor(Color.Black)) {
+                    moveTo(16f, 9f)
+                    verticalLineTo(4f)
+                    horizontalLineToRelative(1f)
+                    curveToRelative(0.55f, 0f, 1f, -0.45f, 1f, -1f)
+                    reflectiveCurveToRelative(-0.45f, -1f, -1f, -1f)
+                    horizontalLineTo(7f)
+                    curveToRelative(-0.55f, 0f, -1f, 0.45f, -1f, 1f)
+                    reflectiveCurveToRelative(0.45f, 1f, 1f, 1f)
+                    horizontalLineToRelative(1f)
+                    verticalLineToRelative(5f)
+                    curveToRelative(0f, 1.66f, -1.34f, 3f, -3f, 3f)
+                    verticalLineToRelative(2f)
+                    horizontalLineToRelative(5.97f)
+                    verticalLineToRelative(7f)
+                    lineToRelative(1f, 1f)
+                    lineToRelative(1f, -1f)
+                    verticalLineToRelative(-7f)
+                    horizontalLineTo(19f)
+                    verticalLineToRelative(-2f)
+                    curveToRelative(-1.66f, 0f, -3f, -1.34f, -3f, -3f)
                     close()
                 }
             }.build()

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivity.kt
@@ -1,5 +1,6 @@
 package com.github.barriosnahuel.vossosunboton.ui.home
 
+import android.content.Context
 import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
@@ -8,6 +9,7 @@ import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
+import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
 
 class LandingActivity : ComponentActivity() {
@@ -37,6 +39,10 @@ class LandingActivity : ComponentActivity() {
             val name = intent.getStringExtra(EXTRA_BUTTON_NAME) ?: ""
             viewModel.onButtonSaved(name)
         }
+        if (intent.getBooleanExtra(EXTRA_BUTTON_RENAMED, false)) {
+            val name = intent.getStringExtra(EXTRA_BUTTON_NAME) ?: ""
+            viewModel.onButtonRenamed(name)
+        }
     }
 
     private fun handleDeeplink(intent: Intent) {
@@ -44,7 +50,6 @@ class LandingActivity : ComponentActivity() {
         val tab =
             when (uri.path) {
                 "/home" -> AppTab.HOME
-                "/favorites" -> AppTab.FAVORITES
                 else -> AppTab.EXPLORE
             }
         viewModel.selectTab(tab)
@@ -52,6 +57,26 @@ class LandingActivity : ComponentActivity() {
 
     companion object {
         const val EXTRA_BUTTON_SAVED = "extra_button_saved"
+        const val EXTRA_BUTTON_RENAMED = "extra_button_renamed"
         const val EXTRA_BUTTON_NAME = "extra_button_name"
+        const val EXTRA_EDIT_SOUND_NAME = "extra_edit_sound_name"
+        const val EXTRA_EDIT_SOUND_FILE = "extra_edit_sound_file"
+        const val EXTRA_EDIT_SOUND_FAVORITE = "extra_edit_sound_favorite"
+        const val EXTRA_EDIT_SOUND_DATE_ADDED = "extra_edit_sound_date_added"
+
+        private const val ADD_BUTTON_ACTIVITY_CLASS =
+            "com.github.barriosnahuel.vossosunboton.feature.addbutton.AddButtonActivity"
+
+        fun editIntent(
+            context: Context,
+            sound: Sound,
+        ): Intent =
+            Intent().apply {
+                setClassName(context, ADD_BUTTON_ACTIVITY_CLASS)
+                putExtra(EXTRA_EDIT_SOUND_NAME, sound.name)
+                putExtra(EXTRA_EDIT_SOUND_FILE, sound.file)
+                putExtra(EXTRA_EDIT_SOUND_FAVORITE, sound.isFavorite)
+                sound.dateAdded?.let { putExtra(EXTRA_EDIT_SOUND_DATE_ADDED, it) }
+            }
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -3,9 +3,10 @@ package com.github.barriosnahuel.vossosunboton.ui.home
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -16,7 +17,6 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.ViewComfyAlt
@@ -102,7 +102,6 @@ fun LandingScreen(viewModel: SoundsViewModel) {
     ) { innerPadding ->
         SoundsList(
             sounds = sounds,
-            selectedTab = selectedTab,
             playbackProgress = playbackProgress,
             listState = listState,
             modifier = Modifier.padding(innerPadding),
@@ -110,7 +109,10 @@ fun LandingScreen(viewModel: SoundsViewModel) {
             onSeek = { positionMs -> viewModel.seekTo(positionMs) },
             onShareClick = { sound -> ShareFeature.instance.share(context, sound) },
             onDelete = { sound -> viewModel.deleteSound(sound) },
-            onFavoriteClick = { sound -> viewModel.toggleFavorite(sound) },
+            onPinClick = { sound -> viewModel.togglePin(sound) },
+            onEdit = { sound ->
+                context.startActivity(LandingActivity.editIntent(context, sound))
+            },
         )
     }
 
@@ -125,7 +127,7 @@ fun LandingScreen(viewModel: SoundsViewModel) {
             onPlayClick = viewModel::playOrStop,
             onSeek = viewModel::seekTo,
             onShareClick = { sound -> ShareFeature.instance.share(context, sound) },
-            onFavoriteClick = viewModel::toggleFavorite,
+            onPinClick = viewModel::togglePin,
             onDelete = { sound ->
                 viewModel.hideSearch()
                 viewModel.deleteSound(sound)
@@ -145,6 +147,7 @@ private fun SnackbarEffects(
     val undoLabel = stringResource(R.string.app_undo)
     val playbackErrorMessage = stringResource(R.string.app_error_playback_failed)
     val buttonSavedTemplate = stringResource(R.string.app_feedback_button_saved)
+    val buttonRenamedTemplate = stringResource(R.string.app_feedback_button_renamed)
 
     LaunchedEffect(Unit) {
         viewModel.playbackErrorEvent.collect {
@@ -159,6 +162,15 @@ private fun SnackbarEffects(
         viewModel.buttonSavedEvent.collect { name ->
             snackbarHostState.showSnackbar(
                 message = String.format(buttonSavedTemplate, name),
+                duration = SnackbarDuration.Short,
+            )
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.buttonRenamedEvent.collect { name ->
+            snackbarHostState.showSnackbar(
+                message = String.format(buttonRenamedTemplate, name),
                 duration = SnackbarDuration.Short,
             )
         }
@@ -219,13 +231,6 @@ private fun AppBottomBar(
         )
         NavigationBarItem(
             colors = itemColors,
-            selected = selectedTab == AppTab.FAVORITES,
-            onClick = { onTabSelected(AppTab.FAVORITES) },
-            icon = { Icon(Icons.Default.Favorite, contentDescription = stringResource(R.string.app_navigation_menu_item_favourites)) },
-            label = { Text(stringResource(R.string.app_navigation_menu_item_favourites)) },
-        )
-        NavigationBarItem(
-            colors = itemColors,
             selected = selectedTab == AppTab.EXPLORE,
             onClick = { onTabSelected(AppTab.EXPLORE) },
             icon = { Icon(Icons.Default.ViewComfyAlt, contentDescription = stringResource(R.string.app_navigation_menu_item_explore)) },
@@ -234,12 +239,11 @@ private fun AppBottomBar(
     }
 }
 
-private const val UNFAVORITE_ANIMATION_DURATION_MS = 300
+private const val DELETE_ANIMATION_DURATION_MS = 300
 
 @Composable
 private fun SoundsList(
     sounds: List<Sound>,
-    selectedTab: AppTab,
     playbackProgress: PlaybackProgress?,
     listState: LazyListState,
     modifier: Modifier = Modifier,
@@ -247,9 +251,10 @@ private fun SoundsList(
     onSeek: (Int) -> Unit,
     onShareClick: (Sound) -> Unit,
     onDelete: (Sound) -> Unit,
-    onFavoriteClick: (Sound) -> Unit,
+    onPinClick: (Sound) -> Unit,
+    onEdit: (Sound) -> Unit,
 ) {
-    val dismissingFavorites = remember { mutableStateSetOf<String>() }
+    val dismissingItems = remember { mutableStateSetOf<String>() }
     val coroutineScope = rememberCoroutineScope()
 
     Box(modifier = modifier.fillMaxSize()) {
@@ -258,14 +263,21 @@ private fun SoundsList(
             contentPadding = PaddingValues(vertical = 8.dp),
         ) {
             itemsIndexed(sounds, key = { _, sound -> sound.name }) { _, sound ->
+                val isDeleting = sound.name in dismissingItems
                 AnimatedVisibility(
-                    visible = sound.name !in dismissingFavorites,
+                    visible = !isDeleting,
+                    modifier =
+                        Modifier.animateItem(
+                            fadeInSpec = null,
+                            fadeOutSpec = null,
+                            placementSpec = spring(),
+                        ),
                     enter = EnterTransition.None,
                     exit =
-                        slideOutVertically(
-                            animationSpec = tween(durationMillis = UNFAVORITE_ANIMATION_DURATION_MS),
-                            targetOffsetY = { -it },
-                        ) + fadeOut(animationSpec = tween(durationMillis = UNFAVORITE_ANIMATION_DURATION_MS)),
+                        scaleOut(
+                            targetScale = 0f,
+                            animationSpec = tween(durationMillis = DELETE_ANIMATION_DURATION_MS),
+                        ) + fadeOut(animationSpec = tween(durationMillis = DELETE_ANIMATION_DURATION_MS)),
                 ) {
                     SoundItem(
                         sound = sound,
@@ -273,19 +285,21 @@ private fun SoundsList(
                         onPlayClick = { onPlayClick(sound) },
                         onSeek = onSeek,
                         onShareClick = { onShareClick(sound) },
-                        onDelete = { onDelete(sound) },
-                        onFavoriteClick = {
-                            if (selectedTab == AppTab.FAVORITES && sound.isFavorite) {
-                                dismissingFavorites.add(sound.name)
-                                coroutineScope.launch {
-                                    delay(UNFAVORITE_ANIMATION_DURATION_MS.toLong())
-                                    onFavoriteClick(sound)
-                                    dismissingFavorites.remove(sound.name)
-                                }
-                            } else {
-                                onFavoriteClick(sound)
+                        onDelete = {
+                            dismissingItems.add(sound.name)
+                            coroutineScope.launch {
+                                delay(DELETE_ANIMATION_DURATION_MS.toLong())
+                                onDelete(sound)
+                                dismissingItems.remove(sound.name)
                             }
                         },
+                        onPinClick = { onPinClick(sound) },
+                        onEditClick =
+                            if (!sound.isBundled()) {
+                                { onEdit(sound) }
+                            } else {
+                                null
+                            },
                     )
                 }
             }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlay.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlay.kt
@@ -70,7 +70,7 @@ fun SearchOverlay(
     onPlayClick: (Sound) -> Unit,
     onSeek: (Int) -> Unit,
     onShareClick: (Sound) -> Unit,
-    onFavoriteClick: (Sound) -> Unit,
+    onPinClick: (Sound) -> Unit,
     onDelete: (Sound) -> Unit,
 ) {
     BackHandler { onClose() }
@@ -151,7 +151,7 @@ fun SearchOverlay(
                                     onPlayClick = onPlayClick,
                                     onSeek = onSeek,
                                     onShareClick = onShareClick,
-                                    onFavoriteClick = onFavoriteClick,
+                                    onPinClick = onPinClick,
                                     onDelete = onDelete,
                                 )
                         }
@@ -239,21 +239,11 @@ private fun SearchResultsList(
     onPlayClick: (Sound) -> Unit,
     onSeek: (Int) -> Unit,
     onShareClick: (Sound) -> Unit,
-    onFavoriteClick: (Sound) -> Unit,
+    onPinClick: (Sound) -> Unit,
     onDelete: (Sound) -> Unit,
 ) {
-    val homeLabel = stringResource(R.string.app_search_origin_home)
-    val exploreLabel = stringResource(R.string.app_search_origin_explore)
-    val homeAndFavoritesLabel = stringResource(R.string.app_search_origin_home_and_favorites)
-
     LazyColumn(contentPadding = PaddingValues(vertical = 8.dp)) {
         items(results, key = { it.name }) { sound ->
-            val originLabel =
-                when {
-                    sound.isBundled() -> exploreLabel
-                    sound.isFavorite -> homeAndFavoritesLabel
-                    else -> homeLabel
-                }
             SoundItem(
                 sound = sound,
                 playbackProgress = if (sound.isPlaying) playbackProgress else null,
@@ -261,8 +251,7 @@ private fun SearchResultsList(
                 onSeek = onSeek,
                 onShareClick = { onShareClick(sound) },
                 onDelete = { onDelete(sound) },
-                onFavoriteClick = { onFavoriteClick(sound) },
-                originLabel = originLabel,
+                onPinClick = { onPinClick(sound) },
             )
         }
     }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
@@ -1,6 +1,11 @@
 package com.github.barriosnahuel.vossosunboton.ui.home
 
+import android.os.Build
+import android.view.HapticFeedbackConstants
+import android.view.View
 import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -10,13 +15,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -33,10 +40,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalResources
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -56,7 +67,8 @@ fun SoundItem(
     onSeek: (Int) -> Unit,
     onShareClick: () -> Unit,
     onDelete: () -> Unit,
-    onFavoriteClick: () -> Unit,
+    onPinClick: () -> Unit,
+    onEditClick: (() -> Unit)? = null,
     originLabel: String? = null,
 ) {
     if (sound.isBundled()) {
@@ -66,7 +78,9 @@ fun SoundItem(
             onPlayClick = onPlayClick,
             onSeek = onSeek,
             onShareClick = onShareClick,
-            onFavoriteClick = onFavoriteClick,
+            onPinClick = null,
+            onEditClick = null,
+            onDelete = null,
             originLabel = originLabel,
         )
         return
@@ -78,17 +92,37 @@ fun SoundItem(
         remember {
             SwipeToDismissBoxState(
                 initialValue = SwipeToDismissBoxValue.Settled,
-                positionalThreshold = { totalDistance -> totalDistance * 0.5f },
+                positionalThreshold = { totalDistance -> totalDistance * 0.35f },
             )
         }
-    LaunchedEffect(dismissState.currentValue) {
-        if (dismissState.currentValue != SwipeToDismissBoxValue.Settled) {
-            onDelete()
-        }
+    val view = LocalView.current
+    // rememberUpdatedState ensures the LaunchedEffect(Unit) always calls the CURRENT lambda,
+    // not the one captured at first composition. Without this, onPinClick closes over the
+    // initial Sound (isPinned=false), so a second swipe re-pins instead of unpinning.
+    val currentOnPinClick by rememberUpdatedState(onPinClick)
+    val currentOnDelete by rememberUpdatedState(onDelete)
+    // settledValue only changes when an animation COMPLETES (unlike currentValue, which changes
+    // at animation start). Watching it ensures we act only after the card is fully swiped.
+    LaunchedEffect(Unit) {
+        snapshotFlow { dismissState.settledValue }
+            .collect { settled ->
+                when (settled) {
+                    SwipeToDismissBoxValue.StartToEnd -> {
+                        performPinHaptic(view)
+                        dismissState.snapTo(SwipeToDismissBoxValue.Settled)
+                        currentOnPinClick()
+                    }
+                    SwipeToDismissBoxValue.EndToStart -> {
+                        performDeleteHaptic(view)
+                        currentOnDelete()
+                    }
+                    SwipeToDismissBoxValue.Settled -> Unit
+                }
+            }
     }
     SwipeToDismissBox(
         state = dismissState,
-        backgroundContent = { SwipeDeleteBackground(dismissState) },
+        backgroundContent = { SwipeActionBackground(dismissState) },
     ) {
         SoundCard(
             sound = sound,
@@ -96,37 +130,50 @@ fun SoundItem(
             onPlayClick = onPlayClick,
             onSeek = onSeek,
             onShareClick = onShareClick,
-            onFavoriteClick = onFavoriteClick,
+            onPinClick = onPinClick,
+            onEditClick = onEditClick,
+            onDelete = onDelete,
             originLabel = originLabel,
         )
     }
 }
 
+private fun performPinHaptic(view: View) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+    } else {
+        view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+    }
+}
+
+private fun performDeleteHaptic(view: View) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        view.performHapticFeedback(HapticFeedbackConstants.REJECT)
+    } else {
+        view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+    }
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SwipeDeleteBackground(dismissState: SwipeToDismissBoxState) {
-    // Only render when an active swipe is in progress to avoid the background
-    // bleeding through the card's horizontal padding when at rest.
+private fun SwipeActionBackground(dismissState: SwipeToDismissBoxState) {
     if (dismissState.dismissDirection == SwipeToDismissBoxValue.Settled) return
-    val alignment =
-        when (dismissState.dismissDirection) {
-            SwipeToDismissBoxValue.StartToEnd -> Alignment.CenterStart
-            SwipeToDismissBoxValue.EndToStart -> Alignment.CenterEnd
-            SwipeToDismissBoxValue.Settled -> Alignment.Center
-        }
+    val isPinAction = dismissState.dismissDirection == SwipeToDismissBoxValue.StartToEnd
+    val backgroundColor =
+        if (isPinAction) PIN_BACKGROUND_COLOR else MaterialTheme.colorScheme.errorContainer
+    val iconTint =
+        if (isPinAction) Color.White else MaterialTheme.colorScheme.onErrorContainer
+    val icon = if (isPinAction) Icons.Default.PushPin else Icons.Default.Delete
+    val alignment = if (isPinAction) Alignment.CenterStart else Alignment.CenterEnd
     Box(
         modifier =
             Modifier
                 .fillMaxSize()
-                .background(MaterialTheme.colorScheme.errorContainer)
+                .background(backgroundColor)
                 .padding(horizontal = 16.dp),
         contentAlignment = alignment,
     ) {
-        Icon(
-            imageVector = Icons.Default.Delete,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onErrorContainer,
-        )
+        Icon(imageVector = icon, contentDescription = null, tint = iconTint)
     }
 }
 
@@ -137,11 +184,14 @@ private fun SoundCard(
     onPlayClick: () -> Unit,
     onSeek: (Int) -> Unit,
     onShareClick: () -> Unit,
-    onFavoriteClick: () -> Unit,
+    onPinClick: (() -> Unit)?,
+    onEditClick: (() -> Unit)?,
+    onDelete: (() -> Unit)?,
     originLabel: String? = null,
 ) {
     var sliderPosition by remember { mutableFloatStateOf(0f) }
     var isDragging by remember { mutableStateOf(false) }
+    var showMenu by remember { mutableStateOf(false) }
 
     LaunchedEffect(playbackProgress) {
         if (!isDragging) {
@@ -153,7 +203,18 @@ private fun SoundCard(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 8.dp, vertical = 4.dp),
+                .padding(horizontal = 8.dp, vertical = 4.dp)
+                .combinedClickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = {},
+                    onLongClick =
+                        if (onEditClick != null) {
+                            { showMenu = true }
+                        } else {
+                            null
+                        },
+                ),
         colors =
             CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.primaryContainer,
@@ -166,48 +227,16 @@ private fun SoundCard(
                     .fillMaxWidth()
                     .padding(horizontal = 8.dp, vertical = 8.dp),
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = sound.name,
-                        style = MaterialTheme.typography.bodyLarge,
-                        fontWeight = FontWeight.Bold,
-                    )
-                    if (originLabel != null) {
-                        Text(
-                            text = originLabel,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.6f),
-                        )
-                    }
-                }
-                if (!sound.isBundled()) {
-                    IconButton(onClick = onFavoriteClick) {
-                        Icon(
-                            imageVector = if (sound.isFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
-                            contentDescription =
-                                stringResource(
-                                    if (sound.isFavorite) R.string.app_remove_from_favorites else R.string.app_add_to_favorites,
-                                ),
-                            tint =
-                                if (sound.isFavorite) {
-                                    MaterialTheme.colorScheme.primary
-                                } else {
-                                    MaterialTheme.colorScheme.onPrimaryContainer
-                                },
-                        )
-                    }
-                    IconButton(onClick = onShareClick) {
-                        Icon(
-                            imageVector = Icons.Default.Share,
-                            contentDescription = stringResource(R.string.app_share_chooser_title),
-                        )
-                    }
-                }
-            }
+            SoundCardHeader(
+                sound = sound,
+                originLabel = originLabel,
+                showMenu = showMenu,
+                onMenuDismiss = { showMenu = false },
+                onPinClick = onPinClick,
+                onShareClick = onShareClick,
+                onEditClick = onEditClick,
+                onDeleteClick = onDelete,
+            )
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -265,6 +294,89 @@ private fun SoundCard(
 }
 
 @Composable
+private fun SoundCardHeader(
+    sound: Sound,
+    originLabel: String?,
+    showMenu: Boolean,
+    onMenuDismiss: () -> Unit,
+    onPinClick: (() -> Unit)?,
+    onShareClick: () -> Unit,
+    onEditClick: (() -> Unit)?,
+    onDeleteClick: (() -> Unit)?,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = sound.name,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Bold,
+            )
+            if (originLabel != null) {
+                Text(
+                    text = originLabel,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.6f),
+                )
+            }
+        }
+        if (sound.isPinned) {
+            Icon(
+                imageVector = Icons.Default.PushPin,
+                contentDescription = stringResource(R.string.app_pinned),
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(end = 4.dp),
+            )
+        }
+        IconButton(onClick = onShareClick) {
+            Icon(
+                imageVector = Icons.Default.Share,
+                contentDescription = stringResource(R.string.app_share_chooser_title),
+            )
+        }
+        if (onEditClick != null) {
+            Box {
+                DropdownMenu(
+                    expanded = showMenu,
+                    onDismissRequest = onMenuDismiss,
+                ) {
+                    if (onPinClick != null) {
+                        DropdownMenuItem(
+                            text = { Text(stringResource(if (sound.isPinned) R.string.app_unpin else R.string.app_pin)) },
+                            leadingIcon = { Icon(Icons.Default.PushPin, contentDescription = null) },
+                            onClick = {
+                                onMenuDismiss()
+                                onPinClick()
+                            },
+                        )
+                    }
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.app_edit)) },
+                        leadingIcon = { Icon(Icons.Default.Edit, contentDescription = null) },
+                        onClick = {
+                            onMenuDismiss()
+                            onEditClick()
+                        },
+                    )
+                    if (onDeleteClick != null) {
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.app_delete)) },
+                            leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
+                            onClick = {
+                                onMenuDismiss()
+                                onDeleteClick()
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
 private fun formatRelativeDate(epochMs: Long): String {
     val today = startOfDay(System.currentTimeMillis())
     val dateDay = startOfDay(epochMs)
@@ -277,3 +389,5 @@ private fun formatRelativeDate(epochMs: Long): String {
         else -> SimpleDateFormat("d MMM", Locale.getDefault()).format(Date(epochMs))
     }
 }
+
+private val PIN_BACKGROUND_COLOR = Color(0xFF2E7D32)

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
@@ -16,9 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -164,7 +162,7 @@ private fun SwipeActionBackground(dismissState: SwipeToDismissBoxState) {
         if (isPinAction) PIN_BACKGROUND_COLOR else MaterialTheme.colorScheme.errorContainer
     val iconTint =
         if (isPinAction) Color.White else MaterialTheme.colorScheme.onErrorContainer
-    val icon = if (isPinAction) Icons.Default.PushPin else Icons.Default.Delete
+    val icon = if (isPinAction) AppIcons.PushPin else Icons.Default.Delete
     val alignment = if (isPinAction) Alignment.CenterStart else Alignment.CenterEnd
     Box(
         modifier =
@@ -325,7 +323,7 @@ private fun SoundCardHeader(
         }
         if (sound.isPinned) {
             Icon(
-                imageVector = Icons.Default.PushPin,
+                imageVector = AppIcons.PushPin,
                 contentDescription = stringResource(R.string.app_pinned),
                 tint = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.padding(end = 4.dp),
@@ -346,7 +344,7 @@ private fun SoundCardHeader(
                     if (onPinClick != null) {
                         DropdownMenuItem(
                             text = { Text(stringResource(if (sound.isPinned) R.string.app_unpin else R.string.app_pin)) },
-                            leadingIcon = { Icon(Icons.Default.PushPin, contentDescription = null) },
+                            leadingIcon = { Icon(AppIcons.PushPin, contentDescription = null) },
                             onClick = {
                                 onMenuDismiss()
                                 onPinClick()

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -125,7 +125,9 @@ class SoundsViewModel(
             if (query.isBlank()) {
                 emptyList()
             } else {
-                allSoundsCache.value.filter { it.name.contains(query, ignoreCase = true) }.sortedBy { it.name.lowercase() }
+                allSoundsCache.value
+                    .filter { it.name.contains(query, ignoreCase = true) }
+                    .sortedWith(compareByDescending<Sound> { it.isPinned }.thenBy { it.name.lowercase() })
             }
     }
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
-enum class AppTab { HOME, FAVORITES, EXPLORE }
+enum class AppTab { HOME, EXPLORE }
 
 data class DeletedSoundEvent(
     val sound: Sound,
@@ -38,6 +38,7 @@ data class PlaybackProgress(
     val fraction: Float get() = if (durationMs > 0) positionMs / durationMs.toFloat() else 0f
 }
 
+@Suppress("TooManyFunctions")
 class SoundsViewModel(
     application: Application,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
@@ -77,6 +78,9 @@ class SoundsViewModel(
 
     private val _buttonSavedEvent = Channel<String>(Channel.BUFFERED)
     val buttonSavedEvent: Flow<String> = _buttonSavedEvent.receiveAsFlow()
+
+    private val _buttonRenamedEvent = Channel<String>(Channel.BUFFERED)
+    val buttonRenamedEvent: Flow<String> = _buttonRenamedEvent.receiveAsFlow()
 
     private val _playbackErrorEvent = Channel<Unit>(Channel.BUFFERED)
     val playbackErrorEvent: Flow<Unit> = _playbackErrorEvent.receiveAsFlow()
@@ -130,17 +134,23 @@ class SoundsViewModel(
         viewModelScope.launch(ioDispatcher) { loadSounds() }
     }
 
-    fun toggleFavorite(sound: Sound) {
-        val nowFavorite = !sound.isFavorite
-        if (_selectedTab.value == AppTab.FAVORITES && !nowFavorite) {
-            _sounds.update { list -> list.filter { it.name != sound.name } }
-        } else {
-            _sounds.update { list -> list.map { if (it.name == sound.name) sound.copy(isFavorite = nowFavorite) else it } }
+    fun togglePin(sound: Sound) {
+        if (sound.isBundled()) return
+        val nowPinned = !sound.isPinned
+        val sortedList = { list: List<Sound> ->
+            list
+                .map { if (it.name == sound.name) it.copy(isPinned = nowPinned) else it }
+                .sortedWith(
+                    compareByDescending<Sound> { it.isPinned }
+                        .thenByDescending { it.dateAdded ?: Long.MIN_VALUE }
+                        .thenBy { it.name.lowercase() },
+                )
         }
-        allSoundsCache.update { list -> list.map { if (it.name == sound.name) it.copy(isFavorite = nowFavorite) else it } }
+        _sounds.update(sortedList)
+        allSoundsCache.update { list -> list.map { if (it.name == sound.name) it.copy(isPinned = nowPinned) else it } }
         recomputeSearchResults()
         viewModelScope.launch(ioDispatcher) {
-            SoundDao().saveFavorite(getApplication(), sound.name, nowFavorite)
+            SoundDao().savePin(getApplication(), sound.name, nowPinned)
         }
     }
 
@@ -209,8 +219,20 @@ class SoundsViewModel(
         _buttonSavedEvent.trySend(name)
     }
 
+    fun onButtonRenamed(name: String) {
+        selectTab(AppTab.HOME)
+        _buttonRenamedEvent.trySend(name)
+    }
+
     private suspend fun loadSounds() {
-        val allSounds = SoundDao().find(getApplication<Application>()).sortedBy { it.name.lowercase() }
+        val allSounds =
+            SoundDao()
+                .find(getApplication<Application>())
+                .sortedWith(
+                    compareByDescending<Sound> { it.isPinned }
+                        .thenByDescending { it.dateAdded ?: Long.MIN_VALUE }
+                        .thenBy { it.name.lowercase() },
+                )
         val playingName = _playingSound.value?.name
         val deletedName = _deletedSoundEvent.value?.sound?.name
         allSoundsCache.value =
@@ -224,7 +246,6 @@ class SoundsViewModel(
             val filtered =
                 when (_selectedTab.value) {
                     AppTab.HOME -> allSounds.filter { !it.isBundled() }
-                    AppTab.FAVORITES -> allSounds.filter { it.isFavorite }
                     AppTab.EXPLORE -> allSounds.filter { it.isBundled() }
                 }.filter { it.name != deletedName }
             if (playingName == null) {

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -8,9 +8,6 @@
     <string name="app_feedback_generic_error_contact_support">Uh! Por favor contactá con soporte</string>
     <string name="app_navigation_menu_item_home">Inicio</string>
     <string name="app_navigation_menu_item_explore">Explorar</string>
-    <string name="app_navigation_menu_item_favourites">Favoritos</string>
-    <string name="app_add_to_favorites">Agregar a favoritos</string>
-    <string name="app_remove_from_favorites">Quitar de favoritos</string>
     <string name="app_play">Reproducir</string>
     <string name="app_pause">Pausar</string>
     <string name="app_date_today">Hoy</string>
@@ -22,7 +19,10 @@
     <string name="app_search_initial_hint">Escribí para filtrar tus stickers…</string>
     <string name="app_search_empty_headline">Silencio absoluto…</string>
     <string name="app_search_empty_subtext">Este sticker aún no existe. Tu colección tiene un vacío que solo vos podés llenar.</string>
-    <string name="app_search_origin_home">Inicio</string>
-    <string name="app_search_origin_explore">Explorar</string>
-    <string name="app_search_origin_home_and_favorites">Inicio · Favoritos</string>
+    <string name="app_edit">Renombrar</string>
+    <string name="app_feedback_button_renamed">¡%1$s renombrado!</string>
+    <string name="app_pin">Destacar al inicio</string>
+    <string name="app_unpin">Quitar destacado</string>
+    <string name="app_pinned">Destacado</string>
+    <string name="app_delete">Eliminar</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,9 +8,6 @@
 <string name="app_feedback_generic_error_contact_support">Oops! I did it again, please contact support</string>
     <string name="app_navigation_menu_item_home">Home</string>
     <string name="app_navigation_menu_item_explore">Explore</string>
-    <string name="app_navigation_menu_item_favourites">Favorites</string>
-    <string name="app_add_to_favorites">Add to favorites</string>
-    <string name="app_remove_from_favorites">Remove from favorites</string>
     <string name="app_play">Play</string>
     <string name="app_pause">Pause</string>
     <string name="app_date_today">Today</string>
@@ -22,7 +19,10 @@
     <string name="app_search_initial_hint">Type to filter your stickers…</string>
     <string name="app_search_empty_headline">Absolute silence…</string>
     <string name="app_search_empty_subtext">This sticker doesn\'t exist yet. Your collection has a gap only you can fill.</string>
-    <string name="app_search_origin_home">Home</string>
-    <string name="app_search_origin_explore">Explore</string>
-    <string name="app_search_origin_home_and_favorites">Home · Favorites</string>
+    <string name="app_edit">Rename</string>
+    <string name="app_feedback_button_renamed">%1$s renamed!</string>
+    <string name="app_pin">Pin to top</string>
+    <string name="app_unpin">Unpin</string>
+    <string name="app_pinned">Pinned</string>
+    <string name="app_delete">Delete</string>
 </resources>

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundDaoTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundDaoTest.kt
@@ -99,4 +99,47 @@ internal class SoundDaoTest : AbstractRobolectricTest() {
 
         assertThat(result.single().isFavorite).isTrue()
     }
+
+    @Test
+    fun `savePin true is returned as isPinned by find`() {
+        dao.save(context, Sound("bell", "bell.mp3"))
+
+        dao.savePin(context, "bell", true)
+
+        assertThat(dao.find(context).single { it.name == "bell" }.isPinned).isTrue()
+    }
+
+    @Test
+    fun `savePin false overrides a previous savePin true`() {
+        dao.save(context, Sound("bell", "bell.mp3"))
+        dao.savePin(context, "bell", true)
+
+        dao.savePin(context, "bell", false)
+
+        assertThat(dao.find(context).single { it.name == "bell" }.isPinned).isFalse()
+    }
+
+    @Test
+    fun `savePin is preserved across a simulated restore`() {
+        dao.save(context, Sound("bell", "bell.mp3"))
+        dao.savePin(context, "bell", true)
+
+        val names = storage.getAll(context, "sounds.name").toSet()
+        val file = storage.get(context, "sounds.file.bell")
+        val pinned = storage.get(context, "sounds.pinned.bell")
+
+        context
+            .getSharedPreferences("my-prefs", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+
+        storage.save(context, "sounds.name", names)
+        storage.save(context, "sounds.file.bell", file)
+        storage.save(context, "sounds.pinned.bell", pinned)
+
+        val result = dao.find(context).filter { !it.isBundled() }
+
+        assertThat(result.single().isPinned).isTrue()
+    }
 }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItemTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItemTest.kt
@@ -1,0 +1,139 @@
+package com.github.barriosnahuel.vossosunboton.ui.home
+
+import android.os.Build
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeLeft
+import androidx.compose.ui.test.swipeRight
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.robolectric.annotation.Config
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+internal class SoundItemTest : AbstractRobolectricTest() {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `swipe right triggers pin callback`() {
+        var pinCallCount = 0
+        val sound = Sound("test sound", file = "test.mp3")
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                SoundItem(
+                    sound = sound,
+                    playbackProgress = null,
+                    onPlayClick = {},
+                    onSeek = {},
+                    onShareClick = {},
+                    onDelete = {},
+                    onPinClick = { pinCallCount++ },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("test sound").performTouchInput { swipeRight() }
+        composeTestRule.waitForIdle()
+
+        assertThat(pinCallCount).isEqualTo(1)
+    }
+
+    // Key regression test for rememberUpdatedState:
+    // Without it, the second swipe calls the stale closure (isPinned=false) → re-pins instead of unpinning.
+    @Test
+    fun `swipe right twice calls onPinClick with updated sound state each time`() {
+        val capturedIsPinned = mutableListOf<Boolean>()
+        var sound by mutableStateOf(Sound("test sound", file = "test.mp3"))
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                SoundItem(
+                    sound = sound,
+                    playbackProgress = null,
+                    onPlayClick = {},
+                    onSeek = {},
+                    onShareClick = {},
+                    onDelete = {},
+                    onPinClick = {
+                        capturedIsPinned.add(sound.isPinned)
+                        sound = sound.copy(isPinned = !sound.isPinned)
+                    },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("test sound").performTouchInput { swipeRight() }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("test sound").performTouchInput { swipeRight() }
+        composeTestRule.waitForIdle()
+
+        assertThat(capturedIsPinned).hasSize(2)
+        assertThat(capturedIsPinned[0]).isFalse()
+        assertThat(capturedIsPinned[1]).isTrue()
+    }
+
+    @Test
+    fun `swipe left triggers delete callback`() {
+        var deleteCallCount = 0
+        val sound = Sound("test sound", file = "test.mp3")
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                SoundItem(
+                    sound = sound,
+                    playbackProgress = null,
+                    onPlayClick = {},
+                    onSeek = {},
+                    onShareClick = {},
+                    onDelete = { deleteCallCount++ },
+                    onPinClick = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("test sound").performTouchInput { swipeLeft() }
+        composeTestRule.waitForIdle()
+
+        assertThat(deleteCallCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `bundled sound does not trigger any callback on swipe`() {
+        var pinCallCount = 0
+        var deleteCallCount = 0
+        val sound = Sound("bundled sound", rawRes = 1)
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                SoundItem(
+                    sound = sound,
+                    playbackProgress = null,
+                    onPlayClick = {},
+                    onSeek = {},
+                    onShareClick = {},
+                    onDelete = { deleteCallCount++ },
+                    onPinClick = { pinCallCount++ },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("bundled sound").performTouchInput { swipeRight() }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("bundled sound").performTouchInput { swipeLeft() }
+        composeTestRule.waitForIdle()
+
+        assertThat(pinCallCount).isEqualTo(0)
+        assertThat(deleteCallCount).isEqualTo(0)
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelSearchTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelSearchTest.kt
@@ -77,6 +77,23 @@ internal class SoundsViewModelSearchTest : AbstractRobolectricTest() {
     }
 
     @Test
+    fun `searchResults sorts pinned result first after togglePin`() {
+        val viewModel = givenAViewModel()
+        val alpha = Sound("test alpha", file = "a.mp3")
+        val beta = Sound("test beta", file = "b.mp3")
+        viewModel.injectSoundsAndAllSounds(listOf(alpha, beta))
+        viewModel.onSearchQueryChange("test")
+
+        viewModel.togglePin(beta)
+
+        assertThat(
+            viewModel.searchResults.value
+                .first()
+                .name,
+        ).isEqualTo("test beta")
+    }
+
+    @Test
     fun `hideSearch resets query and clears results`() {
         val viewModel = givenAViewModel()
         viewModel.injectAllSounds(listOf(Sound("Bromas de oficina", rawRes = 1)))

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelSearchTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelSearchTest.kt
@@ -49,18 +49,18 @@ internal class SoundsViewModelSearchTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `searchResults reflects a favorite toggled while overlay is open`() {
+    fun `searchResults reflects a pin toggled while overlay is open`() {
         val viewModel = givenAViewModel()
         val sound = Sound("custom sound", file = "custom.mp3")
         viewModel.injectSoundsAndAllSounds(listOf(sound))
         viewModel.onSearchQueryChange("custom")
 
-        viewModel.toggleFavorite(sound)
+        viewModel.togglePin(sound)
 
         assertThat(
             viewModel.searchResults.value
                 .single { it.name == "custom sound" }
-                .isFavorite,
+                .isPinned,
         ).isTrue()
     }
 

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
@@ -270,6 +270,24 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
     }
 
     @Test
+    fun `togglePin twice returns sound to its original date-sorted position`() {
+        val viewModel = givenAViewModel()
+        val alpha = Sound(name = "alpha", file = "a.mp3", rawRes = 0, isPlaying = false, dateAdded = 2000L)
+        val beta = Sound(name = "beta", file = "b.mp3", rawRes = 0, isPlaying = false, dateAdded = 1000L)
+        viewModel.injectSounds(listOf(alpha, beta))
+
+        viewModel.togglePin(beta)
+        val pinnedBeta = viewModel.sounds.value.single { it.name == "beta" }
+        viewModel.togglePin(pinnedBeta)
+
+        assertThat(
+            viewModel.sounds.value
+                .first()
+                .name,
+        ).isEqualTo("alpha")
+    }
+
+    @Test
     fun `deleteSound stops playback and removes sound even when passed a stale copy with isPlaying false`() {
         every { PlayerControllerFactory.instance.stopPlayingSound() } answers { nothing }
         val viewModel = givenAViewModel()

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
@@ -205,32 +205,32 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `toggleFavorite marks a sound as favorite`() {
+    fun `togglePin marks a sound as pinned`() {
         val viewModel = givenAViewModel()
         val sound = Sound("test", file = "test.mp3")
         viewModel.injectSounds(listOf(sound))
 
-        viewModel.toggleFavorite(sound)
+        viewModel.togglePin(sound)
 
         assertThat(
             viewModel.sounds.value
                 .single { it.name == "test" }
-                .isFavorite,
+                .isPinned,
         ).isTrue()
     }
 
     @Test
-    fun `toggleFavorite on a favorite sound removes it from favorites`() {
+    fun `togglePin on a pinned sound unpins it`() {
         val viewModel = givenAViewModel()
-        val sound = Sound("test", "test.mp3", 0, false, isFavorite = true)
+        val sound = Sound("test", "test.mp3", 0, false, isPinned = true)
         viewModel.injectSounds(listOf(sound))
 
-        viewModel.toggleFavorite(sound)
+        viewModel.togglePin(sound)
 
         assertThat(
             viewModel.sounds.value
                 .single { it.name == "test" }
-                .isFavorite,
+                .isPinned,
         ).isFalse()
     }
 
@@ -254,15 +254,19 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
         }
 
     @Test
-    fun `toggleFavorite in FAVORITES tab removes unfavorited sound from list`() {
+    fun `togglePin moves pinned sound to top of list`() {
         val viewModel = givenAViewModel()
-        val sound = Sound("test", "test.mp3", 0, false, isFavorite = true)
-        viewModel.injectSounds(listOf(sound))
-        viewModel.selectTab(AppTab.FAVORITES)
+        val sound1 = Sound(name = "alpha", file = "a.mp3", rawRes = 0, isPlaying = false, dateAdded = 2000L)
+        val sound2 = Sound(name = "beta", file = "b.mp3", rawRes = 0, isPlaying = false, dateAdded = 1000L)
+        viewModel.injectSounds(listOf(sound1, sound2))
 
-        viewModel.toggleFavorite(sound)
+        viewModel.togglePin(sound2)
 
-        assertThat(viewModel.sounds.value.none { it.name == "test" }).isTrue()
+        assertThat(
+            viewModel.sounds.value
+                .first()
+                .name,
+        ).isEqualTo("beta")
     }
 
     @Test
@@ -286,7 +290,7 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
         val sound = viewModel.sounds.value.first()
 
         viewModel.deleteSound(sound)
-        viewModel.selectTab(AppTab.FAVORITES)
+        viewModel.selectTab(AppTab.HOME)
         viewModel.selectTab(AppTab.EXPLORE)
 
         assertThat(viewModel.sounds.value.none { it.name == sound.name }).isTrue()
@@ -300,7 +304,7 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
             val playingSound = viewModel.sounds.value.first()
 
             viewModel.onPlayerStart(playingSound, durationMs = 1000)
-            viewModel.selectTab(AppTab.FAVORITES)
+            viewModel.selectTab(AppTab.HOME)
             viewModel.selectTab(AppTab.EXPLORE)
 
             assertThat(

--- a/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivity.kt
+++ b/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivity.kt
@@ -10,6 +10,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.ui.home.LandingActivity
 import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
 
@@ -17,6 +18,12 @@ class AddButtonActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge(statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT))
         super.onCreate(savedInstanceState)
+
+        val editSoundName = intent.getStringExtra(LandingActivity.EXTRA_EDIT_SOUND_NAME)
+        if (editSoundName != null) {
+            launchEditAddButtonMode(editSoundName)
+            return
+        }
 
         val uri: Uri? =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -30,25 +37,58 @@ class AddButtonActivity : ComponentActivity() {
             finish()
             return
         }
+        launchCreateAddButtonMode(uri)
+    }
 
+    private fun launchEditAddButtonMode(soundName: String) {
+        val file = intent.getStringExtra(LandingActivity.EXTRA_EDIT_SOUND_FILE)
+        val isFavorite = intent.getBooleanExtra(LandingActivity.EXTRA_EDIT_SOUND_FAVORITE, false)
+        val dateAddedRaw = intent.getLongExtra(LandingActivity.EXTRA_EDIT_SOUND_DATE_ADDED, 0L)
+        val sound = Sound(soundName, file, 0, false, isFavorite, if (dateAddedRaw > 0L) dateAddedRaw else null)
         setContent {
             AppTheme {
                 AddButtonScreen(
                     context = this,
-                    uri = uri,
-                    onSaved = { name ->
-                        startActivity(
-                            Intent(this, LandingActivity::class.java).apply {
-                                flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
-                                putExtra(LandingActivity.EXTRA_BUTTON_SAVED, true)
-                                putExtra(LandingActivity.EXTRA_BUTTON_NAME, name)
-                            },
-                        )
-                        finishAndRemoveTask()
-                    },
+                    mode = AddButtonMode.Edit(sound),
+                    onSaved = { name -> navigateBackRenamed(name) },
                     onNavigateUp = { finish() },
                 )
             }
         }
+    }
+
+    private fun launchCreateAddButtonMode(uri: Uri) {
+        setContent {
+            AppTheme {
+                AddButtonScreen(
+                    context = this,
+                    mode = AddButtonMode.Create(uri),
+                    onSaved = { name -> navigateBackSaved(name) },
+                    onNavigateUp = { finish() },
+                )
+            }
+        }
+    }
+
+    private fun navigateBackSaved(name: String) {
+        startActivity(
+            Intent(this, LandingActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+                putExtra(LandingActivity.EXTRA_BUTTON_SAVED, true)
+                putExtra(LandingActivity.EXTRA_BUTTON_NAME, name)
+            },
+        )
+        finishAndRemoveTask()
+    }
+
+    private fun navigateBackRenamed(name: String) {
+        startActivity(
+            Intent(this, LandingActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+                putExtra(LandingActivity.EXTRA_BUTTON_RENAMED, true)
+                putExtra(LandingActivity.EXTRA_BUTTON_NAME, name)
+            },
+        )
+        finishAndRemoveTask()
     }
 }

--- a/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
+++ b/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
@@ -17,20 +17,18 @@ import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.io.IOException
 
-/**
- * Actually persists the button into storage.
- */
 interface AddButtonFeature {
-    /**
-     * @param context The execution context.
-     * @param name Name of the button.
-     * @param uri Sound's location.
-     */
     fun saveNewButtonAsync(
         context: @NotNull Context,
         name: String,
         uri: String,
     ): Deferred<Int>
+
+    fun renameButtonAsync(
+        context: @NotNull Context,
+        sound: Sound,
+        newName: String,
+    ): Deferred<Unit>
 
     companion object {
         val instance: AddButtonFeature by lazy { AddButtonFeatureImpl() }
@@ -70,6 +68,17 @@ private class AddButtonFeatureImpl : AddButtonFeature {
             }
 
             feedbackMessage
+        }
+    }
+
+    override fun renameButtonAsync(
+        context: Context,
+        sound: Sound,
+        newName: String,
+    ): Deferred<Unit> {
+        @OptIn(DelicateCoroutinesApi::class)
+        return GlobalScope.async(Dispatchers.IO) {
+            SoundDao().rename(context, sound, newName)
         }
     }
 }

--- a/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonMode.kt
+++ b/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonMode.kt
@@ -1,0 +1,14 @@
+package com.github.barriosnahuel.vossosunboton.feature.addbutton
+
+import android.net.Uri
+import com.github.barriosnahuel.vossosunboton.model.Sound
+
+sealed class AddButtonMode {
+    data class Create(
+        val uri: Uri,
+    ) : AddButtonMode()
+
+    data class Edit(
+        val sound: Sound,
+    ) : AddButtonMode()
+}

--- a/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
+++ b/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
@@ -1,7 +1,7 @@
 package com.github.barriosnahuel.vossosunboton.feature.addbutton
 
 import android.content.Context
-import android.net.Uri
+import android.media.MediaPlayer
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -14,40 +14,55 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
+import com.github.barriosnahuel.vossosunboton.commons.file.getFile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.io.IOException
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddButtonScreen(
     context: Context,
-    uri: Uri,
+    mode: AddButtonMode,
     onSaved: (String) -> Unit,
     onNavigateUp: () -> Unit,
 ) {
-    var name by remember { mutableStateOf("") }
+    var name by remember {
+        mutableStateOf(if (mode is AddButtonMode.Edit) mode.sound.name else "")
+    }
     var nameError by remember { mutableStateOf<String?>(null) }
     val coroutineScope = rememberCoroutineScope()
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -59,13 +74,18 @@ fun AddButtonScreen(
         }
         keyboardController?.hide()
         coroutineScope.launch {
-            AddButtonFeature.instance.saveNewButtonAsync(context, name.trim(), uri.toString()).await()
+            when (val m = mode) {
+                is AddButtonMode.Create ->
+                    AddButtonFeature.instance.saveNewButtonAsync(context, name.trim(), m.uri.toString()).await()
+                is AddButtonMode.Edit ->
+                    AddButtonFeature.instance.renameButtonAsync(context, m.sound, name.trim()).await()
+            }
             withContext(Dispatchers.Main) { onSaved(name.trim()) }
         }
     }
 
     Scaffold(
-        topBar = { AddButtonTopBar(onNavigateUp) },
+        topBar = { AddButtonTopBar(mode = mode, onNavigateUp = onNavigateUp) },
     ) { innerPadding ->
         Column(
             modifier =
@@ -74,13 +94,29 @@ fun AddButtonScreen(
                     .padding(innerPadding)
                     .padding(horizontal = 16.dp, vertical = 8.dp),
         ) {
+            val editFile = (mode as? AddButtonMode.Edit)?.sound?.file
+            if (editFile != null) {
+                AudioPreview(context = context, fileName = editFile, soundName = name)
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+
             OutlinedTextField(
                 value = name,
                 onValueChange = {
                     name = it.take(MAX_NAME_LENGTH)
                     nameError = null
                 },
-                label = { Text(stringResource(R.string.feature_addbutton_name)) },
+                label = {
+                    Text(
+                        stringResource(
+                            if (mode is AddButtonMode.Edit) {
+                                R.string.feature_addbutton_edit_name_label
+                            } else {
+                                R.string.feature_addbutton_name
+                            },
+                        ),
+                    )
+                },
                 placeholder = { Text(stringResource(R.string.feature_addbutton_placeholder)) },
                 isError = nameError != null,
                 supportingText = {
@@ -108,7 +144,111 @@ fun AddButtonScreen(
                 onClick = { save() },
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                Text(stringResource(R.string.feature_addbutton_save))
+                Text(
+                    stringResource(
+                        if (mode is AddButtonMode.Edit) {
+                            R.string.feature_addbutton_save_changes
+                        } else {
+                            R.string.feature_addbutton_save
+                        },
+                    ),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AudioPreview(
+    context: Context,
+    fileName: String,
+    soundName: String,
+) {
+    var isPlaying by remember { mutableStateOf(false) }
+    var sliderPosition by remember { mutableFloatStateOf(0f) }
+    val player = remember { MediaPlayer() }
+    var isReady by remember { mutableStateOf(false) }
+    var durationMs by remember { mutableStateOf(0) }
+
+    DisposableEffect(fileName) {
+        try {
+            val file = getFile(context, fileName)
+            player.setDataSource(file.absolutePath)
+            player.prepare()
+            durationMs = player.duration
+            player.setOnCompletionListener {
+                isPlaying = false
+                sliderPosition = 0f
+            }
+            isReady = true
+        } catch (e: IOException) {
+            Timber.w(e, "Could not load audio preview for file: %s", fileName)
+        } catch (e: IllegalStateException) {
+            Timber.w(e, "MediaPlayer in invalid state for file: %s", fileName)
+        }
+        onDispose {
+            player.release()
+        }
+    }
+
+    if (isReady) {
+        Card(
+            colors =
+                CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                ),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp, vertical = 8.dp),
+            ) {
+                Text(
+                    text = soundName,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(horizontal = 4.dp),
+                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.Top,
+                ) {
+                    IconButton(
+                        onClick = {
+                            if (isPlaying) {
+                                player.pause()
+                                isPlaying = false
+                            } else {
+                                player.start()
+                                isPlaying = true
+                            }
+                        },
+                    ) {
+                        Icon(
+                            imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                            contentDescription = stringResource(R.string.feature_addbutton_preview_audio),
+                        )
+                    }
+                    Slider(
+                        value = sliderPosition,
+                        onValueChange = { value ->
+                            sliderPosition = value
+                            if (durationMs > 0) player.seekTo((value * durationMs).toInt())
+                        },
+                        enabled = isPlaying,
+                        colors =
+                            SliderDefaults.colors(
+                                inactiveTrackColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.24f),
+                                disabledInactiveTrackColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.24f),
+                                disabledThumbColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.24f),
+                                disabledActiveTrackColor = MaterialTheme.colorScheme.primary,
+                            ),
+                        modifier = Modifier.weight(1f),
+                    )
+                }
             }
         }
     }
@@ -118,7 +258,10 @@ private const val MAX_NAME_LENGTH = 50
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun AddButtonTopBar(onNavigateUp: () -> Unit) {
+private fun AddButtonTopBar(
+    mode: AddButtonMode,
+    onNavigateUp: () -> Unit,
+) {
     // Light mode: primary (#5B21B6 deep violet) — dark bar, white title.
     // Dark mode:  primaryContainer (#4A0A96 deep violet) — dark bar, lavender title.
     val isDark = isSystemInDarkTheme()
@@ -127,7 +270,17 @@ private fun AddButtonTopBar(onNavigateUp: () -> Unit) {
     val barContentColor =
         if (isDark) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onPrimary
     TopAppBar(
-        title = { Text(stringResource(R.string.feature_addbutton_activity_title)) },
+        title = {
+            Text(
+                stringResource(
+                    if (mode is AddButtonMode.Edit) {
+                        R.string.feature_addbutton_activity_title_edit
+                    } else {
+                        R.string.feature_addbutton_activity_title
+                    },
+                ),
+            )
+        },
         navigationIcon = {
             IconButton(onClick = onNavigateUp) {
                 Icon(

--- a/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
+++ b/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -46,6 +45,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.github.barriosnahuel.vossosunboton.commons.file.getFile
+import com.github.barriosnahuel.vossosunboton.ui.AppIcons
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -228,7 +228,7 @@ private fun AudioPreview(
                         },
                     ) {
                         Icon(
-                            imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                            imageVector = if (isPlaying) AppIcons.Pause else Icons.Default.PlayArrow,
                             contentDescription = stringResource(R.string.feature_addbutton_preview_audio),
                         )
                     }

--- a/feature_addbutton/src/main/res/values-es/strings.xml
+++ b/feature_addbutton/src/main/res/values-es/strings.xml
@@ -6,4 +6,8 @@
     <string name="feature_addbutton_name_is_required_error">El nombre es obligatorio</string>
     <string name="feature_addbutton_feedback_saved_ok">Guardado</string>
     <string name="feature_addbutton_activity_title">Nuevo botón</string>
+    <string name="feature_addbutton_activity_title_edit">Editar botón</string>
+    <string name="feature_addbutton_save_changes">Guardar cambios</string>
+    <string name="feature_addbutton_edit_name_label">Actualizar el nombre</string>
+    <string name="feature_addbutton_preview_audio">Vista previa del audio</string>
 </resources>

--- a/feature_addbutton/src/main/res/values/strings.xml
+++ b/feature_addbutton/src/main/res/values/strings.xml
@@ -6,4 +6,8 @@
     <string name="feature_addbutton_name_is_required_error">Name is required</string>
     <string name="feature_addbutton_feedback_saved_ok">Saved!</string>
     <string name="feature_addbutton_activity_title">New button</string>
+    <string name="feature_addbutton_activity_title_edit">Edit button</string>
+    <string name="feature_addbutton_save_changes">Save changes</string>
+    <string name="feature_addbutton_edit_name_label">Update the name</string>
+    <string name="feature_addbutton_preview_audio">Preview audio</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,7 @@ compose-ui-tooling                = { module = "androidx.compose.ui:ui-tooling" 
 compose-ui-test-manifest          = { module = "androidx.compose.ui:ui-test-manifest" }
 compose-material3                 = { module = "androidx.compose.material3:material3" }
 compose-material-icons-extended   = { module = "androidx.compose.material:material-icons-extended" }
+compose-ui-test-junit4            = { module = "androidx.compose.ui:ui-test-junit4" }
 
 # ---------- Lifecycle ----------
 lifecycle-viewmodel-compose       = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleCompose" }

--- a/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/Sound.kt
+++ b/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/Sound.kt
@@ -12,6 +12,7 @@ data class Sound(
     val isPlaying: Boolean,
     val isFavorite: Boolean = false,
     val dateAdded: Long? = null,
+    val isPinned: Boolean = false,
 ) {
     constructor(name: String, file: String?) : this(name, file, 0, false, false)
     constructor(

--- a/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundDao.java
+++ b/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundDao.java
@@ -25,6 +25,7 @@ public class SoundDao {
     private static final String SOUNDS_NAME = "sounds.name";
     private static final String SOUNDS_FILE_NAME_PREFFIX = "sounds.file.";
     private static final String SOUNDS_FAVORITE_PREFFIX = "sounds.favorite.";
+    private static final String SOUNDS_PINNED_PREFIX = "sounds.pinned.";
     private final Storage storage;
 
     /**
@@ -57,9 +58,10 @@ public class SoundDao {
         for (final String eachSoundName : names) {
             final String fileName = storage.get(context, SOUNDS_FILE_NAME_PREFFIX + eachSoundName);
             final boolean isFavorite = "true".equals(storage.get(context, SOUNDS_FAVORITE_PREFFIX + eachSoundName));
+            final boolean isPinned = "true".equals(storage.get(context, SOUNDS_PINNED_PREFIX + eachSoundName));
             final java.io.File soundFile = fileName != null ? FileUtils.getFile(context, fileName) : null;
             final Long dateAdded = (soundFile != null && soundFile.exists()) ? soundFile.lastModified() : null;
-            sounds.add(new Sound(eachSoundName, fileName, 0, false, isFavorite, dateAdded));
+            sounds.add(new Sound(eachSoundName, fileName, 0, false, isFavorite, dateAdded, isPinned));
         }
 
         sounds.addAll(PackagedAudios.get(context));
@@ -74,6 +76,10 @@ public class SoundDao {
      */
     public void saveFavorite(final Context context, final String soundName, final boolean isFavorite) {
         storage.save(context, SOUNDS_FAVORITE_PREFFIX + soundName, String.valueOf(isFavorite));
+    }
+
+    public void savePin(final Context context, final String soundName, final boolean isPinned) {
+        storage.save(context, SOUNDS_PINNED_PREFIX + soundName, String.valueOf(isPinned));
     }
 
     /**
@@ -96,11 +102,44 @@ public class SoundDao {
             deleteButtonKey(context, sound.getName());
             deleteButtonKeyFileMapping(context, sound.getName());
             storage.remove(context, SOUNDS_FAVORITE_PREFFIX + sound.getName());
+            storage.remove(context, SOUNDS_PINNED_PREFIX + sound.getName());
         } else {
             Timber.e("Button could NOT be deleted. Button: %s", sound.getName());
         }
 
         return deleted;
+    }
+
+    /**
+     * Renames a custom sound while preserving its file and favorite status.
+     *
+     * @param context  The execution context.
+     * @param sound    The sound to rename (its current name and file are used as source).
+     * @param newName  The new display name.
+     */
+    public void rename(final Context context, final Sound sound, final String newName) {
+        final Set<String> names = storage.getAll(context, SOUNDS_NAME);
+        names.remove(sound.getName());
+        names.add(newName);
+        storage.save(context, SOUNDS_NAME, names);
+
+        final String file = sound.getFile();
+        storage.remove(context, SOUNDS_FILE_NAME_PREFFIX + sound.getName());
+        if (file != null) {
+            storage.save(context, SOUNDS_FILE_NAME_PREFFIX + newName, file);
+        }
+
+        final String favoriteValue = storage.get(context, SOUNDS_FAVORITE_PREFFIX + sound.getName());
+        storage.remove(context, SOUNDS_FAVORITE_PREFFIX + sound.getName());
+        if (favoriteValue != null) {
+            storage.save(context, SOUNDS_FAVORITE_PREFFIX + newName, favoriteValue);
+        }
+
+        final String pinnedValue = storage.get(context, SOUNDS_PINNED_PREFIX + sound.getName());
+        storage.remove(context, SOUNDS_PINNED_PREFIX + sound.getName());
+        if (pinnedValue != null) {
+            storage.save(context, SOUNDS_PINNED_PREFIX + newName, pinnedValue);
+        }
     }
 
     private void deleteButtonKey(final @NonNull Context context, final @NonNull String name) {


### PR DESCRIPTION
### Summary
- Replaces the Favorites tab with a 2-tab layout (Home + Explore); custom sounds can be pinned to the top via swipe-right or long-press menu
- Swipe-right pins/unpins (green background, CONFIRM haptic), swipe-left deletes (error color, REJECT haptic); 35% positional threshold; three subtle bugs fixed — stale closure (`rememberUpdatedState`), wrong observable (`settledValue` vs `currentValue`), animated reset racing the list reorder (`snapTo` vs `reset`)
- 9 new tests: `SoundDao` savePin persistence (3), ViewModel pin sort round-trip (1), search pin ordering (1), and 4 Compose UI swipe tests including the key `rememberUpdatedState` regression guard
- `PushPin` added to `AppIcons` as a hand-crafted vector to replace the icon removed in the M3 extended icons migration

### Code review tips
- `SoundItem.kt` — the `LaunchedEffect(Unit)` + `snapshotFlow { dismissState.settledValue }` + `rememberUpdatedState` trio is load-bearing; removing any part re-introduces one of the three gesture bugs
- `SoundsViewModel.recomputeSearchResults` — now sorts pinned items first within search results (same ordering as the main list)
- `SoundItemTest` — test 2 (`swipe right twice`) is the regression guard for the stale closure bug; if `rememberUpdatedState` is ever removed, this test fails immediately

### Already tested
- [x] Pin/unpin via swipe and long-press menu on a physical device
- [x] Full test suite (`./gradlew test`) — all passing locally
- [x] Linters (`./gradlew check -x test`) — clean

Closes #1060