### PR TITLE
UI polish: preview card layout, duration/date, spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 ### Changed
 - Edit screen audio preview now shows total duration and date added, matching the home card layout
 - Normalized top-bar-to-content spacing to 16 dp across all screens
-- Search FAB now uses the secondary (rose) color to visually stand apart from the cards
 
 ### Added
 - Swipe right on any custom sound to pin/favorite it (PrimaryContainer background); swipe left to delete (ErrorContainer background) — replaces the old single-direction swipe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][], and this project adheres to [Semantic Versioning][].
 
 ## \[unreleased] (v2.0.0)
+### Changed
+- Edit screen audio preview now shows total duration and date added, matching the home card layout
+- Normalized top-bar-to-content spacing to 16 dp across all screens
+- Search FAB now uses the secondary (rose) color to visually stand apart from the cards
+
 ### Added
 - Swipe right on any custom sound to pin/favorite it (PrimaryContainer background); swipe left to delete (ErrorContainer background) — replaces the old single-direction swipe
 - Edit custom sounds: long-press any card to rename it; the existing audio stays, only the name changes

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/DurationFormatter.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/DurationFormatter.kt
@@ -1,9 +1,16 @@
 package com.github.barriosnahuel.vossosunboton.ui.home
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalResources
+import androidx.compose.ui.res.stringResource
+import com.github.barriosnahuel.vossosunboton.R
+import java.text.SimpleDateFormat
 import java.util.Calendar
+import java.util.Date
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 
-internal fun formatDuration(ms: Int): String {
+fun formatDuration(ms: Int): String {
     val totalSeconds = TimeUnit.MILLISECONDS.toSeconds(ms.toLong())
     val minutes = totalSeconds / SECONDS_PER_MINUTE
     val seconds = totalSeconds % SECONDS_PER_MINUTE
@@ -20,6 +27,27 @@ internal fun startOfDay(epochMs: Long): Long =
         set(Calendar.MILLISECOND, 0)
         timeInMillis
     }
+
+fun relativeDateDays(
+    epochMs: Long,
+    nowMs: Long = System.currentTimeMillis(),
+): Long {
+    val today = startOfDay(nowMs)
+    val dateDay = startOfDay(epochMs)
+    return TimeUnit.MILLISECONDS.toDays(today - dateDay)
+}
+
+@Composable
+fun formatRelativeDate(epochMs: Long): String {
+    val diffDays = relativeDateDays(epochMs)
+    val resources = LocalResources.current
+    return when {
+        diffDays == 0L -> stringResource(R.string.app_date_today)
+        diffDays == 1L -> stringResource(R.string.app_date_yesterday)
+        diffDays < RELATIVE_DATE_MAX_DAYS -> resources.getQuantityString(R.plurals.app_date_days_ago, diffDays.toInt(), diffDays.toInt())
+        else -> SimpleDateFormat("d MMM", Locale.getDefault()).format(Date(epochMs))
+    }
+}
 
 internal const val RELATIVE_DATE_MAX_DAYS = 7L
 private const val SECONDS_PER_MINUTE = 60L

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -260,7 +260,7 @@ private fun SoundsList(
     Box(modifier = modifier.fillMaxSize()) {
         LazyColumn(
             state = listState,
-            contentPadding = PaddingValues(vertical = 8.dp),
+            contentPadding = PaddingValues(top = 12.dp, bottom = 8.dp),
         ) {
             itemsIndexed(sounds, key = { _, sound -> sound.name }) { _, sound ->
                 val isDeleting = sound.name in dismissingItems

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
@@ -44,7 +44,6 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -52,10 +51,6 @@ import androidx.compose.ui.unit.dp
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.ui.AppIcons
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
-import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -372,20 +367,6 @@ private fun SoundCardHeader(
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun formatRelativeDate(epochMs: Long): String {
-    val today = startOfDay(System.currentTimeMillis())
-    val dateDay = startOfDay(epochMs)
-    val diffDays = TimeUnit.MILLISECONDS.toDays(today - dateDay)
-    val resources = LocalResources.current
-    return when {
-        diffDays == 0L -> stringResource(R.string.app_date_today)
-        diffDays == 1L -> stringResource(R.string.app_date_yesterday)
-        diffDays < RELATIVE_DATE_MAX_DAYS -> resources.getQuantityString(R.plurals.app_date_days_ago, diffDays.toInt(), diffDays.toInt())
-        else -> SimpleDateFormat("d MMM", Locale.getDefault()).format(Date(epochMs))
     }
 }
 

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/DurationFormatterTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/DurationFormatterTest.kt
@@ -2,6 +2,7 @@ package com.github.barriosnahuel.vossosunboton.ui.home
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
+import java.util.concurrent.TimeUnit
 
 internal class DurationFormatterTest {
     @Test
@@ -22,5 +23,32 @@ internal class DurationFormatterTest {
     @Test
     fun `formatDuration 3723000 ms returns 62 colon 03`() {
         assertThat(formatDuration(3_723_000)).isEqualTo("62:03")
+    }
+
+    @Test
+    fun `relativeDateDays returns 0 for same day`() {
+        val now = System.currentTimeMillis()
+        assertThat(relativeDateDays(now, nowMs = now)).isEqualTo(0L)
+    }
+
+    @Test
+    fun `relativeDateDays returns 1 for yesterday`() {
+        val now = System.currentTimeMillis()
+        val yesterday = now - TimeUnit.DAYS.toMillis(1)
+        assertThat(relativeDateDays(yesterday, nowMs = now)).isEqualTo(1L)
+    }
+
+    @Test
+    fun `relativeDateDays returns 3 for three days ago`() {
+        val now = System.currentTimeMillis()
+        val threeDaysAgo = now - TimeUnit.DAYS.toMillis(3)
+        assertThat(relativeDateDays(threeDaysAgo, nowMs = now)).isEqualTo(3L)
+    }
+
+    @Test
+    fun `relativeDateDays returns 10 for ten days ago`() {
+        val now = System.currentTimeMillis()
+        val tenDaysAgo = now - TimeUnit.DAYS.toMillis(10)
+        assertThat(relativeDateDays(tenDaysAgo, nowMs = now)).isEqualTo(10L)
     }
 }

--- a/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
+++ b/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
@@ -94,7 +94,7 @@ fun AddButtonScreen(
                 Modifier
                     .fillMaxSize()
                     .padding(innerPadding)
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                    .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 8.dp),
         ) {
             val editSound = (mode as? AddButtonMode.Edit)?.sound
             val editFile = editSound?.file

--- a/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
+++ b/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
@@ -46,6 +46,8 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.github.barriosnahuel.vossosunboton.commons.file.getFile
 import com.github.barriosnahuel.vossosunboton.ui.AppIcons
+import com.github.barriosnahuel.vossosunboton.ui.home.formatDuration
+import com.github.barriosnahuel.vossosunboton.ui.home.formatRelativeDate
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -94,9 +96,15 @@ fun AddButtonScreen(
                     .padding(innerPadding)
                     .padding(horizontal = 16.dp, vertical = 8.dp),
         ) {
-            val editFile = (mode as? AddButtonMode.Edit)?.sound?.file
+            val editSound = (mode as? AddButtonMode.Edit)?.sound
+            val editFile = editSound?.file
             if (editFile != null) {
-                AudioPreview(context = context, fileName = editFile, soundName = name)
+                AudioPreview(
+                    context = context,
+                    fileName = editFile,
+                    soundName = name,
+                    dateAdded = editSound.dateAdded,
+                )
                 Spacer(modifier = Modifier.height(16.dp))
             }
 
@@ -163,6 +171,7 @@ private fun AudioPreview(
     context: Context,
     fileName: String,
     soundName: String,
+    dateAdded: Long?,
 ) {
     var isPlaying by remember { mutableStateOf(false) }
     var sliderPosition by remember { mutableFloatStateOf(0f) }
@@ -232,22 +241,37 @@ private fun AudioPreview(
                             contentDescription = stringResource(R.string.feature_addbutton_preview_audio),
                         )
                     }
-                    Slider(
-                        value = sliderPosition,
-                        onValueChange = { value ->
-                            sliderPosition = value
-                            if (durationMs > 0) player.seekTo((value * durationMs).toInt())
-                        },
-                        enabled = isPlaying,
-                        colors =
-                            SliderDefaults.colors(
-                                inactiveTrackColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.24f),
-                                disabledInactiveTrackColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.24f),
-                                disabledThumbColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.24f),
-                                disabledActiveTrackColor = MaterialTheme.colorScheme.primary,
-                            ),
-                        modifier = Modifier.weight(1f),
-                    )
+                    Column(modifier = Modifier.weight(1f)) {
+                        Slider(
+                            value = sliderPosition,
+                            onValueChange = { value ->
+                                sliderPosition = value
+                                if (durationMs > 0) player.seekTo((value * durationMs).toInt())
+                            },
+                            enabled = isPlaying,
+                            colors =
+                                SliderDefaults.colors(
+                                    inactiveTrackColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.24f),
+                                    disabledInactiveTrackColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.24f),
+                                    disabledThumbColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.24f),
+                                    disabledActiveTrackColor = MaterialTheme.colorScheme.primary,
+                                ),
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        Row(modifier = Modifier.fillMaxWidth()) {
+                            Text(
+                                text = formatDuration(durationMs),
+                                style = MaterialTheme.typography.labelSmall,
+                            )
+                            Spacer(modifier = Modifier.weight(1f))
+                            if (dateAdded != null) {
+                                Text(
+                                    text = formatRelativeDate(dateAdded),
+                                    style = MaterialTheme.typography.labelSmall,
+                                )
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Summary
- Audio preview card in edit screen now shows **total duration** (left) and **date added** (right) below the slider, matching the home card layout exactly
- `formatRelativeDate` moved from private in `SoundItem` to public in `DurationFormatter` so `feature_addbutton` can reuse it; new `relativeDateDays()` helper is unit-tested
- Top-bar-to-content spacing normalized to **16 dp** across home and edit screens (was 12 dp on home, 8 dp on edit)

### Code review tips
- `DurationFormatter.kt` now owns both `formatDuration` and `formatRelativeDate` — both are `public` so `feature_addbutton` can import them directly
- `relativeDateDays(epochMs, nowMs)` accepts an injectable `nowMs` for deterministic unit tests — check `DurationFormatterTest` for the 4 new cases
- Spacing change in `LandingScreen` is on `contentPadding.top` (12 dp), not the card margin (4 dp stays); together they produce 16 dp visual gap

### Already tested
- [x] `./gradlew check -x test && ./gradlew test` — all linters and unit tests green
- [x] `app:installDebug` — manually verified preview card shows duration and date, spacing looks consistent

Closes #