### PR TITLE
Enable Gradle configuration cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Added a branded launch screen showing the Bomp brand mark on a theme-aware background (Paper in light mode, Ink in dark) — Android 12+ system splash plus core-splashscreen backport for API 23-30
 - Refined the launcher icon: the brand container is now Acid (Neo-Club signal yellow-green) with an Ink play triangle, replacing the organic blob composition that fought system masks (rounded squares in Play Store, circles on Pixel). The blob remains the brand mark on web surfaces (favicon, wordmark, feature graphic) where there is no system mask
 - Renamed app to **Bomp**: launcher label, About screen heading and Play Store listing now align with the canonical brand. Old name `Sos Un Boton` retired
+- Enabled Gradle configuration cache to speed up incremental builds and CI runs
 - Promoted the Add Button flow from a `:feature_addbutton` dynamic feature module into the core `:app` module (creating buttons is core, not a freemium add-on). Eliminates the bundletool wrapper script and lets the local UI test suite run as plain `./gradlew app:connectedDebugAndroidTest`
 - Deeplink `push-me://open/explore` now falls back to Home when no bundled sounds are available (release builds and debug checkouts without the bundled `raw/` directory), avoiding a blank Explore tab
 - Search overlay's clear-query icon now announces "Clear search" (was "Close search", which collided with the back-arrow's label and confused screen readers)

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,4 @@ org.gradle.jvmargs=-Xmx3072m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF
 org.gradle.vfs.watch=true
 org.gradle.parallel=true
 org.gradle.caching=true
+org.gradle.configuration-cache=true


### PR DESCRIPTION
### Summary
- Adds `org.gradle.configuration-cache=true` to `gradle.properties`. Gradle now serializes the task graph and reuses it across builds, complementing the existing build cache and parallel execution.
- Smoke runs on a freshly cleared cache (`help`, `:app:assembleDebug`, `check -x test`, `test`) reported `totalProblemCount: 0` across all four runs on Gradle 9.5.0 with AGP 9.2.0 and the current plugin set (Google Services 4.4.4, Crashlytics 3.0.7, Firebase Perf 2.0.2, Detekt 1.23.8, KtLint 14.2.0, Spotless 8.4.0).
- CHANGELOG entry under `[unreleased]` › `Changed`.

### Code review tips
- The diff is two lines, but the runtime behavior change is real: any future plugin/task that touches `Project` at execution time, uses `afterEvaluate` problematically, or stores non-serializable state will now fail the build instead of silently working. That is the intended trade-off — fast feedback over silent breakage.
- No `--no-configuration-cache` escape hatches are committed, on purpose. If a future plugin needs one, treat it as a regression to investigate before adding.
- CircleCI's existing Gradle cache orb already covers `~/.gradle`, so the on-disk `.gradle/configuration-cache/` will be cached without CI changes.

### Already tested
- [x] `./gradlew help` (cold + warm): `Configuration cache entry stored` → `Configuration cache entry reused` (2s → 425ms)
- [x] `./gradlew :app:assembleDebug` (cold + warm): 9s → 582ms
- [x] `./gradlew check -x test` (cold + warm): 32s → 714ms; full re-run on Gradle 9.5.0 fresh cache: 1m 41s, 0 problems
- [x] `./gradlew test` (cold + warm): 50s → 569ms; full re-run on Gradle 9.5.0 fresh cache: 51s, 0 problems
- [x] All four `configuration-cache-report.html` reports show `totalProblemCount: 0`