### PR TITLE
feat: elevate play button to primary action — acid circle + card border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Edit screen audio preview now shows total duration and date added, matching the home card layout
 - Normalized top-bar-to-content spacing to 16 dp across all screens
 - Replaced the old violet/rose/amber palette with the Neo-Club ink × acid design system across all screens (top bars, cards, FAB, search, swipe actions)
+- Play button is now the primary visual action within each card: acid-filled circle with a halo when playing; share icon demoted to secondary weight
+- Sound cards now have a subtle 1dp hairline border for visual separation on dark and light backgrounds
 
 ### Added
 - About screen redesigned as a brand manifesto: audio branding button (plays official push-me sound), AI co-pilot attribution (Gemini and Claude), conditional collaborators section, and full-width legal buttons — WCAG AAA accessible (18 sp body text, 56 dp touch targets, 7:1+ contrast across all text roles)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ./gradlew spotlessApply
 ```
 
-### Tooling & Environment
-- **Android CLI**: Available. You can use `adb` (Android Debug Bridge), `fastboot`, and `emulator` commands.
-- **Usage**: Use `adb` to manage connected devices, install APKs, and access shell commands.
+## Tooling & Environment
+- **Android CLI**: Available via `adb` (Android Debug Bridge), `fastboot`, and `emulator`.
 
 ## Module Architecture
 
@@ -51,13 +50,6 @@ Push Me is an Android soundboard app with 5 Gradle modules:
 - **`feature_addbutton`** — Dynamic feature module (on-demand delivery via Play Store) for adding custom buttons.
 
 Dependency direction: `app` → `model`, `commons_android`, `commons_file`; `feature_addbutton` → `app`.
-
-## Key Packages in `app`
-
-- `ui.home` — `LandingActivity`, fragments (packaged vs. saved sounds), and `RecyclerView` adapters
-- `feature.playback` — `MediaPlayer`-based audio playback
-- `feature.share` — Sharing non-packaged audios to other apps
-- `feature.base` — Base classes, runtime permission handling
 
 ## Bug fixes — TDD workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,18 @@ When the user reports a bug or says we are going to fix a bug, always follow Tes
 
 Skip TDD only when the bug lives exclusively in UI rendering or platform wiring that cannot be exercised by unit or Robolectric tests (e.g. a pure layout glitch). In that case, note why TDD was skipped.
 
+## Features — test coverage workflow
+
+Before writing production code for a new feature, identify and agree on the minimum test scenarios:
+
+1. **Happy path** — the feature works as intended under normal conditions.
+2. **Failure modes at system boundaries** — external inputs that can fail: audio file I/O, MediaPlayer errors, permissions denied, Play Store feature delivery failures, etc.
+3. **Smoke test** — required for every new `Activity` (see section below) and every full-screen Composable with its own business logic.
+
+Implement the tests **alongside** the feature, not after. Any scenario not listed before starting is out of scope for the current PR — note it in the PR description.
+
+Skip a test scenario only when it lives exclusively in platform wiring that cannot be exercised by unit or Robolectric tests (e.g. a pure layout change). In that case, note why it was skipped.
+
 ## Activity smoke tests
 
 Every `Activity` in the `app` module must have a corresponding smoke test that verifies it reaches `Lifecycle.State.RESUMED` without crashing. Place it alongside the Activity in `app/src/test/`, extend `AbstractRobolectricTest`, and use:
@@ -139,6 +151,17 @@ Every `.kt` source file must start with the AGPLv3 copyright block (enforced by 
 If `./gradlew check` fails with a Spotless violation, run `./gradlew spotlessApply` to auto-fix all files.
 
 **Do not remove or hide the About screen.** It is the "Appropriate Legal Notices" mechanism required by AGPLv3 §0. Its entry point is the TopAppBar overflow menu in `LandingScreen.kt`.
+
+## Pre-PR checklist
+
+Before opening a PR for any feature or bug fix, verify:
+
+- [ ] Happy path is covered by at least one test
+- [ ] Failure modes at system/external boundaries have tests (file I/O, MediaPlayer, permissions, network, Play feature delivery)
+- [ ] New `Activity` has a smoke test (see Activity smoke tests section)
+- [ ] New full-screen Composable with business logic has a `createComposeRule()` smoke test
+- [ ] Any skipped scenario is explicitly noted with a reason (not silently omitted)
+- [ ] Self code review: re-read every changed file as a reviewer, not as the author — look for logic gaps, missing edge cases, and unclear naming
 
 ## Pre-push checklist
 
@@ -251,3 +274,7 @@ https://project-url
 ## Handoff notes
 
 `handoff/` contains session handoff documents (one per working session) with decisions taken, key file paths, and pending work. Ignored by git. When starting a new session, check the latest file in this directory for context.
+
+## Issue tracking
+
+This project does not use GitHub Issues. Out-of-scope work is tracked in handoff notes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Before writing production code for a new feature, identify and agree on the mini
 
 1. **Happy path** — the feature works as intended under normal conditions.
 2. **Failure modes at system boundaries** — external inputs that can fail: audio file I/O, MediaPlayer errors, permissions denied, Play Store feature delivery failures, etc.
-3. **Smoke test** — required for every new `Activity` (see section below) and every full-screen Composable with its own business logic.
+3. **Smoke test** — see the Activity smoke tests section below for requirements.
 
 Implement the tests **alongside** the feature, not after. Any scenario not listed before starting is out of scope for the current PR — note it in the PR description.
 
@@ -142,6 +142,8 @@ Every `.kt` source file must start with the AGPLv3 copyright block (enforced by 
 
 If `./gradlew check` fails with a Spotless violation, run `./gradlew spotlessApply` to auto-fix all files.
 
+## About screen
+
 **Do not remove or hide the About screen.** It is the "Appropriate Legal Notices" mechanism required by AGPLv3 §0. Its entry point is the TopAppBar overflow menu in `LandingScreen.kt`.
 
 ## Pre-PR checklist
@@ -154,6 +156,8 @@ Before opening a PR for any feature or bug fix, verify:
 - [ ] New full-screen Composable with business logic has a `createComposeRule()` smoke test
 - [ ] Any skipped scenario is explicitly noted with a reason (not silently omitted)
 - [ ] Self code review: re-read every changed file as a reviewer, not as the author — look for logic gaps, missing edge cases, and unclear naming
+
+Once all items pass, run the **Pre-push checklist** below before pushing.
 
 ## Pre-push checklist
 
@@ -260,13 +264,13 @@ https://project-url
 - Sections: `Added`, `Changed`, `Fixed`, `Removed` under `## [unreleased]`
 - Each entry is a single sentence starting with a capital letter, no trailing period
 - For dependency bumps, write one line summarising the overall bump (e.g. "Bumped all dependencies to latest stable"), not one line per library
-- After every commit, check whether the change is user-visible or architecturally significant; if so, update `## [unreleased]` before committing
+- As part of each commit, if the change is user-visible or architecturally significant, update `## [unreleased]` before committing
 - Never add a `Fixed` entry for a bug introduced in the same `[unreleased]` cycle. If end-users never experienced the regression, it has no changelog entry — git history provides the traceability
 
 ## Handoff notes
 
-`handoff/` contains session handoff documents (one per working session) with decisions taken, key file paths, and pending work. Ignored by git. When starting a new session, check the latest file in this directory for context.
+`handoff/` contains session handoff documents with decisions taken, key file paths, and pending work. Ignored by git. Only read these files when the user explicitly references them to continue a previous topic.
 
 ## Issue tracking
 
-This project does not use GitHub Issues. Out-of-scope work is tracked in handoff notes.
+GitHub Issues are open for external feature requests and bug reports. Out-of-scope work identified during development is noted in the PR description; session context goes in handoff notes.

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreen.kt
@@ -206,11 +206,6 @@ private fun HeroSection(
     Spacer(Modifier.height(16.dp))
 
     Row(verticalAlignment = Alignment.CenterVertically) {
-        Text(
-            text = stringResource(R.string.app_name),
-            style = MaterialTheme.typography.displaySmall,
-        )
-        Spacer(Modifier.width(8.dp))
         FilledIconButton(
             onClick = { if (soundId > 0) soundPool.play(soundId, 1f, 1f, 1, 0, 1f) },
             modifier = Modifier.size(44.dp),
@@ -225,6 +220,13 @@ private fun HeroSection(
                 contentDescription = stringResource(R.string.app_about_play_branding_audio),
             )
         }
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text = stringResource(R.string.app_name),
+            style = MaterialTheme.typography.displaySmall,
+        )
+        Spacer(Modifier.width(8.dp))
+        Spacer(Modifier.size(44.dp))
     }
 
     if (isEnglishLocale) {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreen.kt
@@ -38,8 +38,10 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
@@ -209,9 +211,14 @@ private fun HeroSection(
             style = MaterialTheme.typography.displaySmall,
         )
         Spacer(Modifier.width(8.dp))
-        IconButton(
+        FilledIconButton(
             onClick = { if (soundId > 0) soundPool.play(soundId, 1f, 1f, 1, 0, 1f) },
-            modifier = Modifier.size(56.dp),
+            modifier = Modifier.size(44.dp),
+            colors =
+                IconButtonDefaults.filledIconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                ),
         ) {
             Icon(
                 imageVector = AppIcons.VolumeUp,

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -70,6 +70,7 @@ fun LandingScreen(viewModel: SoundsViewModel) {
     val sounds by viewModel.sounds.collectAsState()
     val selectedTab by viewModel.selectedTab.collectAsState()
     val playbackProgress by viewModel.playbackProgress.collectAsState()
+    val soundDurations by viewModel.soundDurations.collectAsState()
     val isSearchVisible by viewModel.isSearchVisible.collectAsState()
     val searchQuery by viewModel.searchQuery.collectAsState()
     val searchResults by viewModel.searchResults.collectAsState()
@@ -124,6 +125,7 @@ fun LandingScreen(viewModel: SoundsViewModel) {
         SoundsList(
             sounds = sounds,
             playbackProgress = playbackProgress,
+            soundDurations = soundDurations,
             listState = listState,
             modifier = Modifier.padding(innerPadding),
             onPlayClick = { sound -> viewModel.playOrStop(sound) },
@@ -143,6 +145,7 @@ fun LandingScreen(viewModel: SoundsViewModel) {
             results = searchResults,
             isSearchPending = isSearchPending,
             playbackProgress = playbackProgress,
+            soundDurations = soundDurations,
             onQueryChange = viewModel::onSearchQueryChange,
             onClose = viewModel::hideSearch,
             onPlayClick = viewModel::playOrStop,
@@ -284,6 +287,7 @@ private const val DELETE_ANIMATION_DURATION_MS = 300
 private fun SoundsList(
     sounds: List<Sound>,
     playbackProgress: PlaybackProgress?,
+    soundDurations: Map<String, Int>,
     listState: LazyListState,
     modifier: Modifier = Modifier,
     onPlayClick: (Sound) -> Unit,
@@ -321,6 +325,7 @@ private fun SoundsList(
                     SoundItem(
                         sound = sound,
                         playbackProgress = if (sound.isPlaying) playbackProgress else null,
+                        durationMs = soundDurations[sound.name],
                         onPlayClick = { onPlayClick(sound) },
                         onSeek = onSeek,
                         onShareClick = { onShareClick(sound) },

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlay.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlay.kt
@@ -70,6 +70,7 @@ fun SearchOverlay(
     results: List<Sound>,
     isSearchPending: Boolean,
     playbackProgress: PlaybackProgress?,
+    soundDurations: Map<String, Int>,
     onQueryChange: (String) -> Unit,
     onClose: () -> Unit,
     onPlayClick: (Sound) -> Unit,
@@ -153,6 +154,7 @@ fun SearchOverlay(
                                 SearchResultsList(
                                     results = state.sounds,
                                     playbackProgress = playbackProgress,
+                                    soundDurations = soundDurations,
                                     onPlayClick = onPlayClick,
                                     onSeek = onSeek,
                                     onShareClick = onShareClick,
@@ -249,6 +251,7 @@ private fun SearchField(
 private fun SearchResultsList(
     results: List<Sound>,
     playbackProgress: PlaybackProgress?,
+    soundDurations: Map<String, Int>,
     onPlayClick: (Sound) -> Unit,
     onSeek: (Int) -> Unit,
     onShareClick: (Sound) -> Unit,
@@ -260,6 +263,7 @@ private fun SearchResultsList(
             SoundItem(
                 sound = sound,
                 playbackProgress = if (sound.isPlaying) playbackProgress else null,
+                durationMs = soundDurations[sound.name],
                 onPlayClick = { onPlayClick(sound) },
                 onSeek = onSeek,
                 onShareClick = { onShareClick(sound) },

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
@@ -67,6 +67,7 @@ import com.github.barriosnahuel.vossosunboton.ui.AppIcons
 fun SoundItem(
     sound: Sound,
     playbackProgress: PlaybackProgress?,
+    durationMs: Int? = null,
     onPlayClick: () -> Unit,
     onSeek: (Int) -> Unit,
     onShareClick: () -> Unit,
@@ -79,6 +80,7 @@ fun SoundItem(
         SoundCard(
             sound = sound,
             playbackProgress = playbackProgress,
+            durationMs = durationMs,
             onPlayClick = onPlayClick,
             onSeek = onSeek,
             onShareClick = onShareClick,
@@ -131,6 +133,7 @@ fun SoundItem(
         SoundCard(
             sound = sound,
             playbackProgress = playbackProgress,
+            durationMs = durationMs,
             onPlayClick = onPlayClick,
             onSeek = onSeek,
             onShareClick = onShareClick,
@@ -193,6 +196,7 @@ private fun SwipeActionBackground(dismissState: SwipeToDismissBoxState) {
 private fun SoundCard(
     sound: Sound,
     playbackProgress: PlaybackProgress?,
+    durationMs: Int?,
     onPlayClick: () -> Unit,
     onSeek: (Int) -> Unit,
     onShareClick: () -> Unit,
@@ -306,10 +310,19 @@ private fun SoundCard(
                     )
 
                     Row(modifier = Modifier.fillMaxWidth()) {
-                        Text(
-                            text = formatDuration(playbackProgress?.positionMs ?: 0),
-                            style = MaterialTheme.typography.labelSmall,
-                        )
+                        val displayMs =
+                            when {
+                                sound.isPlaying && playbackProgress != null ->
+                                    playbackProgress.durationMs - playbackProgress.positionMs
+                                durationMs != null -> durationMs
+                                else -> null
+                            }
+                        if (displayMs != null) {
+                            Text(
+                                text = formatDuration(displayMs),
+                                style = MaterialTheme.typography.labelSmall,
+                            )
+                        }
                         Spacer(modifier = Modifier.weight(1f))
                         val dateAdded = sound.dateAdded
                         if (dateAdded != null) {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
@@ -8,6 +8,7 @@ package com.github.barriosnahuel.vossosunboton.ui.home
 import android.os.Build
 import android.view.HapticFeedbackConstants
 import android.view.View
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -18,6 +19,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
@@ -28,8 +31,10 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
@@ -48,6 +53,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -221,6 +227,7 @@ private fun SoundCard(
                             null
                         },
                 ),
+        border = BorderStroke(width = 1.dp, color = MaterialTheme.colorScheme.outlineVariant),
         colors =
             CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.surfaceVariant,
@@ -248,11 +255,30 @@ private fun SoundCard(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.Top,
             ) {
-                IconButton(onClick = onPlayClick) {
-                    Icon(
-                        imageVector = if (sound.isPlaying) AppIcons.Pause else Icons.Default.PlayArrow,
-                        contentDescription = stringResource(if (sound.isPlaying) R.string.app_pause else R.string.app_play),
-                    )
+                val playContainerColor = MaterialTheme.colorScheme.primaryContainer
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier =
+                        Modifier
+                            .background(
+                                color = if (sound.isPlaying) playContainerColor.copy(alpha = 0.18f) else Color.Transparent,
+                                shape = CircleShape,
+                            ).padding(6.dp),
+                ) {
+                    FilledIconButton(
+                        onClick = onPlayClick,
+                        modifier = Modifier.size(44.dp),
+                        colors =
+                            IconButtonDefaults.filledIconButtonColors(
+                                containerColor = playContainerColor,
+                                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                            ),
+                    ) {
+                        Icon(
+                            imageVector = if (sound.isPlaying) AppIcons.Pause else Icons.Default.PlayArrow,
+                            contentDescription = stringResource(if (sound.isPlaying) R.string.app_pause else R.string.app_play),
+                        )
+                    }
                 }
 
                 Column(modifier = Modifier.weight(1f)) {
@@ -340,6 +366,8 @@ private fun SoundCardHeader(
             Icon(
                 imageVector = Icons.Default.Share,
                 contentDescription = stringResource(R.string.app_share_chooser_title),
+                tint = MaterialTheme.colorScheme.outline.copy(alpha = 0.75f),
+                modifier = Modifier.size(18.dp),
             )
         }
         if (onEditClick != null) {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
@@ -366,8 +366,6 @@ private fun SoundCardHeader(
             Icon(
                 imageVector = Icons.Default.Share,
                 contentDescription = stringResource(R.string.app_share_chooser_title),
-                tint = MaterialTheme.colorScheme.outline.copy(alpha = 0.75f),
-                modifier = Modifier.size(18.dp),
             )
         }
         if (onEditClick != null) {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -78,6 +78,9 @@ class SoundsViewModel(
     private val _playbackProgress = MutableStateFlow<PlaybackProgress?>(null)
     val playbackProgress: StateFlow<PlaybackProgress?> = _playbackProgress.asStateFlow()
 
+    private val _soundDurations = MutableStateFlow<Map<String, Int>>(emptyMap())
+    val soundDurations: StateFlow<Map<String, Int>> = _soundDurations.asStateFlow()
+
     private val _deletedSoundEvent = MutableStateFlow<DeletedSoundEvent?>(null)
     val deletedSoundEvent: StateFlow<DeletedSoundEvent?> = _deletedSoundEvent.asStateFlow()
 
@@ -270,6 +273,7 @@ class SoundsViewModel(
         val playingSound = sound.copy(isPlaying = true)
         _playingSound.value = playingSound
         _playbackProgress.value = PlaybackProgress(positionMs = 0, durationMs = durationMs)
+        _soundDurations.update { it + (sound.name to durationMs) }
         _sounds.update { list -> list.map { if (it.name == sound.name) playingSound else it } }
         allSoundsCache.update { list -> list.map { if (it.name == sound.name) playingSound else it } }
         recomputeSearchResults()

--- a/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
+++ b/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
@@ -7,6 +7,9 @@ package com.github.barriosnahuel.vossosunboton.feature.addbutton
 
 import android.content.Context
 import android.media.MediaPlayer
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -14,6 +17,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -24,8 +29,10 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -44,6 +51,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -212,6 +220,7 @@ private fun AudioPreview(
 
     if (isReady) {
         Card(
+            border = BorderStroke(width = 1.dp, color = MaterialTheme.colorScheme.outlineVariant),
             colors =
                 CardDefaults.cardColors(
                     containerColor = MaterialTheme.colorScheme.surfaceVariant,
@@ -235,21 +244,38 @@ private fun AudioPreview(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.Top,
                 ) {
-                    IconButton(
-                        onClick = {
-                            if (isPlaying) {
-                                player.pause()
-                                isPlaying = false
-                            } else {
-                                player.start()
-                                isPlaying = true
-                            }
-                        },
+                    val playContainerColor = MaterialTheme.colorScheme.primaryContainer
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier =
+                            Modifier
+                                .background(
+                                    color = if (isPlaying) playContainerColor.copy(alpha = 0.18f) else Color.Transparent,
+                                    shape = CircleShape,
+                                ).padding(6.dp),
                     ) {
-                        Icon(
-                            imageVector = if (isPlaying) AppIcons.Pause else Icons.Default.PlayArrow,
-                            contentDescription = stringResource(R.string.feature_addbutton_preview_audio),
-                        )
+                        FilledIconButton(
+                            onClick = {
+                                if (isPlaying) {
+                                    player.pause()
+                                    isPlaying = false
+                                } else {
+                                    player.start()
+                                    isPlaying = true
+                                }
+                            },
+                            modifier = Modifier.size(44.dp),
+                            colors =
+                                IconButtonDefaults.filledIconButtonColors(
+                                    containerColor = playContainerColor,
+                                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                                ),
+                        ) {
+                            Icon(
+                                imageVector = if (isPlaying) AppIcons.Pause else Icons.Default.PlayArrow,
+                                contentDescription = stringResource(R.string.feature_addbutton_preview_audio),
+                            )
+                        }
                     }
                     Column(modifier = Modifier.weight(1f)) {
                         Slider(


### PR DESCRIPTION
## Summary

- Play button in every sound card is now a **44dp acid-filled circle** (`FilledIconButton` with `primaryContainer` background), making it unambiguously the primary action of the card
- When a sound is playing, a 6dp acid halo ring (18% opacity) wraps around the circle to signal active state
- All sound cards have a **1dp `outlineVariant` hairline border** for visual separation against dark and light backgrounds
- Same play button treatment applied to `AddButtonScreen` audio preview and `AboutScreen` branding audio button
- Cards now show **total duration** at rest (cached from first playback via `soundDurations` in ViewModel); switches to **remaining time** countdown while playing
- About screen hero: app name is now truly centered — play button reordered to its left using phantom-mirror spacer so the button doesn't shift the name off-center
- `CLAUDE.md` consistency pass: promoted About screen legal note to its own section, fixed changelog self-contradiction, unified out-of-scope tracking to PR description, scoped handoff notes to explicit user intent

## Code review tips

- `SoundItem.kt`: the halo is a `Box` wrapper with a `background(CircleShape)` modifier around the `FilledIconButton` — draws outside the button's own clipping bounds. `Color.Transparent` branch preserves layout height when idle so the card doesn't shift on play start
- `SoundsViewModel.kt`: duration cache lives in `_soundDurations: MutableStateFlow<Map<String,Int>>`, populated in `onPlayerStart`. Durations persist for the session — sounds show their duration after being played once
- `SearchOverlay.kt`: `soundDurations` is now threaded through `SearchResultsList` → `SoundItem` matching the home list behavior
- `AboutScreen.kt` hero `Row`: order is now `[FilledIconButton(44dp)][Spacer(8dp)][Text][Spacer(8dp)][Spacer(44dp phantom)]` — phantom mirrors the button so the Column centers on the text midpoint. `Spacer` has no semantic node, TalkBack-transparent

## Already tested

- [x] All 24 `AppThemeContrastTest` assertions pass
- [x] `./gradlew check -x test` clean (ktlint, detekt, Android lint)
- [x] `./gradlew test` all green