### PR TITLE
Validate inbound URIs and lock deep-link routing to an allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Custom button audio files are now named after the user-provided sound name (non-alphanumeric chars replaced by underscores) instead of the generic "Button-custom-" prefix.
 
 ### Fixed
+- Validate inbound audio URIs by scheme, MIME type, and size before importing
+- Restrict deep link routing to a known path allowlist with a safe fallback to My Sounds
 - The app now opens the Home tab on launch instead of the Search tab
 - After saving a button via the share intent, the app now navigates to the Home tab and shows a "Saved!" confirmation Snackbar instead of silently returning to the previous app
 - The Add Button screen no longer appears in the recent apps tray after saving

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,6 +284,60 @@ All UI development and generated assets (store listing, What's New, changelogs) 
 
 Verify contrast when adding or changing colors. Use the [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/) or the Material Theme Builder. The brand palette in `AppTheme.kt` was designed to meet AA across all color roles. **All critical role pairs are automatically verified by `AppThemeContrastTest`** — if you change the palette and a test fails, fix the theme, not the test.
 
+## Security boundaries
+
+Concrete rules for input/output validation and component exposure. These match
+the existing concrete style of the rest of this doc — narrow, enforceable, no
+generic policy framing.
+
+### Inbound URI validation
+
+When the app receives a `Uri` via `Intent.EXTRA_STREAM` or `ACTION_SEND` (today
+only `AddButtonActivity`), validate it before opening the stream:
+
+- **Scheme allowlist:** only `content` and `file` pass; reject everything else
+  (e.g. `http`, `javascript`, `data`).
+- **MIME type:** `ContentResolver.getType(uri)` must start with `audio/`. If
+  null, reject — no MIME means we don't know what we're opening.
+- **Size cap:** reject inputs over 50 MB (≈4× a 5-min MP3 at 320 kbps; rejects
+  pathological inputs while leaving headroom). Resolve size via
+  `ContentResolver.openAssetFileDescriptor(uri, "r")?.length` or
+  `OpenableColumns.SIZE`. Unknown size also rejects.
+- **Failure mode:** surface a typed feedback string-res to the caller (same
+  channel as `app_feedback_generic_error_contact_support`). Never throw raw.
+
+The canonical implementation lives in `AddButtonFeature.saveNewButtonAsync`.
+Any future inbound-URI surface must call the same validator.
+
+### Deep link path allowlist
+
+`push-me://open<path>` routes against a closed allowlist of known destinations
+declared in `LandingActivity.handleDeeplink`. Today: `/home` → `MY_SOUNDS`,
+`/explore` → `EXPLORE_SOUNDS`. **Unknown paths fall back to `MY_SOUNDS`** (the
+safe default) — never silently route to Explore or any other tab. New
+destinations require an explicit branch in the `when`; the `else` stays
+`MY_SOUNDS`.
+
+### Backup hygiene
+
+Before adding any new SharedPreferences key or file path that could contain
+sensitive data (auth tokens, account identifiers, private user content), add
+explicit `<exclude>` entries to both `app/src/main/res/xml/app_backup_rules.xml`
+and `app/src/main/res/xml/app_data_extraction_rules.xml`. Today nothing
+sensitive is stored, so the rules are intentionally permissive (`<include>` of
+`my-prefs` and the `Music` external dir). When that changes, the exclusion
+ships in the same commit as the new key.
+
+### Exported components default to false
+
+New `Activity`/`Service`/`Receiver` declarations in `AndroidManifest.xml`
+default `android:exported="false"`. Set `true` only when the component has an
+`<intent-filter>` for external callers; in that case, add a comment above the
+declaration documenting which intents it accepts and from where (launcher,
+system share sheet, deep link, etc.). The two exported activities today are
+`LandingActivity` (LAUNCHER + `push-me://open` deep link) and
+`AddButtonActivity` (system share-sheet `ACTION_SEND` with `audio/*`).
+
 ## Design system
 
 The app uses the **Neo-Club** palette (ink × acid). Single source of truth: `app/src/main/java/…/ui/theme/AppTheme.kt`.

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
@@ -5,9 +5,11 @@
  */
 package com.github.barriosnahuel.vossosunboton.feature.addbutton
 
+import android.content.ContentResolver
 import android.content.Context
 import android.media.MediaMetadataRetriever
 import android.net.Uri
+import android.provider.OpenableColumns
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.file.copy
 import com.github.barriosnahuel.vossosunboton.commons.file.getFile
@@ -54,10 +56,14 @@ private class AddButtonFeatureImpl : AddButtonFeature {
 
         @OptIn(DelicateCoroutinesApi::class)
         return GlobalScope.async(Dispatchers.IO) {
-            var feedbackMessage = com.github.barriosnahuel.vossosunboton.R.string.app_feedback_generic_error_contact_support
+            var feedbackMessage = R.string.app_feedback_generic_error_contact_support
+            val parsed = Uri.parse(uri)
+            if (validateAudioUri(context, parsed) != ValidationResult.Ok) {
+                return@async feedbackMessage
+            }
             try {
                 FileOutputStream(targetFile).use { fileOutputStream ->
-                    context.contentResolver.openInputStream(Uri.parse(uri)).use { inputStream ->
+                    context.contentResolver.openInputStream(parsed).use { inputStream ->
                         if (inputStream == null) {
                             Timber.e("Input stream obtained from the specified content URI is null: %s", uri)
                         } else {
@@ -100,5 +106,61 @@ private class AddButtonFeatureImpl : AddButtonFeature {
         return GlobalScope.async(Dispatchers.IO) {
             SoundDao().rename(context, sound, newName)
         }
+    }
+
+    private fun validateAudioUri(
+        context: Context,
+        uri: Uri,
+    ): ValidationResult {
+        val resolver = context.contentResolver
+        val mime = resolver.getType(uri)
+        val size = resolveSize(resolver, uri)
+        val rejection =
+            when {
+                uri.scheme !in ALLOWED_SCHEMES -> "scheme=${uri.scheme}"
+                mime == null || !mime.startsWith(AUDIO_MIME_PREFIX) -> "mime=$mime"
+                size == null || size > MAX_AUDIO_BYTES -> "size=$size"
+                else -> null
+            }
+        return if (rejection == null) {
+            ValidationResult.Ok
+        } else {
+            Timber.w("Rejected inbound URI: %s", rejection)
+            ValidationResult.Rejected
+        }
+    }
+
+    private fun resolveSize(
+        resolver: ContentResolver,
+        uri: Uri,
+    ): Long? {
+        val fromAfd =
+            runCatching {
+                resolver.openAssetFileDescriptor(uri, "r")?.use { afd ->
+                    afd.length.takeIf { len -> len >= 0 }
+                }
+            }.getOrNull()
+        return fromAfd ?: runCatching {
+            resolver.query(uri, arrayOf(OpenableColumns.SIZE), null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst() && !cursor.isNull(0)) cursor.getLong(0) else null
+            }
+        }.getOrNull()
+    }
+
+    private sealed class ValidationResult {
+        data object Ok : ValidationResult()
+
+        data object Rejected : ValidationResult()
+    }
+
+    private companion object {
+        /**
+         * 50 MB cap — ≈4× a 5-min MP3 at 320 kbps; rejects pathological inputs while leaving
+         * headroom for long voice notes and lossy stems. Constant lives here, not in resources,
+         * because tests need a stable JVM-side reference.
+         */
+        const val MAX_AUDIO_BYTES = 50L * 1024 * 1024
+        const val AUDIO_MIME_PREFIX = "audio/"
+        val ALLOWED_SCHEMES = setOf(ContentResolver.SCHEME_CONTENT, ContentResolver.SCHEME_FILE)
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivity.kt
@@ -53,10 +53,13 @@ class LandingActivity : ComponentActivity() {
 
     private fun handleDeeplink(intent: Intent) {
         val uri = intent.data ?: return
+        // Closed allowlist of known deep-link destinations. Unknown paths fall back to MY_SOUNDS
+        // (the safe default) so we never silently route to a tab the link did not name.
         val requested =
             when (uri.path) {
                 "/home" -> AppTab.MY_SOUNDS
-                else -> AppTab.EXPLORE_SOUNDS
+                "/explore" -> AppTab.EXPLORE_SOUNDS
+                else -> AppTab.MY_SOUNDS
             }
         // Explore is empty in release builds (no bundled audios) and in any debug build that
         // hasn't populated model/src/debug/res/raw/. Routing there would land on a blank tab,

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeatureTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeatureTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.addbutton
+
+import android.content.ContentResolver
+import android.content.Context
+import android.content.res.AssetFileDescriptor
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.R
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.robolectric.Shadows.shadowOf
+import java.io.ByteArrayInputStream
+
+internal class AddButtonFeatureTest : AbstractRobolectricTest() {
+    private val realContext: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `saveNewButtonAsync saves a valid audio URI and returns saved_ok`() {
+        val uri = Uri.parse("content://test/valid-audio")
+        val context = contextWith(uri, mime = "audio/mpeg", sizeBytes = 1024L)
+
+        val result =
+            runBlocking {
+                AddButtonFeature.instance.saveNewButtonAsync(context, "valid", uri.toString()).await()
+            }
+
+        assertThat(result).isEqualTo(R.string.app_addbutton_feedback_saved_ok)
+    }
+
+    @Test
+    fun `saveNewButtonAsync rejects URIs with non-audio MIME types`() {
+        val uri = Uri.parse("content://test/zip-file")
+        val context = contextWith(uri, mime = "application/zip", sizeBytes = 1024L)
+
+        val result =
+            runBlocking {
+                AddButtonFeature.instance.saveNewButtonAsync(context, "zip", uri.toString()).await()
+            }
+
+        assertThat(result).isEqualTo(R.string.app_feedback_generic_error_contact_support)
+    }
+
+    @Test
+    fun `saveNewButtonAsync rejects URIs that exceed the maximum allowed size`() {
+        val uri = Uri.parse("content://test/huge-audio")
+        val tooLarge = 50L * 1024 * 1024 + 1
+        val context = contextWith(uri, mime = "audio/mpeg", sizeBytes = tooLarge)
+
+        val result =
+            runBlocking {
+                AddButtonFeature.instance.saveNewButtonAsync(context, "huge", uri.toString()).await()
+            }
+
+        assertThat(result).isEqualTo(R.string.app_feedback_generic_error_contact_support)
+    }
+
+    @Test
+    fun `saveNewButtonAsync rejects URIs with unsupported schemes`() {
+        val uri = Uri.parse("http://example.com/foo.mp3")
+
+        val result =
+            runBlocking {
+                AddButtonFeature.instance.saveNewButtonAsync(realContext, "http", uri.toString()).await()
+            }
+
+        assertThat(result).isEqualTo(R.string.app_feedback_generic_error_contact_support)
+    }
+
+    @Test
+    fun `saveNewButtonAsync rejects URIs whose MIME type is unknown`() {
+        val uri = Uri.parse("content://test/no-mime")
+        val context = contextWith(uri, mime = null, sizeBytes = 1024L)
+
+        val result =
+            runBlocking {
+                AddButtonFeature.instance.saveNewButtonAsync(context, "nomime", uri.toString()).await()
+            }
+
+        assertThat(result).isEqualTo(R.string.app_feedback_generic_error_contact_support)
+    }
+
+    /**
+     * Wraps the Robolectric application in a spy so we can stub the [ContentResolver] surfaces
+     * the validator depends on (`getType`, `openAssetFileDescriptor`) without touching the real
+     * MediaStore. The shadow resolver still serves `openInputStream` for the happy-path copy.
+     */
+    private fun contextWith(
+        uri: Uri,
+        mime: String?,
+        sizeBytes: Long,
+    ): Context {
+        val baseResolver = realContext.contentResolver
+        shadowOf(baseResolver).registerInputStream(uri, ByteArrayInputStream(ByteArray(0)))
+        val resolver = spyk(baseResolver)
+        every { resolver.getType(uri) } returns mime
+        val afd = mockk<AssetFileDescriptor>(relaxed = true)
+        every { afd.length } returns sizeBytes
+        every { resolver.openAssetFileDescriptor(uri, "r") } returns afd
+
+        val context = spyk(realContext)
+        every { context.contentResolver } returns resolver
+        return context
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivityTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivityTest.kt
@@ -5,13 +5,16 @@
  */
 package com.github.barriosnahuel.vossosunboton.ui.home
 
+import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
+import com.github.barriosnahuel.vossosunboton.model.data.local.defaultaudios.PackagedAudios
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockkObject
@@ -68,5 +71,55 @@ internal class LandingActivityTest : AbstractRobolectricTest() {
 
         val viewModel = ViewModelProvider(controller.get(), SoundsViewModel.Factory)[SoundsViewModel::class.java]
         assertThat(viewModel.selectedTab.value).isEqualTo(AppTab.MY_SOUNDS)
+    }
+
+    @Test
+    fun `deep link with home path opens MY_SOUNDS tab`() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("push-me://open/home"))
+        ActivityScenario.launch<LandingActivity>(intent).use { scenario ->
+            scenario.onActivity { activity ->
+                val viewModel = ViewModelProvider(activity, SoundsViewModel.Factory)[SoundsViewModel::class.java]
+                assertThat(viewModel.selectedTab.value).isEqualTo(AppTab.MY_SOUNDS)
+            }
+        }
+    }
+
+    @Test
+    fun `deep link with explore path opens EXPLORE_SOUNDS tab when bundled audios exist`() {
+        // Skip when this checkout has no bundled audios — the empty-Explore UX fallback would
+        // mask the allowlist behaviour we want to assert. Run only on debug builds with raw/.
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        if (PackagedAudios.get(ctx).isEmpty()) {
+            return
+        }
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("push-me://open/explore"))
+        ActivityScenario.launch<LandingActivity>(intent).use { scenario ->
+            scenario.onActivity { activity ->
+                val viewModel = ViewModelProvider(activity, SoundsViewModel.Factory)[SoundsViewModel::class.java]
+                assertThat(viewModel.selectedTab.value).isEqualTo(AppTab.EXPLORE_SOUNDS)
+            }
+        }
+    }
+
+    @Test
+    fun `deep link with unknown path falls back to MY_SOUNDS tab`() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("push-me://open/unknown"))
+        ActivityScenario.launch<LandingActivity>(intent).use { scenario ->
+            scenario.onActivity { activity ->
+                val viewModel = ViewModelProvider(activity, SoundsViewModel.Factory)[SoundsViewModel::class.java]
+                assertThat(viewModel.selectedTab.value).isEqualTo(AppTab.MY_SOUNDS)
+            }
+        }
+    }
+
+    @Test
+    fun `deep link with no path falls back to MY_SOUNDS tab`() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("push-me://open"))
+        ActivityScenario.launch<LandingActivity>(intent).use { scenario ->
+            scenario.onActivity { activity ->
+                val viewModel = ViewModelProvider(activity, SoundsViewModel.Factory)[SoundsViewModel::class.java]
+                assertThat(viewModel.selectedTab.value).isEqualTo(AppTab.MY_SOUNDS)
+            }
+        }
     }
 }


### PR DESCRIPTION
### Summary
- Adds a `## Security boundaries` section to `CLAUDE.md` with four enforceable rules: inbound URI validation, deep-link allowlist, backup hygiene, and `exported="false"` default.
- `AddButtonFeature.saveNewButtonAsync` now validates scheme (`content`/`file`), MIME (`audio/*`), and size (<= 50 MB) before opening the stream; rejection surfaces the existing generic error string.
- `LandingActivity.handleDeeplink` replaces the "anything else -> Explore" fallback with an explicit allowlist; unknown paths now route to `MY_SOUNDS`.

### Code review tips
- `MAX_AUDIO_BYTES = 50 MB` (~4x a 5-min MP3 @ 320 kbps). Push back if you want a different cap; constant lives in `AddButtonFeatureImpl` so tests have a stable JVM ref.
- `validateAudioUri` runs inside the existing `GlobalScope.async(Dispatchers.IO)` block, keeping the cursor query off the main thread.
- `resolveSize` tries `openAssetFileDescriptor.length` first, falls back to `OpenableColumns.SIZE`. Returns null on unknown size, which is also rejected.
- `LandingActivity` allowlist: only `/home` and `/explore` today. New destinations require a new `when` branch — never broaden the `else`.
- `commons_file/FileUtils.kt` left untouched: size enforcement belongs at the inbound boundary, not in the generic copy helper.

### Already tested
- [x] `./gradlew check -x test` — clean (ktlint, detekt, Spotless, Android lint)
- [x] `./gradlew test` — all unit/Robolectric tests pass; 5 new `AddButtonFeatureTest` cases and 4 new `LandingActivityTest` cases included
- [ ] Local UI test suite (`./gradlew app:connectedDebugAndroidTest`) — not run from this worktree; recommend before merge