### PR TITLE
Add Privacy Policy and Data Safety links to About

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Sound cards now have a subtle 1dp hairline border for visual separation on dark and light backgrounds
 
 ### Added
+- Privacy Policy and Data Safety links added to the About screen's new "Legal & Privacy" section, opening the published pages with `?hl=` matched to the device locale (es-AR, es-419, es-ES, en, pt-BR)
 - Firebase Analytics instrumentation: emits events for every active user flow (add, edit, delete, play, pin, search, share, about) plus 6 canonical `screen_view` names (`my_sounds`, `explore_sounds`, `about`, `search_sound`, `add_sound`, `edit_sound`) with auto-tracking disabled, one-shot `first_*` variants on first invocation, and user properties (`current_sounds`, `current_pinned`, `lifetime_shares`, `lifetime_plays`) that unlock cohort segmentation in Firebase Console
 - Renamed the first bottom-nav tab from "Inicio"/"Home" to "Mis audios"/"My Sounds" so the visible label matches the canonical telemetry `screen_name`
 - Bundled sounds (Explore tab) can now be pinned to the top via button tap or swipe right, with the pinned state persisting across app restarts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,46 @@ merging; the aggregated Reports dashboards have a 24–48 h delay and do not
 confirm a single new event.
 
 
+## Error tracking (non-fatals)
+
+Non-fatal exceptions go to Firebase Crashlytics through the `Tracker` wrapper at
+`commons_android/.../error/Trackable.kt`. Two methods, very different effects:
+
+- `Tracker.track(throwable)` → calls `FirebaseCrashlytics.recordException(...)`.
+  **This is what shows up as a non-fatal in the Crashlytics dashboard** with the
+  full stack trace. Use this for any caught exception you want operations to
+  see.
+- `Tracker.log(message)` → calls `FirebaseCrashlytics.log(...)`. **Breadcrumb
+  only**: it is attached to the next crash/non-fatal recorded after it, and is
+  invisible in the dashboard until then. Useful right before a `Tracker.track(...)`
+  to attach extra context, not as a standalone report.
+
+Hard rules that affect how to write error-handling code:
+
+- **Do NOT rely on `Timber.e(throwable, message)` to surface a non-fatal.** The
+  `ErrorTrackerTree` Timber tree (planted in debug and release) forwards only
+  the formatted message via `Tracker.log(...)` — the throwable parameter is
+  silently dropped. As a maintainer you will not see those events as non-fatals
+  in the dashboard. `Timber.e` / `Timber.w` are fine for logcat-only diagnostic
+  output during development.
+- For caught exceptions, follow the established pattern (see
+  `PlayerControllerImpl.kt`): wrap the cause in a `RuntimeException` whose
+  message describes the operation, then hand it to `Tracker.track`. The wrapper
+  message becomes the searchable Crashlytics title; the original throwable is
+  preserved as `cause` with full stack trace.
+  ```kotlin
+  } catch (e: ActivityNotFoundException) {
+      Tracker.track(RuntimeException("Could not launch ACTION_VIEW for $url", e))
+      // ...recovery UI (snackbar, fallback) goes here
+  }
+  ```
+- A caught exception that is **expected and recoverable** (e.g. user dismissed
+  a chooser) does not need `Tracker.track`. Reserve it for things you want to
+  investigate.
+- In tests, you can mock `Tracker` with MockK (see `PlayerControllerTest.kt`):
+  `every { Tracker.track(any()) } answers { nothing }`.
+
+
 ## Worktree setup
 
 After creating a new worktree, always run these commands to replace the dummy `google-services.json` and copy the bundled audio files from the main worktree:

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenFlowTest.kt
@@ -8,12 +8,15 @@ package com.github.barriosnahuel.vossosunboton.ui.about
 import android.app.Activity
 import android.app.Instrumentation
 import android.content.Intent
+import android.net.Uri
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.intent.Intents.intended
@@ -24,6 +27,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.barriosnahuel.vossosunboton.AbstractUiTest
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.ui.home.LandingActivity
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import org.hamcrest.TypeSafeMatcher
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -110,11 +116,53 @@ internal class AboutScreenFlowTest : AbstractUiTest() {
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             openAbout()
-            composeRule.onNodeWithText(sourceLabel()).performClick()
+            composeRule.onNodeWithText(sourceLabel()).performScrollTo().performClick()
             composeRule.waitForIdle()
             // The data URL is unique to this button's ACTION_VIEW; matching the URL alone
             // is sufficient and avoids the hamcrest 1.3 `allOf(2-arg)` API gap.
             intended(hasData(context.getString(R.string.app_about_source_url)))
+        }
+    }
+
+    @Test
+    fun privacyPolicyItemEmitsActionViewIntentWithLocalizedHl() {
+        intending(hasAction(Intent.ACTION_VIEW))
+            .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, null))
+
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            openAbout()
+            composeRule.onNodeWithText(privacyPolicyLabel()).performScrollTo().performClick()
+            composeRule.waitForIdle()
+            intended(hasData(matchesSupportedHl(context.getString(R.string.app_about_privacy_policy_url))))
+        }
+    }
+
+    @Test
+    fun dataSafetyItemEmitsActionViewIntentWithLocalizedHl() {
+        intending(hasAction(Intent.ACTION_VIEW))
+            .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, null))
+
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            openAbout()
+            composeRule.onNodeWithText(dataSafetyLabel()).performScrollTo().performClick()
+            composeRule.waitForIdle()
+            intended(hasData(matchesSupportedHl(context.getString(R.string.app_about_data_safety_url))))
+        }
+    }
+
+    @Test
+    fun externalLegalItemsExposeOpensInBrowserHint() {
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            openAbout()
+            composeRule.onNodeWithText(privacyPolicyLabel()).performScrollTo()
+            composeRule
+                .onAllNodesWithContentDescription(context.getString(R.string.app_about_open_in_browser))
+                .fetchSemanticsNodes()
+                .let { nodes ->
+                    assert(nodes.size == EXTERNAL_LEGAL_ITEMS) {
+                        "Expected $EXTERNAL_LEGAL_ITEMS open-in-browser hints, got ${nodes.size}"
+                    }
+                }
         }
     }
 
@@ -149,7 +197,26 @@ internal class AboutScreenFlowTest : AbstractUiTest() {
 
     private fun claudeName() = context.getString(R.string.app_about_ai_claude_name)
 
+    private fun privacyPolicyLabel() = context.getString(R.string.app_about_privacy_policy)
+
+    private fun dataSafetyLabel() = context.getString(R.string.app_about_data_safety)
+
+    private fun matchesSupportedHl(baseUrl: String): Matcher<Uri> =
+        object : TypeSafeMatcher<Uri>() {
+            override fun describeTo(description: Description) {
+                description.appendText("URI matching $baseUrl with supported ?hl= value")
+            }
+
+            override fun matchesSafely(uri: Uri): Boolean {
+                if ("${uri.scheme}://${uri.authority}${uri.path}" != baseUrl) return false
+                val hl = uri.getQueryParameter("hl") ?: return false
+                return hl in SUPPORTED_HL
+            }
+        }
+
     companion object {
         private const val WAIT_TIMEOUT_MS = 5_000L
+        private const val EXTERNAL_LEGAL_ITEMS = 3
+        private val SUPPORTED_HL = setOf("es-AR", "es-419", "es-ES", "en", "pt-BR")
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/AppIcons.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/AppIcons.kt
@@ -151,6 +151,171 @@ public object AppIcons {
             }.build()
     }
 
+    val Description: ImageVector by lazy {
+        ImageVector
+            .Builder(
+                name = "Description",
+                defaultWidth = 24.dp,
+                defaultHeight = 24.dp,
+                viewportWidth = 24f,
+                viewportHeight = 24f,
+            ).apply {
+                path(fill = SolidColor(Color.Black)) {
+                    moveTo(14f, 2f)
+                    horizontalLineTo(6f)
+                    curveToRelative(-1.1f, 0f, -1.99f, 0.9f, -1.99f, 2f)
+                    lineTo(4f, 20f)
+                    curveToRelative(0f, 1.1f, 0.89f, 2f, 1.99f, 2f)
+                    horizontalLineTo(18f)
+                    curveToRelative(1.1f, 0f, 2f, -0.9f, 2f, -2f)
+                    verticalLineTo(8f)
+                    lineToRelative(-6f, -6f)
+                    close()
+                    moveTo(16f, 18f)
+                    horizontalLineTo(8f)
+                    verticalLineToRelative(-2f)
+                    horizontalLineToRelative(8f)
+                    verticalLineToRelative(2f)
+                    close()
+                    moveTo(16f, 14f)
+                    horizontalLineTo(8f)
+                    verticalLineToRelative(-2f)
+                    horizontalLineToRelative(8f)
+                    verticalLineToRelative(2f)
+                    close()
+                    moveTo(13f, 9f)
+                    verticalLineTo(3.5f)
+                    lineTo(18.5f, 9f)
+                    horizontalLineTo(13f)
+                    close()
+                }
+            }.build()
+    }
+
+    val PrivacyTip: ImageVector by lazy {
+        ImageVector
+            .Builder(
+                name = "PrivacyTip",
+                defaultWidth = 24.dp,
+                defaultHeight = 24.dp,
+                viewportWidth = 24f,
+                viewportHeight = 24f,
+            ).apply {
+                path(fill = SolidColor(Color.Black), pathFillType = PathFillType.EvenOdd) {
+                    moveTo(12f, 2f)
+                    lineTo(4f, 5f)
+                    verticalLineToRelative(6f)
+                    curveToRelative(0f, 5.55f, 3.5f, 10.74f, 8f, 12f)
+                    curveToRelative(4.5f, -1.26f, 8f, -6.45f, 8f, -12f)
+                    verticalLineTo(5f)
+                    lineTo(12f, 2f)
+                    close()
+                    moveTo(11f, 7f)
+                    horizontalLineToRelative(2f)
+                    verticalLineToRelative(2f)
+                    horizontalLineToRelative(-2f)
+                    close()
+                    moveTo(11f, 11f)
+                    horizontalLineToRelative(2f)
+                    verticalLineToRelative(6f)
+                    horizontalLineToRelative(-2f)
+                    close()
+                }
+            }.build()
+    }
+
+    val Shield: ImageVector by lazy {
+        ImageVector
+            .Builder(
+                name = "Shield",
+                defaultWidth = 24.dp,
+                defaultHeight = 24.dp,
+                viewportWidth = 24f,
+                viewportHeight = 24f,
+            ).apply {
+                path(fill = SolidColor(Color.Black)) {
+                    moveTo(12f, 2f)
+                    lineTo(4f, 5f)
+                    verticalLineToRelative(6f)
+                    curveToRelative(0f, 5.55f, 3.5f, 10.74f, 8f, 12f)
+                    curveToRelative(4.5f, -1.26f, 8f, -6.45f, 8f, -12f)
+                    verticalLineTo(5f)
+                    lineTo(12f, 2f)
+                    close()
+                }
+            }.build()
+    }
+
+    val Code: ImageVector by lazy {
+        ImageVector
+            .Builder(
+                name = "Code",
+                defaultWidth = 24.dp,
+                defaultHeight = 24.dp,
+                viewportWidth = 24f,
+                viewportHeight = 24f,
+            ).apply {
+                path(fill = SolidColor(Color.Black)) {
+                    moveTo(9.4f, 16.6f)
+                    lineTo(4.8f, 12f)
+                    lineToRelative(4.6f, -4.6f)
+                    lineTo(8f, 6f)
+                    lineToRelative(-6f, 6f)
+                    lineToRelative(6f, 6f)
+                    lineToRelative(1.4f, -1.4f)
+                    close()
+                    moveTo(14.6f, 16.6f)
+                    lineToRelative(4.6f, -4.6f)
+                    lineToRelative(-4.6f, -4.6f)
+                    lineTo(16f, 6f)
+                    lineToRelative(6f, 6f)
+                    lineToRelative(-6f, 6f)
+                    lineToRelative(-1.4f, -1.4f)
+                    close()
+                }
+            }.build()
+    }
+
+    val OpenInNew: ImageVector by lazy {
+        ImageVector
+            .Builder(
+                name = "OpenInNew",
+                defaultWidth = 24.dp,
+                defaultHeight = 24.dp,
+                viewportWidth = 24f,
+                viewportHeight = 24f,
+            ).apply {
+                path(fill = SolidColor(Color.Black)) {
+                    moveTo(19f, 19f)
+                    horizontalLineTo(5f)
+                    verticalLineTo(5f)
+                    horizontalLineToRelative(7f)
+                    verticalLineTo(3f)
+                    horizontalLineTo(5f)
+                    curveToRelative(-1.1f, 0f, -2f, 0.9f, -2f, 2f)
+                    verticalLineToRelative(14f)
+                    curveToRelative(0f, 1.1f, 0.9f, 2f, 2f, 2f)
+                    horizontalLineToRelative(14f)
+                    curveToRelative(1.1f, 0f, 2f, -0.9f, 2f, -2f)
+                    verticalLineToRelative(-7f)
+                    horizontalLineToRelative(-2f)
+                    verticalLineToRelative(7f)
+                    close()
+                    moveTo(14f, 3f)
+                    verticalLineToRelative(2f)
+                    horizontalLineToRelative(3.59f)
+                    lineToRelative(-9.83f, 9.83f)
+                    lineToRelative(1.41f, 1.41f)
+                    lineTo(19f, 6.41f)
+                    verticalLineTo(10f)
+                    horizontalLineToRelative(2f)
+                    verticalLineTo(3f)
+                    horizontalLineToRelative(-7f)
+                    close()
+                }
+            }.build()
+    }
+
     val ViewComfyAlt: ImageVector by lazy {
         ImageVector
             .Builder(

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreen.kt
@@ -78,11 +78,11 @@ import com.github.barriosnahuel.vossosunboton.BuildConfig
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsEvent
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.ui.AppIcons
 import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
 import com.github.barriosnahuel.vossosunboton.util.withDeviceHl
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import java.util.Locale
 
 private val COLLABORATORS: List<Collaborator> = emptyList()
@@ -482,6 +482,6 @@ private fun openUrl(
         context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
         true
     } catch (e: ActivityNotFoundException) {
-        Timber.e(e, "Could not launch ACTION_VIEW for %s", url)
+        Tracker.track(RuntimeException("Could not launch ACTION_VIEW for $url", e))
         false
     }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreen.kt
@@ -44,7 +44,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -77,6 +76,7 @@ import com.github.barriosnahuel.vossosunboton.commons.android.analytics.Analytic
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
 import com.github.barriosnahuel.vossosunboton.ui.AppIcons
 import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
+import com.github.barriosnahuel.vossosunboton.util.withDeviceHl
 import java.util.Locale
 
 private val COLLABORATORS: List<Collaborator> = emptyList()
@@ -90,6 +90,8 @@ fun AboutScreen(onBack: () -> Unit) {
     val creditEntries = remember { parseCreditEntries(creditsText) }
     val versionInfo = remember { context.versionInfo() }
     val sourceUrl = stringResource(R.string.app_about_source_url)
+    val privacyPolicyUrl = stringResource(R.string.app_about_privacy_policy_url)
+    val dataSafetyUrl = stringResource(R.string.app_about_data_safety_url)
     val isEnglishLocale = remember { Locale.getDefault().language == "en" }
 
     var soundId by remember { mutableIntStateOf(0) }
@@ -156,11 +158,19 @@ fun AboutScreen(onBack: () -> Unit) {
                 Spacer(Modifier.height(Spacing.LG))
                 CollaboratorsSection(COLLABORATORS)
             }
-            Spacer(Modifier.height(Spacing.LG))
-            LegalSection(
+            Spacer(Modifier.height(Spacing.XL))
+            LegalAndPrivacySection(
                 onLicenseClick = {
                     AnalyticsTrackerProvider.get(context.applicationContext).log(AnalyticsEvent.AboutLicenseOpen)
                     isLicenseSheetVisible = true
+                },
+                onPrivacyPolicyClick = {
+                    AnalyticsTrackerProvider.get(context.applicationContext).log(AnalyticsEvent.AboutPrivacyPolicyOpen)
+                    openUrl(context, privacyPolicyUrl.withDeviceHl())
+                },
+                onDataSafetyClick = {
+                    AnalyticsTrackerProvider.get(context.applicationContext).log(AnalyticsEvent.AboutDataSafetyOpen)
+                    openUrl(context, dataSafetyUrl.withDeviceHl())
                 },
                 onSourceClick = {
                     AnalyticsTrackerProvider.get(context.applicationContext).log(AnalyticsEvent.AboutSourceOpen)
@@ -432,31 +442,6 @@ private fun CollaboratorsSection(collaborators: List<Collaborator>) {
                 )
             }
         }
-    }
-}
-
-@Composable
-private fun LegalSection(
-    onLicenseClick: () -> Unit,
-    onSourceClick: () -> Unit,
-) {
-    OutlinedButton(
-        onClick = onLicenseClick,
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(horizontal = Spacing.LG, vertical = Spacing.XS),
-    ) {
-        Text(stringResource(R.string.app_about_license))
-    }
-    OutlinedButton(
-        onClick = onSourceClick,
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(horizontal = Spacing.LG, vertical = Spacing.XS),
-    ) {
-        Text(stringResource(R.string.app_about_source))
     }
 }
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreen.kt
@@ -7,6 +7,7 @@
 
 package com.github.barriosnahuel.vossosunboton.ui.about
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -45,6 +46,8 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -55,6 +58,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -77,6 +81,8 @@ import com.github.barriosnahuel.vossosunboton.commons.android.analytics.Analytic
 import com.github.barriosnahuel.vossosunboton.ui.AppIcons
 import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
 import com.github.barriosnahuel.vossosunboton.util.withDeviceHl
+import kotlinx.coroutines.launch
+import timber.log.Timber
 import java.util.Locale
 
 private val COLLABORATORS: List<Collaborator> = emptyList()
@@ -92,7 +98,10 @@ fun AboutScreen(onBack: () -> Unit) {
     val sourceUrl = stringResource(R.string.app_about_source_url)
     val privacyPolicyUrl = stringResource(R.string.app_about_privacy_policy_url)
     val dataSafetyUrl = stringResource(R.string.app_about_data_safety_url)
+    val noBrowserMessage = stringResource(R.string.app_about_error_no_browser)
     val isEnglishLocale = remember { Locale.getDefault().language == "en" }
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
 
     var soundId by remember { mutableIntStateOf(0) }
     val soundPool =
@@ -137,6 +146,7 @@ fun AboutScreen(onBack: () -> Unit) {
                     ),
             )
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { innerPadding ->
         Column(
             modifier =
@@ -165,16 +175,25 @@ fun AboutScreen(onBack: () -> Unit) {
                     isLicenseSheetVisible = true
                 },
                 onPrivacyPolicyClick = {
-                    AnalyticsTrackerProvider.get(context.applicationContext).log(AnalyticsEvent.AboutPrivacyPolicyOpen)
-                    openUrl(context, privacyPolicyUrl.withDeviceHl())
+                    if (openUrl(context, privacyPolicyUrl.withDeviceHl())) {
+                        AnalyticsTrackerProvider.get(context.applicationContext).log(AnalyticsEvent.AboutPrivacyPolicyOpen)
+                    } else {
+                        scope.launch { snackbarHostState.showSnackbar(noBrowserMessage) }
+                    }
                 },
                 onDataSafetyClick = {
-                    AnalyticsTrackerProvider.get(context.applicationContext).log(AnalyticsEvent.AboutDataSafetyOpen)
-                    openUrl(context, dataSafetyUrl.withDeviceHl())
+                    if (openUrl(context, dataSafetyUrl.withDeviceHl())) {
+                        AnalyticsTrackerProvider.get(context.applicationContext).log(AnalyticsEvent.AboutDataSafetyOpen)
+                    } else {
+                        scope.launch { snackbarHostState.showSnackbar(noBrowserMessage) }
+                    }
                 },
                 onSourceClick = {
-                    AnalyticsTrackerProvider.get(context.applicationContext).log(AnalyticsEvent.AboutSourceOpen)
-                    openUrl(context, sourceUrl)
+                    if (openUrl(context, sourceUrl)) {
+                        AnalyticsTrackerProvider.get(context.applicationContext).log(AnalyticsEvent.AboutSourceOpen)
+                    } else {
+                        scope.launch { snackbarHostState.showSnackbar(noBrowserMessage) }
+                    }
                 },
             )
             Spacer(Modifier.height(Spacing.XXL))
@@ -458,6 +477,11 @@ private fun Context.readRawResource(resId: Int): String = resources.openRawResou
 private fun openUrl(
     context: Context,
     url: String,
-) {
-    context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
-}
+): Boolean =
+    try {
+        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+        true
+    } catch (e: ActivityNotFoundException) {
+        Timber.e(e, "Could not launch ACTION_VIEW for %s", url)
+        false
+    }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/LegalAndPrivacySection.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/LegalAndPrivacySection.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.about
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.ui.AppIcons
+import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
+
+@Composable
+internal fun LegalAndPrivacySection(
+    onLicenseClick: () -> Unit,
+    onPrivacyPolicyClick: () -> Unit,
+    onDataSafetyClick: () -> Unit,
+    onSourceClick: () -> Unit,
+) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Spacing.LG),
+    ) {
+        Text(
+            text = stringResource(R.string.app_about_legal_section_title),
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(start = Spacing.SM, bottom = Spacing.XS),
+        )
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        ) {
+            Column {
+                LegalListItem(
+                    icon = AppIcons.Description,
+                    label = stringResource(R.string.app_about_license),
+                    isExternal = false,
+                    onClick = onLicenseClick,
+                )
+                LegalListItem(
+                    icon = AppIcons.PrivacyTip,
+                    label = stringResource(R.string.app_about_privacy_policy),
+                    isExternal = true,
+                    onClick = onPrivacyPolicyClick,
+                )
+                LegalListItem(
+                    icon = AppIcons.Shield,
+                    label = stringResource(R.string.app_about_data_safety),
+                    isExternal = true,
+                    onClick = onDataSafetyClick,
+                )
+                LegalListItem(
+                    icon = AppIcons.Code,
+                    label = stringResource(R.string.app_about_source),
+                    isExternal = true,
+                    onClick = onSourceClick,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LegalListItem(
+    icon: ImageVector,
+    label: String,
+    isExternal: Boolean,
+    onClick: () -> Unit,
+) {
+    val externalLabel = stringResource(R.string.app_about_open_in_browser)
+    ListItem(
+        modifier = Modifier.clickable(onClick = onClick),
+        colors =
+            ListItemDefaults.colors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                headlineColor = MaterialTheme.colorScheme.onSurface,
+                leadingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                trailingIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            ),
+        leadingContent = {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+            )
+        },
+        headlineContent = { Text(label) },
+        trailingContent =
+            if (isExternal) {
+                {
+                    Icon(
+                        imageVector = AppIcons.OpenInNew,
+                        contentDescription = externalLabel,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+            } else {
+                null
+            },
+    )
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/util/LocalizedUrl.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/util/LocalizedUrl.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.util
+
+import java.util.Locale
+
+private const val HL_PARAM = "hl"
+
+private const val ES_AR = "es-AR"
+private const val ES_ES = "es-ES"
+private const val ES_419 = "es-419"
+private const val EN = "en"
+private const val PT_BR = "pt-BR"
+
+internal fun toSupportedHl(locale: Locale): String =
+    when (locale.language) {
+        "es" ->
+            when (locale.country) {
+                "AR" -> ES_AR
+                "ES" -> ES_ES
+                else -> ES_419
+            }
+        "en" -> EN
+        "pt" -> PT_BR
+        else -> EN
+    }
+
+internal fun appendHl(
+    url: String,
+    hl: String,
+): String {
+    val separator = if (url.contains('?')) '&' else '?'
+    return "$url$separator$HL_PARAM=$hl"
+}
+
+fun String.withDeviceHl(): String = appendHl(this, toSupportedHl(Locale.getDefault()))

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -39,6 +39,10 @@
     <string name="app_about_license">Licencia de código</string>
     <string name="app_about_credits">Créditos de terceros</string>
     <string name="app_about_source">Código fuente</string>
+    <string name="app_about_legal_section_title">Legal y privacidad</string>
+    <string name="app_about_privacy_policy">Política de privacidad</string>
+    <string name="app_about_data_safety">Seguridad de datos</string>
+    <string name="app_about_open_in_browser">Se abre en el navegador</string>
 
     <string name="app_addbutton_activity_title">Nuevo botón</string>
     <string name="app_addbutton_activity_title_edit">Editar botón</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -43,6 +43,7 @@
     <string name="app_about_privacy_policy">Política de privacidad</string>
     <string name="app_about_data_safety">Seguridad de datos</string>
     <string name="app_about_open_in_browser">Se abre en el navegador</string>
+    <string name="app_about_error_no_browser">No se pudo abrir el navegador</string>
 
     <string name="app_addbutton_activity_title">Nuevo botón</string>
     <string name="app_addbutton_activity_title_edit">Editar botón</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,12 @@
     <string name="app_about_credits">Third-party credits</string>
     <string name="app_about_source">Source code</string>
     <string name="app_about_source_url" translatable="false">https://github.com/barriosnahuel/push-me</string>
+    <string name="app_about_legal_section_title">Legal &amp; Privacy</string>
+    <string name="app_about_privacy_policy">Privacy Policy</string>
+    <string name="app_about_data_safety">Data Safety</string>
+    <string name="app_about_open_in_browser">Opens in browser</string>
+    <string name="app_about_privacy_policy_url" translatable="false">https://barriosnahuel.github.io/bomp/privacy-policy.html</string>
+    <string name="app_about_data_safety_url" translatable="false">https://barriosnahuel.github.io/bomp/data-safety.html</string>
 
     <string name="app_addbutton_activity_title">New button</string>
     <string name="app_addbutton_activity_title_edit">Edit button</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,7 @@
     <string name="app_about_privacy_policy">Privacy Policy</string>
     <string name="app_about_data_safety">Data Safety</string>
     <string name="app_about_open_in_browser">Opens in browser</string>
+    <string name="app_about_error_no_browser">Couldn\'t open in a browser</string>
     <string name="app_about_privacy_policy_url" translatable="false">https://barriosnahuel.github.io/bomp/privacy-policy.html</string>
     <string name="app_about_data_safety_url" translatable="false">https://barriosnahuel.github.io/bomp/data-safety.html</string>
 

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenAnalyticsTest.kt
@@ -89,6 +89,32 @@ internal class AboutScreenAnalyticsTest : AbstractRobolectricTest() {
     }
 
     @Test
+    fun `tap on privacy policy item emits about_privacy_policy_open`() {
+        composeTestRule.setContent { AppTheme { AboutScreen(onBack = {}) } }
+
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.app_about_privacy_policy))
+            .performScrollTo()
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        fake.assertEmitted("about_privacy_policy_open")
+    }
+
+    @Test
+    fun `tap on data safety item emits about_data_safety_open`() {
+        composeTestRule.setContent { AppTheme { AboutScreen(onBack = {}) } }
+
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.app_about_data_safety))
+            .performScrollTo()
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        fake.assertEmitted("about_data_safety_open")
+    }
+
+    @Test
     fun `tap on branding audio button does not emit before the SoundPool finishes loading`() {
         composeTestRule.setContent { AppTheme { AboutScreen(onBack = {}) } }
 

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenTest.kt
@@ -7,9 +7,11 @@ package com.github.barriosnahuel.vossosunboton.ui.about
 
 import android.content.Context
 import android.os.Build
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -142,10 +144,19 @@ internal class AboutScreenTest : AbstractRobolectricTest() {
         composeTestRule.onNodeWithText(geminiName).assertDoesNotExist()
     }
 
-    // --- Legal section ---
+    // --- Legal & Privacy section ---
 
     @Test
-    fun `source license button is displayed`() {
+    fun `legal section header is displayed`() {
+        launch()
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.app_about_legal_section_title))
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `source license item is displayed`() {
         launch()
         composeTestRule
             .onNodeWithText(context.getString(R.string.app_about_license))
@@ -154,7 +165,25 @@ internal class AboutScreenTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `source code button is displayed`() {
+    fun `privacy policy item is displayed`() {
+        launch()
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.app_about_privacy_policy))
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `data safety item is displayed`() {
+        launch()
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.app_about_data_safety))
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `source code item is displayed`() {
         launch()
         composeTestRule
             .onNodeWithText(context.getString(R.string.app_about_source))
@@ -163,7 +192,15 @@ internal class AboutScreenTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `license bottom sheet opens on license button click`() {
+    fun `external items expose the opens-in-browser accessibility hint`() {
+        launch()
+        composeTestRule
+            .onAllNodesWithContentDescription(context.getString(R.string.app_about_open_in_browser))
+            .assertCountEquals(EXTERNAL_LEGAL_ITEMS)
+    }
+
+    @Test
+    fun `license bottom sheet opens on license item click`() {
         launch()
         composeTestRule.onNodeWithText(context.getString(R.string.app_about_license)).performScrollTo().performClick()
         composeTestRule.mainClock.advanceTimeBy(500L)
@@ -183,5 +220,9 @@ internal class AboutScreenTest : AbstractRobolectricTest() {
             .onNodeWithContentDescription(context.getString(R.string.app_about_back))
             .performClick()
         assertTrue(called)
+    }
+
+    private companion object {
+        const val EXTERNAL_LEGAL_ITEMS = 3
     }
 }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenTest.kt
@@ -200,6 +200,19 @@ internal class AboutScreenTest : AbstractRobolectricTest() {
     }
 
     @Test
+    fun `tap on privacy policy when the intent succeeds does not show the no-browser snackbar`() {
+        launch()
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.app_about_privacy_policy))
+            .performScrollTo()
+            .performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.app_about_error_no_browser))
+            .assertDoesNotExist()
+    }
+
+    @Test
     fun `license bottom sheet opens on license item click`() {
         launch()
         composeTestRule.onNodeWithText(context.getString(R.string.app_about_license)).performScrollTo().performClick()

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/util/LocalizedUrlTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/util/LocalizedUrlTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.util
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Test
+import java.util.Locale
+
+internal class LocalizedUrlTest {
+    private val originalDefault = Locale.getDefault()
+
+    @After
+    fun restoreDefault() {
+        Locale.setDefault(originalDefault)
+    }
+
+    @Test
+    fun `Argentine Spanish maps to es-AR`() {
+        assertThat(toSupportedHl(Locale("es", "AR"))).isEqualTo("es-AR")
+    }
+
+    @Test
+    fun `Spain Spanish maps to es-ES`() {
+        assertThat(toSupportedHl(Locale("es", "ES"))).isEqualTo("es-ES")
+    }
+
+    @Test
+    fun `Latin American Spanish countries fall back to es-419`() {
+        listOf("MX", "CL", "UY", "CO", "PE", "BO", "419").forEach { country ->
+            assertThat(toSupportedHl(Locale("es", country))).isEqualTo("es-419")
+        }
+    }
+
+    @Test
+    fun `Spanish without country falls back to es-419`() {
+        assertThat(toSupportedHl(Locale("es"))).isEqualTo("es-419")
+    }
+
+    @Test
+    fun `English of any country maps to en`() {
+        listOf("US", "GB", "AU", "IN", "CA").forEach { country ->
+            assertThat(toSupportedHl(Locale("en", country))).isEqualTo("en")
+        }
+        assertThat(toSupportedHl(Locale("en"))).isEqualTo("en")
+    }
+
+    @Test
+    fun `Portuguese of any country maps to pt-BR`() {
+        listOf("BR", "PT", "AO", "MZ").forEach { country ->
+            assertThat(toSupportedHl(Locale("pt", country))).isEqualTo("pt-BR")
+        }
+    }
+
+    @Test
+    fun `unsupported languages fall back to en`() {
+        listOf(
+            Locale("ja", "JP"),
+            Locale("fr", "FR"),
+            Locale("de", "DE"),
+            Locale("zh", "CN"),
+            Locale("it", "IT"),
+            Locale.ROOT,
+        ).forEach { locale ->
+            assertThat(toSupportedHl(locale)).isEqualTo("en")
+        }
+    }
+
+    @Test
+    fun `appendHl uses question mark when URL has no query string`() {
+        assertThat(appendHl("https://example.com/page", "es-AR"))
+            .isEqualTo("https://example.com/page?hl=es-AR")
+    }
+
+    @Test
+    fun `appendHl uses ampersand when URL already has a query string`() {
+        assertThat(appendHl("https://example.com/page?foo=bar", "en"))
+            .isEqualTo("https://example.com/page?foo=bar&hl=en")
+    }
+
+    @Test
+    fun `withDeviceHl uses the JVM default locale`() {
+        Locale.setDefault(Locale("pt", "BR"))
+        assertThat("https://example.com/p".withDeviceHl()).isEqualTo("https://example.com/p?hl=pt-BR")
+
+        Locale.setDefault(Locale("ja", "JP"))
+        assertThat("https://example.com/p".withDeviceHl()).isEqualTo("https://example.com/p?hl=en")
+    }
+}

--- a/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsEvent.kt
+++ b/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsEvent.kt
@@ -104,6 +104,12 @@ sealed class AnalyticsEvent(
     /** External "Source code" link followed from About. The user leaves the app. */
     object AboutSourceOpen : AnalyticsEvent(name = "about_source_open", hasFirstVariant = true)
 
+    /** External Privacy Policy link followed from About. The user leaves the app. */
+    object AboutPrivacyPolicyOpen : AnalyticsEvent(name = "about_privacy_policy_open", hasFirstVariant = true)
+
+    /** External Data Safety link followed from About. The user leaves the app. */
+    object AboutDataSafetyOpen : AnalyticsEvent(name = "about_data_safety_open", hasFirstVariant = true)
+
     /** Branding audio (Sticker Cero) played from the About hero section. */
     object AboutBrandingAudioPlay : AnalyticsEvent(name = "about_branding_audio_play", hasFirstVariant = true)
 

--- a/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsCoverageMatrixTest.kt
+++ b/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsCoverageMatrixTest.kt
@@ -65,6 +65,8 @@ internal class AnalyticsCoverageMatrixTest {
                 "AboutCreditsOpen",
                 "AboutLicenseOpen",
                 "AboutSourceOpen",
+                "AboutPrivacyPolicyOpen",
+                "AboutDataSafetyOpen",
                 "AboutBrandingAudioPlay",
                 "MilestoneAudios",
             )


### PR DESCRIPTION
## Summary
- New "Legal & Privacy" section in About: License (internal sheet) plus Privacy Policy, Data Safety, and Source code as ListItems with leading icons and `open_in_new` trailing for the three externals
- Privacy Policy and Data Safety open the published GitHub Pages with `?hl=<bcp47>` matched to the device locale (`es-AR`, `es-419`, `es-ES`, `en`, `pt-BR`; non-supported languages fall back to `en`)
- Two new analytics events (`about_privacy_policy_open`, `about_data_safety_open`) wired through the existing `AnalyticsTracker` wrapper, with the `first_*` variants enabled

## Code review tips
- `LocalizedUrl.kt` reads `Locale.getDefault()` lazily inside the click lambda so a runtime locale change is reflected without recomposition tricks
- `LegalAndPrivacySection.kt` was extracted to its own file to keep `AboutScreen.kt` under detekt's `TooManyFunctions` threshold; visibility had to bump from `private` to `internal`
- `AnalyticsCoverageMatrixTest` was updated alongside the new sealed events — leaving it stale would fail CI
- The `OpenInNew` trailing icon's `contentDescription` ("Opens in browser") is non-null on purpose: it merges into the ListItem's semantics so TalkBack reads "Privacy Policy. Opens in browser. Button"

## Already tested
- [x] `./gradlew check` (ktlint, detekt, Spotless, Android Lint, all unit tests including new `LocalizedUrlTest` 10/10, `AboutScreenTest` 19/19, `AboutScreenAnalyticsTest` 6/6)
- [x] `./gradlew app:connectedDebugAndroidTest` on `push_me_test` AVD (44/44, including 3 new `AboutScreenFlowTest` cases for the localized intents and the open-in-browser a11y hint)
- [x] Manual smoke on a real Pixel 8 (Android 16): tap on Privacy Policy and Data Safety opens Chrome with the expected `?hl=` for the device locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)