### PR TITLE
Enable pinning for bundled sounds and fix Explore scroll lag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Bundled audio files removed from version control; bottom navigation bar hidden in release builds (Explore tab only appears in debug when audio files are manually placed)
 
 ### Changed
+- Swipe-to-delete haptic feedback on custom sounds changed from double-pulse (reject) to single-pulse (confirm), matching the pin gesture — a successful delete is a confirmed action
 - Edit screen audio preview now shows total duration and date added, matching the home card layout
 - Normalized top-bar-to-content spacing to 16 dp across all screens
 - Replaced the old violet/rose/amber palette with the Neo-Club ink × acid design system across all screens (top bars, cards, FAB, search, swipe actions)
@@ -15,6 +16,9 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Sound cards now have a subtle 1dp hairline border for visual separation on dark and light backgrounds
 
 ### Added
+- Bundled sounds (Explore tab) can now be pinned to the top via button tap or swipe right, with the pinned state persisting across app restarts
+- Swiping left or long-pressing a bundled sound gives haptic rejection feedback (double-pulse), indicating those actions are not available
+- Pinning any sound now automatically scrolls the list back to the top so the newly pinned item is immediately visible
 - About screen redesigned as a brand manifesto: audio branding button (plays official push-me sound), AI co-pilot attribution (Gemini and Claude), conditional collaborators section, and full-width legal buttons — WCAG AAA accessible (18 sp body text, 56 dp touch targets, 7:1+ contrast across all text roles)
 - About screen: version info, license viewer (AGPLv3), third-party credits, and source code link — accessible from the top-bar overflow menu
 - AGPLv3 copyright header on all source files, enforced by Spotless

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/AppIcons.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/AppIcons.kt
@@ -6,6 +6,7 @@
 package com.github.barriosnahuel.vossosunboton.ui
 
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.path
@@ -68,6 +69,48 @@ public object AppIcons {
                     horizontalLineTo(19f)
                     verticalLineToRelative(-2f)
                     curveToRelative(-1.66f, 0f, -3f, -1.34f, -3f, -3f)
+                    close()
+                }
+            }.build()
+    }
+
+    val PushPinOutlined: ImageVector by lazy {
+        ImageVector
+            .Builder(
+                name = "PushPinOutlined",
+                defaultWidth = 24.dp,
+                defaultHeight = 24.dp,
+                viewportWidth = 24f,
+                viewportHeight = 24f,
+            ).apply {
+                path(fill = SolidColor(Color.Black), pathFillType = PathFillType.EvenOdd) {
+                    moveTo(16f, 9f)
+                    verticalLineTo(4f)
+                    horizontalLineToRelative(1f)
+                    curveToRelative(0.55f, 0f, 1f, -0.45f, 1f, -1f)
+                    reflectiveCurveToRelative(-0.45f, -1f, -1f, -1f)
+                    horizontalLineTo(7f)
+                    curveToRelative(-0.55f, 0f, -1f, 0.45f, -1f, 1f)
+                    reflectiveCurveToRelative(0.45f, 1f, 1f, 1f)
+                    horizontalLineToRelative(1f)
+                    verticalLineToRelative(5f)
+                    curveToRelative(0f, 1.66f, -1.34f, 3f, -3f, 3f)
+                    verticalLineToRelative(2f)
+                    horizontalLineToRelative(5.97f)
+                    verticalLineToRelative(7f)
+                    lineToRelative(1f, 1f)
+                    lineToRelative(1f, -1f)
+                    verticalLineToRelative(-7f)
+                    horizontalLineTo(19f)
+                    verticalLineToRelative(-2f)
+                    curveToRelative(-1.66f, 0f, -3f, -1.34f, -3f, -3f)
+                    close()
+                    // Inner rectangle: creates the hollow pin-body via EvenOdd
+                    moveTo(14f, 9f)
+                    horizontalLineToRelative(-4f)
+                    verticalLineTo(4f)
+                    horizontalLineToRelative(4f)
+                    verticalLineTo(9f)
                     close()
                 }
             }.build()

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -92,6 +92,12 @@ fun LandingScreen(viewModel: SoundsViewModel) {
         viewModel.selectTab(tabBackStack.removeAt(tabBackStack.lastIndex))
     }
 
+    LaunchedEffect(Unit) {
+        viewModel.scrollToTopEvent.collect {
+            listState.animateScrollToItem(0)
+        }
+    }
+
     SnackbarEffects(viewModel = viewModel, snackbarHostState = snackbarHostState)
 
     Scaffold(

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
@@ -368,13 +368,14 @@ private fun SoundCardHeader(
                 )
             }
         }
-        if (sound.isPinned) {
-            Icon(
-                imageVector = AppIcons.PushPin,
-                contentDescription = stringResource(R.string.app_pinned),
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(end = Spacing.XS),
-            )
+        if (onPinClick != null) {
+            IconButton(onClick = onPinClick) {
+                Icon(
+                    imageVector = if (sound.isPinned) AppIcons.PushPin else AppIcons.PushPinOutlined,
+                    contentDescription = stringResource(if (sound.isPinned) R.string.app_unpin else R.string.app_pin),
+                    tint = if (sound.isPinned) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
         IconButton(onClick = onShareClick) {
             Icon(
@@ -388,16 +389,6 @@ private fun SoundCardHeader(
                     expanded = showMenu,
                     onDismissRequest = onMenuDismiss,
                 ) {
-                    if (onPinClick != null) {
-                        DropdownMenuItem(
-                            text = { Text(stringResource(if (sound.isPinned) R.string.app_unpin else R.string.app_pin)) },
-                            leadingIcon = { Icon(AppIcons.PushPin, contentDescription = null) },
-                            onClick = {
-                                onMenuDismiss()
-                                onPinClick()
-                            },
-                        )
-                    }
                     DropdownMenuItem(
                         text = { Text(stringResource(R.string.app_edit)) },
                         leadingIcon = { Icon(Icons.Default.Edit, contentDescription = null) },

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.SwipeToDismissBoxState
 import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -54,6 +55,9 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -78,18 +82,59 @@ fun SoundItem(
     originLabel: String? = null,
 ) {
     if (sound.isBundled()) {
-        SoundCard(
-            sound = sound,
-            playbackProgress = playbackProgress,
-            durationMs = durationMs,
-            onPlayClick = onPlayClick,
-            onSeek = onSeek,
-            onShareClick = onShareClick,
-            onPinClick = null,
-            onEditClick = null,
-            onDelete = null,
-            originLabel = originLabel,
-        )
+        val view = LocalView.current
+        val dismissState =
+            remember {
+                SwipeToDismissBoxState(
+                    initialValue = SwipeToDismissBoxValue.Settled,
+                    positionalThreshold = { totalDistance -> totalDistance * 0.35f },
+                )
+            }
+        val currentOnPinClick by rememberUpdatedState(onPinClick)
+        LaunchedEffect(Unit) {
+            snapshotFlow { dismissState.settledValue }
+                .collect { settled ->
+                    when (settled) {
+                        SwipeToDismissBoxValue.StartToEnd -> {
+                            performConfirmHaptic(view)
+                            dismissState.snapTo(SwipeToDismissBoxValue.Settled)
+                            currentOnPinClick()
+                        }
+                        SwipeToDismissBoxValue.EndToStart -> {
+                            performRejectHaptic(view)
+                            dismissState.snapTo(SwipeToDismissBoxValue.Settled)
+                        }
+                        SwipeToDismissBoxValue.Settled -> Unit
+                    }
+                }
+        }
+        val noOpHaptic =
+            remember {
+                object : HapticFeedback {
+                    @Suppress("EmptyFunctionBlock")
+                    override fun performHapticFeedback(hapticFeedbackType: HapticFeedbackType) {}
+                }
+            }
+        SwipeToDismissBox(
+            state = dismissState,
+            backgroundContent = { SwipeActionBackground(dismissState, canDelete = false) },
+        ) {
+            CompositionLocalProvider(LocalHapticFeedback provides noOpHaptic) {
+                SoundCard(
+                    sound = sound,
+                    playbackProgress = playbackProgress,
+                    durationMs = durationMs,
+                    onPlayClick = onPlayClick,
+                    onSeek = onSeek,
+                    onShareClick = onShareClick,
+                    onPinClick = onPinClick,
+                    onEditClick = null,
+                    onDelete = null,
+                    onLongClick = { performRejectHaptic(view) },
+                    originLabel = originLabel,
+                )
+            }
+        }
         return
     }
     // rememberSaveable (used by rememberSwipeToDismissBoxState) restores the dismissed state
@@ -115,12 +160,12 @@ fun SoundItem(
             .collect { settled ->
                 when (settled) {
                     SwipeToDismissBoxValue.StartToEnd -> {
-                        performPinHaptic(view)
+                        performConfirmHaptic(view)
                         dismissState.snapTo(SwipeToDismissBoxValue.Settled)
                         currentOnPinClick()
                     }
                     SwipeToDismissBoxValue.EndToStart -> {
-                        performDeleteHaptic(view)
+                        performConfirmHaptic(view)
                         currentOnDelete()
                     }
                     SwipeToDismissBoxValue.Settled -> Unit
@@ -146,7 +191,7 @@ fun SoundItem(
     }
 }
 
-private fun performPinHaptic(view: View) {
+private fun performConfirmHaptic(view: View) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
     } else {
@@ -154,7 +199,7 @@ private fun performPinHaptic(view: View) {
     }
 }
 
-private fun performDeleteHaptic(view: View) {
+private fun performRejectHaptic(view: View) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         view.performHapticFeedback(HapticFeedbackConstants.REJECT)
     } else {
@@ -164,9 +209,13 @@ private fun performDeleteHaptic(view: View) {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SwipeActionBackground(dismissState: SwipeToDismissBoxState) {
+private fun SwipeActionBackground(
+    dismissState: SwipeToDismissBoxState,
+    canDelete: Boolean = true,
+) {
     if (dismissState.dismissDirection == SwipeToDismissBoxValue.Settled) return
     val isPinAction = dismissState.dismissDirection == SwipeToDismissBoxValue.StartToEnd
+    if (!isPinAction && !canDelete) return
     val backgroundColor =
         if (isPinAction) {
             MaterialTheme.colorScheme.primaryContainer
@@ -204,6 +253,7 @@ private fun SoundCard(
     onPinClick: (() -> Unit)?,
     onEditClick: (() -> Unit)?,
     onDelete: (() -> Unit)?,
+    onLongClick: (() -> Unit)? = null,
     originLabel: String? = null,
 ) {
     var sliderPosition by remember { mutableFloatStateOf(0f) }
@@ -229,7 +279,7 @@ private fun SoundCard(
                         if (onEditClick != null) {
                             { showMenu = true }
                         } else {
-                            null
+                            onLongClick
                         },
                 ),
         border = BorderStroke(width = 1.dp, color = MaterialTheme.colorScheme.outlineVariant),

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -93,6 +93,9 @@ class SoundsViewModel(
     private val _buttonRenamedEvent = Channel<String>(Channel.BUFFERED)
     val buttonRenamedEvent: Flow<String> = _buttonRenamedEvent.receiveAsFlow()
 
+    private val _scrollToTopEvent = Channel<Unit>(Channel.BUFFERED)
+    val scrollToTopEvent: Flow<Unit> = _scrollToTopEvent.receiveAsFlow()
+
     private val _playbackErrorEvent = Channel<Unit>(Channel.BUFFERED)
     val playbackErrorEvent: Flow<Unit> = _playbackErrorEvent.receiveAsFlow()
 
@@ -148,7 +151,6 @@ class SoundsViewModel(
     }
 
     fun togglePin(sound: Sound) {
-        if (sound.isBundled()) return
         val nowPinned = !sound.isPinned
         val sortedList = { list: List<Sound> ->
             list
@@ -162,6 +164,7 @@ class SoundsViewModel(
         _sounds.update(sortedList)
         allSoundsCache.update { list -> list.map { if (it.name == sound.name) it.copy(isPinned = nowPinned) else it } }
         recomputeSearchResults()
+        if (nowPinned) _scrollToTopEvent.trySend(Unit)
         viewModelScope.launch(ioDispatcher) {
             SoundDao().savePin(getApplication(), sound.name, nowPinned)
         }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -23,7 +23,6 @@
     <string name="app_feedback_button_renamed">¡%1$s renombrado!</string>
     <string name="app_pin">Destacar al inicio</string>
     <string name="app_unpin">Quitar destacado</string>
-    <string name="app_pinned">Destacado</string>
     <string name="app_delete">Eliminar</string>
 
     <string name="app_overflow_menu">Más opciones</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,7 +23,6 @@
     <string name="app_feedback_button_renamed">%1$s renamed!</string>
     <string name="app_pin">Pin to top</string>
     <string name="app_unpin">Unpin</string>
-    <string name="app_pinned">Pinned</string>
     <string name="app_delete">Delete</string>
 
     <string name="app_overflow_menu">More options</string>

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItemTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItemTest.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeLeft
@@ -201,8 +202,32 @@ internal class SoundItemTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `bundled sound does not trigger any callback on swipe`() {
+    fun `swipe right on bundled sound triggers pin callback`() {
         var pinCallCount = 0
+        val sound = Sound("bundled sound", rawRes = 1)
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                SoundItem(
+                    sound = sound,
+                    playbackProgress = null,
+                    onPlayClick = {},
+                    onSeek = {},
+                    onShareClick = {},
+                    onDelete = {},
+                    onPinClick = { pinCallCount++ },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("bundled sound").performTouchInput { swipeRight() }
+        composeTestRule.waitForIdle()
+
+        assertThat(pinCallCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `swipe left on bundled sound does not trigger delete callback`() {
         var deleteCallCount = 0
         val sound = Sound("bundled sound", rawRes = 1)
 
@@ -215,17 +240,35 @@ internal class SoundItemTest : AbstractRobolectricTest() {
                     onSeek = {},
                     onShareClick = {},
                     onDelete = { deleteCallCount++ },
-                    onPinClick = { pinCallCount++ },
+                    onPinClick = {},
                 )
             }
         }
 
-        composeTestRule.onNodeWithText("bundled sound").performTouchInput { swipeRight() }
-        composeTestRule.waitForIdle()
         composeTestRule.onNodeWithText("bundled sound").performTouchInput { swipeLeft() }
         composeTestRule.waitForIdle()
 
-        assertThat(pinCallCount).isEqualTo(0)
         assertThat(deleteCallCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `pin button is visible for bundled sound`() {
+        val sound = Sound("bundled sound", rawRes = 1)
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                SoundItem(
+                    sound = sound,
+                    playbackProgress = null,
+                    onPlayClick = {},
+                    onSeek = {},
+                    onShareClick = {},
+                    onDelete = {},
+                    onPinClick = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("Pin to top").assertExists()
     }
 }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItemTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItemTest.kt
@@ -6,11 +6,15 @@
 package com.github.barriosnahuel.vossosunboton.ui.home
 
 import android.os.Build
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTouchInput
@@ -155,6 +159,45 @@ internal class SoundItemTest : AbstractRobolectricTest() {
         }
 
         composeTestRule.onNodeWithText("0:30").assertExists()
+    }
+
+    @Test
+    fun `pinned and unpinned card have the same height`() {
+        var pinnedHeight = 0
+        var unpinnedHeight = 0
+        val sound = Sound("test sound", file = "test.mp3")
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                Column {
+                    Box(modifier = Modifier.onGloballyPositioned { pinnedHeight = it.size.height }) {
+                        SoundItem(
+                            sound = sound.copy(isPinned = true),
+                            playbackProgress = null,
+                            onPlayClick = {},
+                            onSeek = {},
+                            onShareClick = {},
+                            onDelete = {},
+                            onPinClick = {},
+                        )
+                    }
+                    Box(modifier = Modifier.onGloballyPositioned { unpinnedHeight = it.size.height }) {
+                        SoundItem(
+                            sound = sound.copy(isPinned = false),
+                            playbackProgress = null,
+                            onPlayClick = {},
+                            onSeek = {},
+                            onShareClick = {},
+                            onDelete = {},
+                            onPinClick = {},
+                        )
+                    }
+                }
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        assertThat(pinnedHeight).isEqualTo(unpinnedHeight)
     }
 
     @Test

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.After
 import org.junit.Assume.assumeTrue
 import org.junit.Before
@@ -281,6 +282,46 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
                 .first()
                 .name,
         ).isEqualTo("beta")
+    }
+
+    @Test
+    fun `togglePin emits scrollToTopEvent when sound is pinned`() =
+        runTest {
+            val viewModel = givenAViewModel()
+            val sound = Sound("test", file = "test.mp3")
+            viewModel.injectSounds(listOf(sound))
+
+            viewModel.togglePin(sound)
+
+            viewModel.scrollToTopEvent.first()
+        }
+
+    @Test
+    fun `togglePin does not emit scrollToTopEvent when sound is unpinned`() =
+        runTest {
+            val viewModel = givenAViewModel()
+            val sound = Sound("test", "test.mp3", 0, false, isPinned = true)
+            viewModel.injectSounds(listOf(sound))
+
+            viewModel.togglePin(sound)
+
+            val received = withTimeoutOrNull(50) { viewModel.scrollToTopEvent.first() }
+            assertThat(received).isNull()
+        }
+
+    @Test
+    fun `togglePin on bundled sound updates isPinned to true`() {
+        val viewModel = givenAViewModel()
+        val sound = Sound("bundled", rawRes = 1)
+        viewModel.injectSounds(listOf(sound))
+
+        viewModel.togglePin(sound)
+
+        assertThat(
+            viewModel.sounds.value
+                .single { it.name == "bundled" }
+                .isPinned,
+        ).isTrue()
     }
 
     @Test

--- a/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundDao.java
+++ b/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundDao.java
@@ -67,7 +67,14 @@ public class SoundDao {
             sounds.add(new Sound(eachSoundName, fileName, 0, false, isFavorite, dateAdded, isPinned));
         }
 
-        sounds.addAll(PackagedAudios.get(context));
+        for (Sound bundled : PackagedAudios.get(context)) {
+            final boolean isPinned = "true".equals(storage.get(context, SOUNDS_PINNED_PREFIX + bundled.getName()));
+            if (isPinned) {
+                sounds.add(new Sound(bundled.getName(), bundled.getFile(), bundled.getRawRes(), false, bundled.isFavorite(), bundled.getDateAdded(), true));
+            } else {
+                sounds.add(bundled);
+            }
+        }
 
         return sounds;
     }


### PR DESCRIPTION
### Summary
- Bundled sounds (Explore tab) can now be pinned via button tap or swipe right; pin state persists across restarts via `SoundDao` reading `SOUNDS_PINNED_PREFIX` from SharedPrefs at load time
- Swipe left / long press on bundled sounds gives REJECT haptic (2 beeps) and snaps back — no red background, no delete
- Delete haptic on custom sounds changed from REJECT (2 beeps) to CONFIRM (1 beep): a successful delete is a confirmed action, matching the pin gesture
- Pinning any sound (bundled or custom) scrolls the list to top via `scrollToTopEvent` channel in `SoundsViewModel`
- Fixes severe scroll lag on Explore tab: root cause was the deprecated `SwipeToDismissBoxState(density, confirmValueChange)` constructor, which computes anchors eagerly at construction time — replaced with the 2-param non-deprecated constructor, moving EndToStart rejection to `LaunchedEffect`

### Code review tips
- `SoundItem.kt` bundled path now uses the same non-deprecated `SwipeToDismissBoxState` constructor as custom sounds — the previous `confirmValueChange` approach required explicit `density` and caused per-item anchor recomputation during `LazyColumn` scroll (see Compose BOM 2026.04.01 deprecation)
- `CompositionLocalProvider(LocalHapticFeedback provides noOpHaptic)` suppresses the system-level long-press haptic that `combinedClickable` fires automatically, preventing a 1-beep + 2-beep collision; this wrapper is still needed even with the constructor change
- `SoundDao.java` bundled loop: constructs a new `Sound` only when `isPinned = true`; otherwise passes the original `PackagedAudios` instance unchanged — avoid breaking the `dateAdded = null` contract for bundled sounds
- UX delta on reject haptic: fires at swipe settle (after release) rather than at threshold crossing — same as iOS rubber-band, acceptable

### Already tested
- [x] `./gradlew check -x test && ./gradlew test` — all green
- [x] Manual: Explore scroll is smooth, swipe right pins + scrolls to top, swipe left snaps back with 2-beep haptic, long press gives 2-beep haptic, pin persists after app restart