### PR TITLE
chore: add FUNDING.yml and donation buttons (Ko-fi + Cafecito)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,5 +1,4 @@
 # These are supported funding model platforms; see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
-github: barriosnahuel
 ko_fi: barriosnahuel
 custom:
   - https://cafecito.app/barriosnahuel

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# These are supported funding model platforms; see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+github: barriosnahuel
+ko_fi: barriosnahuel
+custom:
+  - https://cafecito.app/barriosnahuel

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ An Android app made, by the moment, only for fun. Currently it's aimed to be use
 [![Semver](https://img.shields.io/badge/SemVer-v2.0.0-green.svg)](http://semver.org/spec/v2.0.0.html)
 [![stable](https://img.shields.io/badge/stability-experimental-green.svg)](https://nodejs.org/api/documentation.html#documentation_stability_index)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE)
-[![Sponsor](https://img.shields.io/github/sponsors/barriosnahuel?logo=github)](https://github.com/sponsors/barriosnahuel)
 
 [![API](https://img.shields.io/badge/API-21%2B-brightgreen.svg?style=flat)](https://source.android.com/setup/start/build-numbers)
 [![API](https://img.shields.io/badge/API-33-brightgreen.svg?style=flat)](https://source.android.com/setup/start/build-numbers)
@@ -14,6 +13,11 @@ An Android app made, by the moment, only for fun. Currently it's aimed to be use
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/50c7ef07a05e47419c084c64dd460c9a)](https://www.codacy.com/app/barrios.nahuel/push-me?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=barriosnahuel/push-me&amp;utm_campaign=Badge_Grade)
 
 Wanna know about the entire tech stack? Check it at [techstack.md](techstack.md).
+
+## Support the project
+
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/Y8Y31YIHWK)
+[![Invitame un café en cafecito.app](https://cdn.cafecito.app/imgs/buttons/button_1.svg)](https://cafecito.app/barriosnahuel)
 
 ## Features 🏁
 - Play packaged audios.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ An Android app made, by the moment, only for fun. Currently it's aimed to be use
 [![Semver](https://img.shields.io/badge/SemVer-v2.0.0-green.svg)](http://semver.org/spec/v2.0.0.html)
 [![stable](https://img.shields.io/badge/stability-experimental-green.svg)](https://nodejs.org/api/documentation.html#documentation_stability_index)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE)
+[![Sponsor](https://img.shields.io/github/sponsors/barriosnahuel?logo=github)](https://github.com/sponsors/barriosnahuel)
 
 [![API](https://img.shields.io/badge/API-21%2B-brightgreen.svg?style=flat)](https://source.android.com/setup/start/build-numbers)
 [![API](https://img.shields.io/badge/API-33-brightgreen.svg?style=flat)](https://source.android.com/setup/start/build-numbers)


### PR DESCRIPTION
### Summary
- Adds `.github/FUNDING.yml` declaring Ko-fi and Cafecito as funding channels — drives the native "Sponsor this project" button on the GitHub repo page.
- Adds a dedicated `## Support the project` section in the README with the official Ko-fi and Cafecito buttons, intentionally separated from the project-status / tech-stack badges so the two visual languages don't mix.
- GitHub Sponsors is **out of scope** for this PR by product decision: the two existing channels (Ko-fi + Cafecito) are enough for now and avoid the Stripe Connect KYC overhead.
- Phase 0 prerequisite for the in-app donations trident (Fase 2). The trident spec still references three channels; that revisit will happen when the in-app flow gets implemented.

### Code review tips
- `.github/FUNDING.yml` is a public file and contains only handles / public URLs — no secrets. A typo in `ko_fi:` would silently break the native Sponsor button dropdown; confirm `barriosnahuel` is the right Ko-fi handle.
- Ko-fi button URL uses the page id `Y8Y31YIHWK` (Ko-fi's official embed pattern), while `FUNDING.yml` uses the username `barriosnahuel` — both resolve to the same Ko-fi profile but live in different fields by design.
- The `## Support the project` section is placed right after `## Project status` so it doesn't get visually conflated with the build / version / license badges above it.

### Already tested
- [x] `FUNDING.yml` parses cleanly (no trailing whitespace, valid YAML).
- [x] All referenced URLs are public and resolve in a browser.
- [ ] After merge: verify the "Sponsor this project" button appears at https://github.com/barriosnahuel/push-me with Ko-fi + Cafecito entries.
- [ ] After merge: verify the README renders the two donation buttons in their own section.