### PR TITLE
fix(about): point source-code URL to renamed bomp repo

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,7 +42,7 @@
     <string name="app_about_license">Source license</string>
     <string name="app_about_credits">Third-party credits</string>
     <string name="app_about_source">Source code</string>
-    <string name="app_about_source_url" translatable="false">https://github.com/barriosnahuel/push-me</string>
+    <string name="app_about_source_url" translatable="false">https://github.com/barriosnahuel/bomp</string>
     <string name="app_about_legal_section_title">Legal &amp; Privacy</string>
     <string name="app_about_privacy_policy">Privacy Policy</string>
     <string name="app_about_data_safety">Data Safety</string>


### PR DESCRIPTION
### Summary
- The GitHub repo was renamed from `push-me` to `bomp`; the About screen's "Source code" button was still pointing at the old slug, which 404s once the redirect is dropped.
- Updates `app_about_source_url` in `app/src/main/res/values/strings.xml` to the new canonical URL.

### Code review tips
- Single-string change in `strings.xml`, marked `translatable="false"` so no locale ripple.
- The About source-code link was added during this same `[unreleased]` cycle, so per CLAUDE.md no CHANGELOG `Fixed` entry is added (no end-user ever shipped with the broken URL).

### Already tested
- [x] `git diff` confirms the only change is the URL string.
- [ ] Manual tap on About → "Source code" once merged into a release build (low risk: pure string).