### PR TITLE
Align unknown-path deeplink test with the safe-default fallback to MY_SOUNDS

### DIFF
--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/DeepLinkTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/DeepLinkTest.kt
@@ -81,16 +81,22 @@ internal class DeepLinkTest : AbstractUiTest() {
     }
 
     @Test
-    fun unknownPathDeeplinkRoutesLikeExplore() {
+    fun unknownPathDeeplinkFallsBackToHome() {
         val bundled = PackagedAudios.get(context)
         assumeTrue(
-            "Need bundled sounds so the unknown-path fallback to Explore is observable.",
+            "Need bundled sounds so MY_SOUNDS (custom) is distinguishable from EXPLORE_SOUNDS (bundled).",
             bundled.isNotEmpty(),
         )
+        TestData.seedCustomSounds(context, count = 1)
 
         ActivityScenario.launch<LandingActivity>(deeplink("/anything-unknown")).use {
             composeRule.waitForIdle()
-            composeRule.onNodeWithText(bundled.first().name).assertIsDisplayed()
+            // Per the closed deep-link allowlist in LandingActivity.handleDeeplink,
+            // any unknown path must safely fall back to MY_SOUNDS — never silently route to Explore.
+            composeRule.onNodeWithText("custom_1").assertIsDisplayed()
+            composeRule.onAllNodes(hasText(bundled.first().name)).fetchSemanticsNodes().let {
+                assert(it.isEmpty()) { "Bundled sound should not be visible since unknown paths fall back to MY_SOUNDS." }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- `LandingActivity.handleDeeplink` already routes unknown deep-link paths to `MY_SOUNDS` per the closed allowlist documented in `CLAUDE.md` § "Deep link path allowlist". The instrumented test was still asserting the legacy "routes like Explore" behaviour and failing locally.
- Renames the test to `unknownPathDeeplinkFallsBackToHome` and rewrites the body to mirror `homeDeeplinkLandsOnHomeTab`: asserts the seeded custom sound is shown and the first bundled sound is **not**.
- Discovered while running the full instrumented suite from PR #1086; the failure is unrelated to that PR's scope, so it's split into this dedicated fix.

## Code review tips

- Pure test-only change. No production code touched.
- The `assumeTrue(bundled.isNotEmpty(), ...)` guard is preserved so the test only runs when the developer has bundled audio in `model/src/debug/res/raw/` (without it, custom and bundled tabs aren't distinguishable). Skipping when un-seeded matches the pattern of the other tests in this file.

## Already tested

- [x] Worktree set up from `develop`, bundled audio copied from main worktree.
- [x] \`./gradlew check -x test && ./gradlew test\` — clean.
- [x] \`ANDROID_SERIAL=emulator-5554 ./gradlew app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=...DeepLinkTest\` — 3 ran and passed (`homeDeeplinkLandsOnHomeTab`, `exploreDeeplinkWithBundledLandsOnExploreTab`, `unknownPathDeeplinkFallsBackToHome`); `exploreDeeplinkWithoutBundledFallsBackToHome` skipped as expected since bundled sounds are present.