### PR TITLE
feat: Neo-Club ink × acid design system + WCAG contrast tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 ### Changed
 - Edit screen audio preview now shows total duration and date added, matching the home card layout
 - Normalized top-bar-to-content spacing to 16 dp across all screens
+- Replaced the old violet/rose/amber palette with the Neo-Club ink × acid design system across all screens (top bars, cards, FAB, search, swipe actions)
 
 ### Added
 - Swipe right on any custom sound to pin/favorite it (PrimaryContainer background); swipe left to delete (ErrorContainer background) — replaces the old single-direction swipe

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,46 @@ All UI development and generated assets (store listing, What's New, changelogs) 
 - **Touch targets (2.5.8):** Minimum 24 × 24 dp; prefer 48 × 48 dp for primary actions
 - **Labels match names (2.5.3):** Visible button/field labels must match the accessible name used by screen readers
 
-Verify contrast when adding or changing colors. Use the [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/) or the Material Theme Builder. The brand palette in `AppTheme.kt` was designed to meet AA across all color roles.
+Verify contrast when adding or changing colors. Use the [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/) or the Material Theme Builder. The brand palette in `AppTheme.kt` was designed to meet AA across all color roles. **All critical role pairs are automatically verified by `AppThemeContrastTest`** — if you change the palette and a test fails, fix the theme, not the test.
+
+## Design system
+
+The app uses the **Neo-Club** palette (ink × acid). Single source of truth: `app/src/main/java/…/ui/theme/AppTheme.kt`.
+
+### Palette
+
+| Token | Value | Notes |
+|---|---|---|
+| `Ink1000` | `#0B0B0C` | Near-black; dark bg, top-bar backgrounds |
+| `Ink900` | `#141415` | Card/nav bg in dark mode |
+| `Ink800` | `#1C1C1D` | Snackbar bg in light mode |
+| `Ink50` | `#F1F0EA` | Card/nav bg in light mode |
+| `Paper` | `#FAFAF7` | Bone-white; light bg, top-bar text |
+| `Acid400` | `#D7FF3A` | Signal yellow-green; all filled actions |
+| `AcidDark` | `#3E5400` | Acid darkened for text on light surfaces |
+| `Blood600` | `#C72C2F` | Destructive (light error, dark errorContainer) |
+
+### Semantic role → intent mapping
+
+| Role | Light | Dark | Used for |
+|---|---|---|---|
+| `primary` | AcidDark | Acid400 | Nav text, active labels |
+| `primaryContainer` | Acid400 | Acid400 | FAB, buttons, swipe-pin bg, search accent |
+| `onPrimaryContainer` | Ink1000 | Ink1000 | Text/icons on acid fills |
+| `secondary` | Ink1000 | Ink900 | Top-bar backgrounds (always dark) |
+| `onSecondary` | Paper | Paper | Top-bar title and icons |
+| `surfaceVariant` | Ink50 | Ink900 | Card backgrounds, bottom-nav background |
+| `onSurfaceVariant` | Ink500 | Ink300 | Card muted text, unselected nav icons |
+| `inverseSurface` | Ink800 | Paper | Snackbar background |
+| `inversePrimary` | Acid400 | AcidDark | Snackbar action button text |
+| `error` / `errorContainer` | Blood scale | Blood scale | Swipe-delete background, error states |
+
+### Rules for component authors
+
+- **Never add `isSystemInDarkTheme()` / `isDark` in component files.** If the same semantic role needs to look different per mode, the role mapping in `AppTheme.kt` is wrong — fix the theme, not the component.
+- **Never hardcode a color literal in a component** (e.g. `Color(0xFF2E7D32)`). Use the closest semantic role from `AppTheme.kt`.
+- **Components inside always-dark bars** (TopAppBar using `secondary`): use `primaryContainer` (= Acid400 in both modes) for accent elements like cursor, underline, and icons — not `primary`, which is AcidDark in light mode and nearly invisible on a dark bar.
+- **Adding a new color:** add the constant to `AppTheme.kt`, map it to an M3 role in both `LightColors` and `DarkColors`, then add a contrast assertion for the relevant pair in `AppThemeContrastTest`.
 
 ## Labels and milestone
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleOut
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -92,7 +91,11 @@ fun LandingScreen(viewModel: SoundsViewModel) {
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         floatingActionButton = {
-            FloatingActionButton(onClick = { viewModel.showSearch() }) {
+            FloatingActionButton(
+                onClick = { viewModel.showSearch() },
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            ) {
                 Icon(
                     imageVector = Icons.Default.Search,
                     contentDescription = stringResource(R.string.app_search),
@@ -194,16 +197,12 @@ private fun SnackbarEffects(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun AppTopBar() {
-    // Light mode: primary (#5B21B6 deep violet) — dark bar, white title.
-    // Dark mode:  primaryContainer (#4A0A96 deep violet) — dark bar, lavender title.
-    // Both are dark bars, so the status bar keeps light (white) icons in both modes.
-    val isDark = isSystemInDarkTheme()
     TopAppBar(
         title = { Text(stringResource(R.string.app_name)) },
         colors =
             TopAppBarDefaults.topAppBarColors(
-                containerColor = if (isDark) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.primary,
-                titleContentColor = if (isDark) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onPrimary,
+                containerColor = MaterialTheme.colorScheme.secondary,
+                titleContentColor = MaterialTheme.colorScheme.onSecondary,
             ),
     )
 }
@@ -215,13 +214,13 @@ private fun AppBottomBar(
 ) {
     val itemColors =
         NavigationBarItemDefaults.colors(
-            selectedIconColor = MaterialTheme.colorScheme.onPrimary,
+            selectedIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
             selectedTextColor = MaterialTheme.colorScheme.primary,
-            indicatorColor = MaterialTheme.colorScheme.primary,
-            unselectedIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
-            unselectedTextColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            indicatorColor = MaterialTheme.colorScheme.primaryContainer,
+            unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-    NavigationBar(containerColor = MaterialTheme.colorScheme.primaryContainer) {
+    NavigationBar(containerColor = MaterialTheme.colorScheme.surfaceVariant) {
         NavigationBarItem(
             colors = itemColors,
             selected = selectedTab == AppTab.HOME,

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlay.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlay.kt
@@ -106,8 +106,8 @@ fun SearchOverlay(
                     },
                     colors =
                         TopAppBarDefaults.topAppBarColors(
-                            containerColor = MaterialTheme.colorScheme.primaryContainer,
-                            navigationIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                            containerColor = MaterialTheme.colorScheme.secondary,
+                            navigationIconContentColor = MaterialTheme.colorScheme.onSecondary,
                         ),
                 )
 
@@ -197,6 +197,7 @@ private fun SearchField(
     onQueryChange: (String) -> Unit,
 ) {
     val focusRequester = remember { FocusRequester() }
+    val contentColor = MaterialTheme.colorScheme.onSecondary
 
     TextField(
         value = query,
@@ -222,8 +223,15 @@ private fun SearchField(
             TextFieldDefaults.colors(
                 focusedContainerColor = Color.Transparent,
                 unfocusedContainerColor = Color.Transparent,
-                focusedIndicatorColor = Color.Transparent,
+                focusedIndicatorColor = MaterialTheme.colorScheme.primaryContainer,
                 unfocusedIndicatorColor = Color.Transparent,
+                focusedTextColor = contentColor,
+                unfocusedTextColor = contentColor,
+                cursorColor = MaterialTheme.colorScheme.primaryContainer,
+                focusedPlaceholderColor = contentColor.copy(alpha = 0.6f),
+                unfocusedPlaceholderColor = contentColor.copy(alpha = 0.6f),
+                focusedTrailingIconColor = MaterialTheme.colorScheme.primaryContainer,
+                unfocusedTrailingIconColor = contentColor,
             ),
     )
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
@@ -43,7 +43,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -154,9 +153,17 @@ private fun SwipeActionBackground(dismissState: SwipeToDismissBoxState) {
     if (dismissState.dismissDirection == SwipeToDismissBoxValue.Settled) return
     val isPinAction = dismissState.dismissDirection == SwipeToDismissBoxValue.StartToEnd
     val backgroundColor =
-        if (isPinAction) PIN_BACKGROUND_COLOR else MaterialTheme.colorScheme.errorContainer
+        if (isPinAction) {
+            MaterialTheme.colorScheme.primaryContainer
+        } else {
+            MaterialTheme.colorScheme.errorContainer
+        }
     val iconTint =
-        if (isPinAction) Color.White else MaterialTheme.colorScheme.onErrorContainer
+        if (isPinAction) {
+            MaterialTheme.colorScheme.onPrimaryContainer
+        } else {
+            MaterialTheme.colorScheme.onErrorContainer
+        }
     val icon = if (isPinAction) AppIcons.PushPin else Icons.Default.Delete
     val alignment = if (isPinAction) Alignment.CenterStart else Alignment.CenterEnd
     Box(
@@ -211,8 +218,8 @@ private fun SoundCard(
                 ),
         colors =
             CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.primaryContainer,
-                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
             ),
     ) {
         Column(
@@ -259,9 +266,9 @@ private fun SoundCard(
                         enabled = sound.isPlaying,
                         colors =
                             SliderDefaults.colors(
-                                inactiveTrackColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.24f),
-                                disabledInactiveTrackColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.24f),
-                                disabledThumbColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.24f),
+                                inactiveTrackColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.24f),
+                                disabledInactiveTrackColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.24f),
+                                disabledThumbColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.24f),
                                 disabledActiveTrackColor = MaterialTheme.colorScheme.primary,
                             ),
                         modifier = Modifier.fillMaxWidth(),
@@ -312,7 +319,7 @@ private fun SoundCardHeader(
                 Text(
                     text = originLabel,
                     style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.6f),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
                 )
             }
         }
@@ -369,5 +376,3 @@ private fun SoundCardHeader(
         }
     }
 }
-
-private val PIN_BACKGROUND_COLOR = Color(0xFF2E7D32)

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/theme/AppTheme.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/theme/AppTheme.kt
@@ -7,123 +7,94 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 
-// Brand palette — Deep Violet + Vivid Rose + Amber. All roles verified WCAG 2.2 AA.
-// Light primaries
-private val Violet800 = Color(0xFF5B21B6) // primary light  (white: 8.1:1)
-private val Lavender100 = Color(0xFFEDE9FE) // primaryContainer light
-private val Violet950 = Color(0xFF2E0075) // onPrimaryContainer light (15:1 on Lavender100)
+// Neo-Club palette — ink × acid. WCAG 2.2 AA verified for all roles.
+// Ink scale
+private val Ink1000 = Color(0xFF0B0B0C)
+private val Ink900 = Color(0xFF141415)
+private val Ink800 = Color(0xFF1C1C1D)
+private val Ink500 = Color(0xFF5A5A55)
+private val Ink400 = Color(0xFF8A8A83)
+private val Ink300 = Color(0xFFB8B7AE)
+private val Ink100 = Color(0xFFE5E4DE)
+private val Ink50 = Color(0xFFF1F0EA)
+private val Paper = Color(0xFFFAFAF7)
 
-// Light secondaries
-private val Rose800 = Color(0xFF9D174D) // secondary light (white: 7.4:1)
-private val Rose100 = Color(0xFFFFE4E6) // secondaryContainer light
-private val Rose950 = Color(0xFF500724) // onSecondaryContainer light (11.7:1 on Rose100)
+// Acid — signal / primary action color
+private val Acid400 = Color(0xFFD7FF3A) // 15.2:1 on Ink1000; 14.2:1 on Ink900
+private val AcidDark = Color(0xFF3E5400) // 7.4:1 on Paper — for light-mode text
 
-// Light tertiaries
-private val Amber800 = Color(0xFF92400E) // tertiary light  (white: 6.3:1)
-private val Amber100 = Color(0xFFFEF3C7) // tertiaryContainer light
-private val Amber950 = Color(0xFF451A03) // onTertiaryContainer light (15:1 on Amber100)
+// Blood — destructive
+private val Blood700 = Color(0xFF9E1B1D)
+private val Blood600 = Color(0xFFC72C2F) // 5.6:1 on Paper — AA large text
+private val Blood400 = Color(0xFFF26163) // 5.4:1 on Ink1000 — AA
+private val Blood200 = Color(0xFFFBD4D5)
 
-// Light surfaces/backgrounds
-private val NearWhite = Color(0xFFFFFBFE)
-private val NearBlack = Color(0xFF1C1B1F)
-private val LavendertintedSurface = Color(0xFFE7E0EC) // surfaceVariant light
-private val DarkGray = Color(0xFF49454F) // onSurfaceVariant light (6.8:1 on LavendertintedSurface)
-
-// Light error
-private val ErrorRed = Color(0xFFB3261E)
-private val ErrorRedContainer = Color(0xFFF9DEDC) // soft pink, not vivid red
-private val ErrorRedDark = Color(0xFF410E0B)
-
-// Light outline
-private val OutlineGray = Color(0xFF79747E) // 4.1:1 on white (non-text req: 3:1)
-private val OutlineVariantGray = Color(0xFFCAC4D0)
-
-// Dark primaries
-private val LavenderLight = Color(0xFFD4BBFF) // primary dark   (12:1 on #1C1B1F)
-private val VioletDark = Color(0xFF310065) // onPrimary dark (12:1 on LavenderLight)
-private val VioletMid = Color(0xFF4A0A96) // primaryContainer dark
-
-// Dark secondaries
-private val RoseLight = Color(0xFFFFB3C6) // secondary dark (10.8:1 on dark bg)
-private val RoseDark = Color(0xFF560718) // onSecondary dark
-private val RoseMid = Color(0xFF7D1037) // secondaryContainer dark
-private val RosePale = Color(0xFFFFD9E2) // onSecondaryContainer dark
-
-// Dark tertiaries
-private val AmberLight = Color(0xFFFBBE63) // tertiary dark
-private val AmberVeryDark = Color(0xFF3E1B00) // onTertiary dark
-private val AmberMid = Color(0xFF5A2E00) // tertiaryContainer dark
-private val AmberPale = Color(0xFFFFDDB3) // onTertiaryContainer dark
-
-// Dark surfaces/backgrounds
-private val DarkSurface = Color(0xFF1C1B1F)
-private val LightOnDark = Color(0xFFE6E1E5)
-private val DarkSurfaceVariant = Color(0xFF49454F)
-private val LightOnSurfaceVariant = Color(0xFFCAC4D0) // 4.8:1 on DarkSurfaceVariant
-
-// Dark error
-private val ErrorDarkText = Color(0xFFF2B8B5)
-private val ErrorDarkOnContainer = Color(0xFF601410)
-private val ErrorDarkContainer = Color(0xFF8C1D18) // muted dark red
-private val ErrorDarkOnText = Color(0xFFF9DEDC)
-
-// Dark outline
-private val OutlineDark = Color(0xFF938F99) // 5.9:1 on dark bg
-
-private val LightColors =
+internal val LightColors =
     lightColorScheme(
-        primary = Violet800,
-        onPrimary = Color.White,
-        primaryContainer = Lavender100,
-        onPrimaryContainer = Violet950,
-        secondary = Rose800,
-        onSecondary = Color.White,
-        secondaryContainer = Rose100,
-        onSecondaryContainer = Rose950,
-        tertiary = Amber800,
-        onTertiary = Color.White,
-        tertiaryContainer = Amber100,
-        onTertiaryContainer = Amber950,
-        background = NearWhite,
-        onBackground = NearBlack,
-        surface = NearWhite,
-        onSurface = NearBlack,
-        surfaceVariant = LavendertintedSurface,
-        onSurfaceVariant = DarkGray,
-        error = ErrorRed,
-        onError = Color.White,
-        errorContainer = ErrorRedContainer,
-        onErrorContainer = ErrorRedDark,
-        outline = OutlineGray,
-        outlineVariant = OutlineVariantGray,
+        // Acid — FAB, indicators, pin action background
+        primary = AcidDark, // 7.4:1 on Paper — active labels / nav text
+        onPrimary = Paper,
+        primaryContainer = Acid400, // filled button, FAB, swipe-pin bg
+        onPrimaryContainer = Ink1000, // 14.2:1 on Acid400 — AAA
+        // Ink — always-dark top bars and navigation bar
+        secondary = Ink1000,
+        onSecondary = Paper, // 19.7:1 on Ink1000 — AAA
+        secondaryContainer = Ink100,
+        onSecondaryContainer = Ink1000,
+        // Not used in UI — mirrors primary for completeness
+        tertiary = AcidDark,
+        onTertiary = Paper,
+        tertiaryContainer = Acid400,
+        onTertiaryContainer = Ink1000,
+        background = Paper,
+        onBackground = Ink1000,
+        surface = Paper,
+        onSurface = Ink1000,
+        surfaceVariant = Ink50, // card and nav bar background
+        onSurfaceVariant = Ink500, // 6.0:1 on Ink50 — AA
+        error = Blood600, // 5.6:1 on Paper
+        onError = Paper,
+        errorContainer = Blood200,
+        onErrorContainer = Blood700,
+        outline = Ink400, // 3.3:1 on Paper — non-text ≥3:1 ✓
+        outlineVariant = Ink100,
+        inverseSurface = Ink800,
+        inverseOnSurface = Paper, // 14.7:1 on Ink800 — AAA
+        inversePrimary = Acid400, // snackbar action text; 13.5:1 on Ink800 — AAA
     )
 
-private val DarkColors =
+internal val DarkColors =
     darkColorScheme(
-        primary = LavenderLight,
-        onPrimary = VioletDark,
-        primaryContainer = VioletMid,
-        onPrimaryContainer = Lavender100,
-        secondary = RoseLight,
-        onSecondary = RoseDark,
-        secondaryContainer = RoseMid,
-        onSecondaryContainer = RosePale,
-        tertiary = AmberLight,
-        onTertiary = AmberVeryDark,
-        tertiaryContainer = AmberMid,
-        onTertiaryContainer = AmberPale,
-        background = DarkSurface,
-        onBackground = LightOnDark,
-        surface = DarkSurface,
-        onSurface = LightOnDark,
-        surfaceVariant = DarkSurfaceVariant,
-        onSurfaceVariant = LightOnSurfaceVariant,
-        error = ErrorDarkText,
-        onError = ErrorDarkOnContainer,
-        errorContainer = ErrorDarkContainer,
-        onErrorContainer = ErrorDarkOnText,
-        outline = OutlineDark,
-        outlineVariant = DarkSurfaceVariant,
+        // Acid — FAB, indicators, pin action background
+        primary = Acid400, // 15.2:1 on Ink1000 — AAA
+        onPrimary = Ink1000,
+        primaryContainer = Acid400,
+        onPrimaryContainer = Ink1000,
+        // Ink900 — slightly lighter than bg so bar is distinct without being jarring
+        secondary = Ink900,
+        onSecondary = Paper, // 18.4:1 on Ink900 — AAA
+        secondaryContainer = Ink800,
+        onSecondaryContainer = Paper,
+        // Not used in UI — mirrors primary for completeness
+        tertiary = Acid400,
+        onTertiary = Ink1000,
+        tertiaryContainer = Acid400,
+        onTertiaryContainer = Ink1000,
+        background = Ink1000,
+        onBackground = Paper,
+        surface = Ink1000,
+        onSurface = Paper,
+        surfaceVariant = Ink900, // card and nav bar background
+        onSurfaceVariant = Ink300, // 9.1:1 on Ink1000; 4.8:1 on Ink900 — AA
+        error = Blood400, // 5.4:1 on Ink1000 — AA
+        onError = Ink1000,
+        errorContainer = Blood600,
+        onErrorContainer = Paper,
+        outline = Ink400, // 5.7:1 on Ink1000 — non-text ≥3:1 ✓ (Ink700 fails at ~1.4:1, Ink500 at ~2.8:1)
+        outlineVariant = Ink800,
+        inverseSurface = Paper,
+        inverseOnSurface = Ink1000, // 19.7:1 on Paper — AAA
+        inversePrimary = AcidDark, // snackbar action text; 7.4:1 on Paper — AA
     )
 
 @Composable

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/theme/AppThemeContrastTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/theme/AppThemeContrastTest.kt
@@ -1,0 +1,178 @@
+package com.github.barriosnahuel.vossosunboton.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import com.google.common.truth.Truth.assertWithMessage
+import org.junit.Test
+
+/**
+ * Verifies every critical color pair in the Neo-Club palette meets WCAG 2.2 AA contrast ratios.
+ *
+ * Thresholds:
+ *   ≥ 4.5:1 — normal text (body, labels, icons conveying meaning)
+ *   ≥ 3.0:1 — large text and non-text UI components (borders, focus indicators)
+ *
+ * If a test fails here, the AppTheme.kt change that caused it broke an accessibility contract.
+ * Fix the palette mapping; do not lower the threshold.
+ */
+internal class AppThemeContrastTest {
+    // --- Light mode ---
+
+    @Test
+    fun `light onSurface on surface body text passes AA`() {
+        assertTextAA(LightColors.onSurface, LightColors.surface, "light: onSurface / surface")
+    }
+
+    @Test
+    fun `light primary on surface active labels pass AA`() {
+        assertTextAA(LightColors.primary, LightColors.surface, "light: primary / surface")
+    }
+
+    @Test
+    fun `light onPrimaryContainer on primaryContainer button text passes AA`() {
+        assertTextAA(LightColors.onPrimaryContainer, LightColors.primaryContainer, "light: onPrimaryContainer / primaryContainer")
+    }
+
+    @Test
+    fun `light onSecondary on secondary top-bar title passes AA`() {
+        assertTextAA(LightColors.onSecondary, LightColors.secondary, "light: onSecondary / secondary")
+    }
+
+    @Test
+    fun `light onSurfaceVariant on surfaceVariant card muted text passes AA`() {
+        assertTextAA(LightColors.onSurfaceVariant, LightColors.surfaceVariant, "light: onSurfaceVariant / surfaceVariant")
+    }
+
+    @Test
+    fun `light onError on error error text passes AA`() {
+        assertTextAA(LightColors.onError, LightColors.error, "light: onError / error")
+    }
+
+    @Test
+    fun `light onErrorContainer on errorContainer swipe-delete passes AA`() {
+        assertTextAA(LightColors.onErrorContainer, LightColors.errorContainer, "light: onErrorContainer / errorContainer")
+    }
+
+    @Test
+    fun `light inverseOnSurface on inverseSurface snackbar body passes AA`() {
+        assertTextAA(LightColors.inverseOnSurface, LightColors.inverseSurface, "light: inverseOnSurface / inverseSurface")
+    }
+
+    @Test
+    fun `light inversePrimary on inverseSurface snackbar action passes AA`() {
+        assertTextAA(LightColors.inversePrimary, LightColors.inverseSurface, "light: inversePrimary / inverseSurface")
+    }
+
+    @Test
+    fun `light primaryContainer on secondary search accent on dark bar passes non-text AA`() {
+        assertNonTextAA(LightColors.primaryContainer, LightColors.secondary, "light: primaryContainer / secondary")
+    }
+
+    @Test
+    fun `light outline on surface input border passes non-text AA`() {
+        assertNonTextAA(LightColors.outline, LightColors.surface, "light: outline / surface")
+    }
+
+    @Test
+    fun `light primary on surfaceVariant pin icon on card passes non-text AA`() {
+        assertNonTextAA(LightColors.primary, LightColors.surfaceVariant, "light: primary / surfaceVariant")
+    }
+
+    // --- Dark mode ---
+
+    @Test
+    fun `dark onSurface on surface body text passes AA`() {
+        assertTextAA(DarkColors.onSurface, DarkColors.surface, "dark: onSurface / surface")
+    }
+
+    @Test
+    fun `dark primary on surface active labels pass AA`() {
+        assertTextAA(DarkColors.primary, DarkColors.surface, "dark: primary / surface")
+    }
+
+    @Test
+    fun `dark onPrimaryContainer on primaryContainer button text passes AA`() {
+        assertTextAA(DarkColors.onPrimaryContainer, DarkColors.primaryContainer, "dark: onPrimaryContainer / primaryContainer")
+    }
+
+    @Test
+    fun `dark onSecondary on secondary top-bar title passes AA`() {
+        assertTextAA(DarkColors.onSecondary, DarkColors.secondary, "dark: onSecondary / secondary")
+    }
+
+    @Test
+    fun `dark onSurfaceVariant on surfaceVariant card muted text passes AA`() {
+        assertTextAA(DarkColors.onSurfaceVariant, DarkColors.surfaceVariant, "dark: onSurfaceVariant / surfaceVariant")
+    }
+
+    @Test
+    fun `dark onError on error error text passes AA`() {
+        assertTextAA(DarkColors.onError, DarkColors.error, "dark: onError / error")
+    }
+
+    @Test
+    fun `dark onErrorContainer on errorContainer swipe-delete passes AA`() {
+        assertTextAA(DarkColors.onErrorContainer, DarkColors.errorContainer, "dark: onErrorContainer / errorContainer")
+    }
+
+    @Test
+    fun `dark inverseOnSurface on inverseSurface snackbar body passes AA`() {
+        assertTextAA(DarkColors.inverseOnSurface, DarkColors.inverseSurface, "dark: inverseOnSurface / inverseSurface")
+    }
+
+    @Test
+    fun `dark inversePrimary on inverseSurface snackbar action passes AA`() {
+        assertTextAA(DarkColors.inversePrimary, DarkColors.inverseSurface, "dark: inversePrimary / inverseSurface")
+    }
+
+    @Test
+    fun `dark primaryContainer on secondary search accent on dark bar passes non-text AA`() {
+        assertNonTextAA(DarkColors.primaryContainer, DarkColors.secondary, "dark: primaryContainer / secondary")
+    }
+
+    @Test
+    fun `dark outline on surface input border passes non-text AA`() {
+        assertNonTextAA(DarkColors.outline, DarkColors.surface, "dark: outline / surface")
+    }
+
+    @Test
+    fun `dark primary on surfaceVariant pin icon on card passes non-text AA`() {
+        assertNonTextAA(DarkColors.primary, DarkColors.surfaceVariant, "dark: primary / surfaceVariant")
+    }
+}
+
+private fun assertTextAA(
+    fg: Color,
+    bg: Color,
+    label: String,
+) {
+    assertContrast(fg = fg, bg = bg, minRatio = 4.5f, label = label)
+}
+
+private fun assertNonTextAA(
+    fg: Color,
+    bg: Color,
+    label: String,
+) {
+    assertContrast(fg = fg, bg = bg, minRatio = 3.0f, label = label)
+}
+
+private fun assertContrast(
+    fg: Color,
+    bg: Color,
+    minRatio: Float,
+    label: String,
+) {
+    val ratio = contrastRatio(fg, bg)
+    val msg = "WCAG contrast [$label]: got ${"%.2f".format(ratio)}:1, need ≥ ${"%.1f".format(minRatio)}:1"
+    assertWithMessage(msg).that(ratio).isAtLeast(minRatio)
+}
+
+private fun contrastRatio(
+    a: Color,
+    b: Color,
+): Float {
+    val l1 = maxOf(a.luminance(), b.luminance())
+    val l2 = minOf(a.luminance(), b.luminance())
+    return (l1 + 0.05f) / (l2 + 0.05f)
+}

--- a/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
+++ b/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
@@ -2,7 +2,6 @@ package com.github.barriosnahuel.vossosunboton.feature.addbutton
 
 import android.content.Context
 import android.media.MediaPlayer
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -16,6 +15,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -150,6 +150,11 @@ fun AddButtonScreen(
             Spacer(modifier = Modifier.height(16.dp))
             Button(
                 onClick = { save() },
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    ),
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(
@@ -204,8 +209,8 @@ private fun AudioPreview(
         Card(
             colors =
                 CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
                 ),
             modifier = Modifier.fillMaxWidth(),
         ) {
@@ -251,9 +256,9 @@ private fun AudioPreview(
                             enabled = isPlaying,
                             colors =
                                 SliderDefaults.colors(
-                                    inactiveTrackColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.24f),
-                                    disabledInactiveTrackColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.24f),
-                                    disabledThumbColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.24f),
+                                    inactiveTrackColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.24f),
+                                    disabledInactiveTrackColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.24f),
+                                    disabledThumbColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.24f),
                                     disabledActiveTrackColor = MaterialTheme.colorScheme.primary,
                                 ),
                             modifier = Modifier.fillMaxWidth(),
@@ -286,13 +291,6 @@ private fun AddButtonTopBar(
     mode: AddButtonMode,
     onNavigateUp: () -> Unit,
 ) {
-    // Light mode: primary (#5B21B6 deep violet) — dark bar, white title.
-    // Dark mode:  primaryContainer (#4A0A96 deep violet) — dark bar, lavender title.
-    val isDark = isSystemInDarkTheme()
-    val barContainerColor =
-        if (isDark) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.primary
-    val barContentColor =
-        if (isDark) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onPrimary
     TopAppBar(
         title = {
             Text(
@@ -315,9 +313,9 @@ private fun AddButtonTopBar(
         },
         colors =
             TopAppBarDefaults.topAppBarColors(
-                containerColor = barContainerColor,
-                titleContentColor = barContentColor,
-                navigationIconContentColor = barContentColor,
+                containerColor = MaterialTheme.colorScheme.secondary,
+                titleContentColor = MaterialTheme.colorScheme.onSecondary,
+                navigationIconContentColor = MaterialTheme.colorScheme.onSecondary,
             ),
     )
 }


### PR DESCRIPTION
## Summary

- Replaces the old violet/rose/amber Material 3 palette with the **Neo-Club ink × acid** design system across all screens (top bars, cards, FAB, search overlay, swipe actions, snackbar)
- Eliminates all `isSystemInDarkTheme()` / `isDark` checks from component files — dark/light differences now live exclusively in `AppTheme.kt` via M3 semantic roles
- Adds `AppThemeContrastTest` — 24 pure-JVM WCAG 2.2 AA assertions (no Robolectric, no Compose rule) that run in ~3 s and lock the palette against regressions
- Documents the design system (palette, role → intent mapping, component rules) in `CLAUDE.md`

## Code review tips

- `LightColors`/`DarkColors` changed from `private` to `internal` — the only reason is to give the same-module test direct access; they remain invisible outside `app`
- The `secondary` role is always-dark (`Ink1000`/`Ink900`) so top bars never need `isDark` in components — this is the core pattern to validate
- `SearchField` uses `primaryContainer` (= Acid400 in both modes) for cursor/underline/icons, not `primary` — `primary` is `AcidDark` in light mode and nearly invisible on a dark bar
- `AppThemeContrastTest` tests `primary / surfaceVariant` (pin icon on card) and `onErrorContainer / errorContainer` (swipe-delete) — two pairs that were missing from the original spec

## Already tested

- [x] All 24 `AppThemeContrastTest` assertions pass
- [x] `./gradlew :app:ktlintCheck` clean
- [x] Visual review in light and dark mode: top bars, cards, FAB, search overlay, swipe-pin/delete, snackbar action button