### PR TITLE
docs(claude): codify FakeAnalyticsTracker substitution rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,9 @@ Hard rules that affect how to write code:
   `tracker.logScreen(CanonicalScreenName.X)` manually with a canonical literal.
 - The `first_*` variant is emitted by the wrapper when the event declares
   `hasFirstVariant = true` — call-sites never reference `first_*` directly.
+- In tests, substitute the tracker via `AnalyticsTrackerProvider.setForTest(FakeAnalyticsTracker())`
+  and assert with `fake.assertEmitted(...)` / `fake.assertScreenView(...)` — never mock
+  `AnalyticsTracker` directly. The fake lives in `:commons_android` test fixtures.
 
 When adding a new track, follow `CONTRIBUTING.md` § "Analytics events 📊" — the
 naming rules, regression-test matrix, and DebugView / `adb logcat -s FA FA-SVC`


### PR DESCRIPTION
### Summary
- Adds a 4th hard rule under "Analytics events" in CLAUDE.md so tests substitute the tracker via `AnalyticsTrackerProvider.setForTest(FakeAnalyticsTracker())` and assert with `fake.assertEmitted(...)` / `fake.assertScreenView(...)`, never by mocking `AnalyticsTracker` directly.
- Reflects the contract already enforced at runtime by `AnalyticsTrackerProvider` and at CI time by the analytics regression net (#1077). This PR just makes it discoverable so future contributors don't have to re-derive it.

### Code review tips
- Doc-only change. The new bullet sits between the existing `first_*` rule and the "When adding a new track" pointer to `CONTRIBUTING.md`. Verify wording, ordering, and indentation match the surrounding hard rules.

### Already tested
- N/A — doc-only, no code paths touched.