### PR TITLE
Cover AddButtonScreen analytics events under Robolectric

### DIFF
--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeatureProvider.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeatureProvider.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.addbutton
+
+import androidx.annotation.VisibleForTesting
+
+/**
+ * Factory for the [AddButtonFeature] singleton. Call sites obtain the feature via [get]; tests inject a fake via
+ * [setForTest]. Mirrors `AnalyticsTrackerProvider` so the AddButton flow is substitutable from Robolectric Compose
+ * tests without mocking the Firebase wrapper or reaching into the underlying file I/O.
+ */
+object AddButtonFeatureProvider {
+    @Volatile
+    private var override: AddButtonFeature? = null
+
+    fun get(): AddButtonFeature = override ?: AddButtonFeature.instance
+
+    /**
+     * Replace the production feature for tests. Call from `@Before`; reset to `null` from `@After` if isolation is
+     * needed.
+     */
+    @VisibleForTesting
+    fun setForTest(feature: AddButtonFeature?) {
+        override = feature
+    }
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
@@ -95,10 +95,11 @@ fun AddButtonScreen(
         coroutineScope.launch {
             val trimmedName = name.trim()
             val tracker = AnalyticsTrackerProvider.get(context.applicationContext)
+            val feature = AddButtonFeatureProvider.get()
             when (val m = mode) {
                 is AddButtonMode.Create -> {
                     val feedbackId =
-                        AddButtonFeature.instance.saveNewButtonAsync(context, trimmedName, m.uri.toString()).await()
+                        feature.saveNewButtonAsync(context, trimmedName, m.uri.toString()).await()
                     if (feedbackId == R.string.app_addbutton_feedback_saved_ok) {
                         val totalSounds = withContext(Dispatchers.IO) { SoundDao().find(context).size }
                         tracker.log(
@@ -113,7 +114,7 @@ fun AddButtonScreen(
                     }
                 }
                 is AddButtonMode.Edit -> {
-                    AddButtonFeature.instance.renameButtonAsync(context, m.sound, trimmedName).await()
+                    feature.renameButtonAsync(context, m.sound, trimmedName).await()
                     tracker.log(
                         AnalyticsEvent.SoundEdit(
                             nameLength = trimmedName.length,

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenAnalyticsTest.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.addbutton
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.FakeAnalyticsTracker
+import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.github.barriosnahuel.vossosunboton.ui.home.LandingActivity
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.robolectric.annotation.Config
+
+@Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+internal class AddButtonScreenAnalyticsTest : AbstractRobolectricTest() {
+    @get:Rule
+    val composeTestRule = createEmptyComposeRule()
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    private lateinit var fake: FakeAnalyticsTracker
+    private lateinit var feature: FakeAddButtonFeature
+
+    @Before
+    fun setUp() {
+        fake = FakeAnalyticsTracker()
+        AnalyticsTrackerProvider.setForTest(fake)
+        feature = FakeAddButtonFeature()
+        AddButtonFeatureProvider.setForTest(feature)
+    }
+
+    @After
+    fun tearDown() {
+        AnalyticsTrackerProvider.setForTest(null)
+        AddButtonFeatureProvider.setForTest(null)
+    }
+
+    @Test
+    fun `Create mode emits screen_view add_sound on first composition`() {
+        ActivityScenario.launch<AddButtonActivity>(createIntent()).use {
+            composeTestRule.waitForIdle()
+
+            val screen = fake.assertScreenView(CanonicalScreenName.ADD_SOUND)
+            assertThat(screen.extras["source"]).isEqualTo(AddButtonActivity.SOURCE_SHARE)
+        }
+    }
+
+    @Test
+    fun `Edit mode emits screen_view edit_sound on first composition`() {
+        ActivityScenario.launch<AddButtonActivity>(editIntent()).use {
+            composeTestRule.waitForIdle()
+
+            fake.assertScreenView(CanonicalScreenName.EDIT_SOUND)
+        }
+    }
+
+    @Test
+    fun `saving a new button emits sound_add and does not emit sound_edit`() {
+        ActivityScenario.launch<AddButtonActivity>(createIntent()).use {
+            composeTestRule.waitForIdle()
+            composeTestRule.onNode(hasSetTextAction()).performTextInput(NEW_NAME)
+            composeTestRule.onNodeWithText(context.getString(R.string.app_addbutton_save)).performClick()
+            composeTestRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) { fake.events.isNotEmpty() }
+
+            assertThat(feature.saveNewCalls).isEqualTo(1)
+            val event = fake.assertEmitted("sound_add")
+            assertThat(event.params["source"]).isEqualTo(AddButtonActivity.SOURCE_SHARE)
+            assertThat(event.params["name_length"]).isEqualTo(NEW_NAME.length)
+            fake.assertNotEmitted("sound_edit")
+        }
+    }
+
+    @Test
+    fun `renaming an existing button emits sound_edit and does not emit sound_add`() {
+        ActivityScenario.launch<AddButtonActivity>(editIntent()).use {
+            composeTestRule.waitForIdle()
+            composeTestRule
+                .onNodeWithText(context.getString(R.string.app_addbutton_save_changes))
+                .performClick()
+            composeTestRule.waitForIdle()
+
+            val event = fake.assertEmitted("sound_edit")
+            assertThat(event.params["name_changed"]).isEqualTo(false)
+            assertThat(event.params["name_length"]).isEqualTo(EXISTING_NAME.length)
+            fake.assertNotEmitted("sound_add")
+        }
+    }
+
+    @Test
+    fun `Create flow does not emit sound_add when saveNewButtonAsync signals the generic error`() {
+        feature.saveNewFeedback = R.string.app_feedback_generic_error_contact_support
+
+        ActivityScenario.launch<AddButtonActivity>(createIntent()).use {
+            composeTestRule.waitForIdle()
+            composeTestRule.onNode(hasSetTextAction()).performTextInput(NEW_NAME)
+            composeTestRule.onNodeWithText(context.getString(R.string.app_addbutton_save)).performClick()
+            composeTestRule.waitForIdle()
+
+            assertThat(feature.saveNewCalls).isEqualTo(1)
+            fake.assertNotEmitted("sound_add")
+        }
+    }
+
+    private fun createIntent(): Intent =
+        Intent(context, AddButtonActivity::class.java).apply {
+            action = Intent.ACTION_SEND
+            type = "audio/*"
+            putExtra(Intent.EXTRA_STREAM, SAMPLE_URI)
+        }
+
+    private fun editIntent(): Intent =
+        Intent(context, AddButtonActivity::class.java).apply {
+            putExtra(LandingActivity.EXTRA_EDIT_SOUND_NAME, EXISTING_NAME)
+        }
+
+    /**
+     * Test double for [AddButtonFeature]. Returns already-completed deferreds so the Compose `coroutineScope.launch`
+     * inside `save()` does not race with `composeTestRule.waitForIdle()`.
+     */
+    private class FakeAddButtonFeature : AddButtonFeature {
+        var saveNewFeedback: Int = R.string.app_addbutton_feedback_saved_ok
+        var saveNewCalls: Int = 0
+
+        override fun saveNewButtonAsync(
+            context: Context,
+            name: String,
+            uri: String,
+        ): Deferred<Int> {
+            saveNewCalls += 1
+            return CompletableDeferred(saveNewFeedback)
+        }
+
+        override fun renameButtonAsync(
+            context: Context,
+            sound: Sound,
+            newName: String,
+        ): Deferred<Unit> = CompletableDeferred(Unit)
+    }
+
+    private companion object {
+        val SAMPLE_URI: Uri = Uri.parse("content://test/audio.mp3")
+        const val NEW_NAME = "Test sound"
+        const val EXISTING_NAME = "Existing sound"
+        const val WAIT_TIMEOUT_MS = 5_000L
+    }
+}


### PR DESCRIPTION
### Summary

- Self-review follow-up #4 from PR #1077: AddButtonScreen's analytics paths were the last hole in the regression net because `AddButtonFeature.instance` could not be replaced from a Compose-side test.
- Introduces `AddButtonFeatureProvider` (mirroring `AnalyticsTrackerProvider` exactly) so tests can swap in a fake feature via `setForTest(...)`.
- New `AddButtonScreenAnalyticsTest` drives `AddButtonActivity` under Robolectric and asserts `sound_add`, `sound_edit`, the `add_sound` / `edit_sound` `screen_view` literals, and a negative guard on the generic-error feedback id from `saveNewButtonAsync`.

### Code review tips

- `AddButtonFeatureProvider`: identical shape to `AnalyticsTrackerProvider` — falls back to `AddButtonFeature.instance` when no override is set, so production behavior is unchanged.
- `AddButtonScreen.kt`: the only call-site change is `feature` resolved once at the top of `save()` instead of two `AddButtonFeature.instance` references. Verify no third call-site got missed.
- The failure-mode test covers the realistic path: Create with `feedbackId != app_addbutton_feedback_saved_ok` must skip emission. There is no equivalent gate on the Edit path today, which the test reflects.
- The happy-path Create assertion uses `waitUntil { fake.events.isNotEmpty() }` because `withContext(Dispatchers.IO) { SoundDao().find(...) }` between save() and the tracker call is not pumped by `waitForIdle`.

### Already tested

- [x] `./gradlew check -x test`
- [x] `./gradlew test`
- New: `AddButtonScreenAnalyticsTest` (5 tests, all passing under Robolectric)