### PR TITLE
Fix: show audio duration from first render and display elapsed time during playback

### DIFF
--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
@@ -314,7 +314,7 @@ private fun SoundCard(
                         val displayMs =
                             when {
                                 sound.isPlaying && playbackProgress != null ->
-                                    playbackProgress.durationMs - playbackProgress.positionMs
+                                    playbackProgress.positionMs
                                 durationMs != null -> durationMs
                                 else -> null
                             }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -235,14 +235,17 @@ class SoundsViewModel(
     }
 
     private suspend fun loadSounds() {
+        val dao = SoundDao()
         val allSounds =
-            SoundDao()
+            dao
                 .find(getApplication<Application>())
                 .sortedWith(
                     compareByDescending<Sound> { it.isPinned }
                         .thenByDescending { it.dateAdded ?: Long.MIN_VALUE }
                         .thenBy { it.name.lowercase() },
                 )
+        val cachedDurations = dao.findDurations(getApplication<Application>())
+        _soundDurations.update { current -> cachedDurations + current }
         val playingName = _playingSound.value?.name
         val deletedName = _deletedSoundEvent.value?.sound?.name
         allSoundsCache.value =
@@ -274,6 +277,9 @@ class SoundsViewModel(
         _playingSound.value = playingSound
         _playbackProgress.value = PlaybackProgress(positionMs = 0, durationMs = durationMs)
         _soundDurations.update { it + (sound.name to durationMs) }
+        viewModelScope.launch(ioDispatcher) {
+            SoundDao().saveDuration(getApplication(), sound.name, durationMs)
+        }
         _sounds.update { list -> list.map { if (it.name == sound.name) playingSound else it } }
         allSoundsCache.update { list -> list.map { if (it.name == sound.name) playingSound else it } }
         recomputeSearchResults()

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundDaoTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundDaoTest.kt
@@ -8,6 +8,7 @@ package com.github.barriosnahuel.vossosunboton.model.data.manager
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.commons.file.getFile
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.model.data.local.Storage
 import com.google.common.truth.Truth.assertThat
@@ -146,5 +147,35 @@ internal class SoundDaoTest : AbstractRobolectricTest() {
         val result = dao.find(context).filter { !it.isBundled() }
 
         assertThat(result.single().isPinned).isTrue()
+    }
+
+    @Test
+    fun `findDurations returns empty map when no durations saved`() {
+        val durations = dao.findDurations(context)
+
+        assertThat(durations).isEmpty()
+    }
+
+    @Test
+    fun `saveDuration then findDurations returns the saved duration`() {
+        dao.save(context, Sound("bell", "bell.mp3"))
+
+        dao.saveDuration(context, "bell", 42000)
+
+        assertThat(dao.findDurations(context)).containsEntry("bell", 42000)
+    }
+
+    @Test
+    fun `delete also removes the persisted duration`() {
+        val sound = Sound("bell", "bell.mp3")
+        dao.save(context, sound)
+        dao.saveDuration(context, "bell", 42000)
+        val soundFile = getFile(context, "bell.mp3")
+        soundFile.parentFile?.mkdirs()
+        soundFile.createNewFile()
+
+        dao.delete(context, sound)
+
+        assertThat(dao.findDurations(context)).doesNotContainKey("bell")
     }
 }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItemTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItemTest.kt
@@ -114,6 +114,50 @@ internal class SoundItemTest : AbstractRobolectricTest() {
     }
 
     @Test
+    fun `when idle with duration shows total duration`() {
+        val sound = Sound("bell", file = "bell.mp3")
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                SoundItem(
+                    sound = sound,
+                    playbackProgress = null,
+                    durationMs = 62000,
+                    onPlayClick = {},
+                    onSeek = {},
+                    onShareClick = {},
+                    onDelete = {},
+                    onPinClick = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("1:02").assertExists()
+    }
+
+    @Test
+    fun `when playing shows elapsed time not remaining`() {
+        val sound = Sound("bell", file = "bell.mp3").copy(isPlaying = true)
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                SoundItem(
+                    sound = sound,
+                    playbackProgress = PlaybackProgress(positionMs = 30000, durationMs = 62000),
+                    durationMs = 62000,
+                    onPlayClick = {},
+                    onSeek = {},
+                    onShareClick = {},
+                    onDelete = {},
+                    onPinClick = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("0:30").assertExists()
+    }
+
+    @Test
     fun `bundled sound does not trigger any callback on swipe`() {
         var pinCallCount = 0
         var deleteCallCount = 0

--- a/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
+++ b/feature_addbutton/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
@@ -6,6 +6,7 @@
 package com.github.barriosnahuel.vossosunboton.feature.addbutton
 
 import android.content.Context
+import android.media.MediaMetadataRetriever
 import android.net.Uri
 import com.github.barriosnahuel.vossosunboton.commons.file.copy
 import com.github.barriosnahuel.vossosunboton.commons.file.getFile
@@ -61,6 +62,19 @@ private class AddButtonFeatureImpl : AddButtonFeature {
                         } else {
                             copy(inputStream, fileOutputStream)
                             SoundDao().save(context, Sound(name, fileName))
+                            val durationMs =
+                                runCatching {
+                                    val retriever = MediaMetadataRetriever()
+                                    try {
+                                        retriever.setDataSource(targetFile.absolutePath)
+                                        retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)?.toInt()
+                                    } finally {
+                                        retriever.release()
+                                    }
+                                }.getOrNull()
+                            if (durationMs != null) {
+                                SoundDao().saveDuration(context, name, durationMs)
+                            }
 
                             feedbackMessage = R.string.feature_addbutton_feedback_saved_ok
                         }

--- a/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundDao.java
+++ b/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundDao.java
@@ -10,7 +10,9 @@ import com.github.barriosnahuel.vossosunboton.model.data.local.Storage;
 import com.github.barriosnahuel.vossosunboton.model.data.local.defaultaudios.PackagedAudios;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import timber.log.Timber;
@@ -26,6 +28,7 @@ public class SoundDao {
     private static final String SOUNDS_FILE_NAME_PREFFIX = "sounds.file.";
     private static final String SOUNDS_FAVORITE_PREFFIX = "sounds.favorite.";
     private static final String SOUNDS_PINNED_PREFIX = "sounds.pinned.";
+    private static final String SOUNDS_DURATION_PREFIX = "sounds.duration.";
     private final Storage storage;
 
     /**
@@ -82,6 +85,25 @@ public class SoundDao {
         storage.save(context, SOUNDS_PINNED_PREFIX + soundName, String.valueOf(isPinned));
     }
 
+    public void saveDuration(final Context context, final String soundName, final int durationMs) {
+        storage.save(context, SOUNDS_DURATION_PREFIX + soundName, String.valueOf(durationMs));
+    }
+
+    public Map<String, Integer> findDurations(final Context context) {
+        final Set<String> names = storage.getAll(context, SOUNDS_NAME);
+        final Map<String, Integer> durations = new HashMap<>();
+        for (final String name : names) {
+            final String raw = storage.get(context, SOUNDS_DURATION_PREFIX + name);
+            if (raw != null) {
+                try {
+                    durations.put(name, Integer.parseInt(raw));
+                } catch (NumberFormatException ignored) {
+                }
+            }
+        }
+        return durations;
+    }
+
     /**
      * @param context The execution context.
      * @param sound   The sound to delete.
@@ -103,6 +125,7 @@ public class SoundDao {
             deleteButtonKeyFileMapping(context, sound.getName());
             storage.remove(context, SOUNDS_FAVORITE_PREFFIX + sound.getName());
             storage.remove(context, SOUNDS_PINNED_PREFIX + sound.getName());
+            storage.remove(context, SOUNDS_DURATION_PREFIX + sound.getName());
         } else {
             Timber.e("Button could NOT be deleted. Button: %s", sound.getName());
         }
@@ -139,6 +162,12 @@ public class SoundDao {
         storage.remove(context, SOUNDS_PINNED_PREFIX + sound.getName());
         if (pinnedValue != null) {
             storage.save(context, SOUNDS_PINNED_PREFIX + newName, pinnedValue);
+        }
+
+        final String durationValue = storage.get(context, SOUNDS_DURATION_PREFIX + sound.getName());
+        storage.remove(context, SOUNDS_DURATION_PREFIX + sound.getName());
+        if (durationValue != null) {
+            storage.save(context, SOUNDS_DURATION_PREFIX + newName, durationValue);
         }
     }
 


### PR DESCRIPTION
### Summary
- Audio duration was only computed on first play via `MediaPlayer.prepare()` and kept in memory — cards showed no duration until the user tapped play, then it appeared suddenly
- Duration is now extracted at button-save time (`MediaMetadataRetriever`) and persisted in SharedPreferences under `sounds.duration.{name}`, so it's visible from the first render
- `onPlayerStart()` also persists the duration as a fallback (e.g. if `MediaMetadataRetriever` failed at save time)
- During playback the displayed time now counts **up** (elapsed: 0 → total) instead of down (remaining: total → 0), matching the forward movement of the slider

### Code review tips
- `SoundDao.findDurations()` iterates the same `sounds.name` set used by `find()` — both always in sync
- `loadSounds()` merges cached durations with `cachedDurations + current` so in-session learned durations are never overwritten by a stale SharedPreferences read
- `MediaMetadataRetriever.use {}` would require API 29 (AutoCloseable cast) — replaced with explicit try/finally calling `release()`
- Duration key is cleaned up in both `delete()` and `rename()` — no orphan keys

### Already tested
- [x] 3 new `SoundDaoTest` cases: empty map, save+find, delete cleans up the key
- [x] 2 new `SoundItemTest` cases: idle shows total duration, playing shows elapsed (not remaining)
- [x] Full test suite green (`./gradlew test`)
- [x] All linters green (`./gradlew check -x test`)

Closes 