### PR TITLE
fix(about): translate manifesto closing for English locales

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,8 @@ When generating user-facing copy in any locale (in-app strings, store listings, 
 
 If any of these paths is missing (CI, alternate checkout), do **not** invent the claim — flag the gap to the user and proceed with the in-repo strings as authoritative.
 
+**Default locale for in-app strings.** `app/src/main/res/values/strings.xml` is the **English** master; Spanish-AR copy lives in `values-es/strings.xml`.
+
 Hard rules:
 
 - **No calque translations.** A phrase that's natural in the source can be wrong in the target. Examples we hit and fixed during the en-US listing: "save a day" (calque of "salvar un día" — correct English idiom is `save the day`); "on the other side" (calque of "del otro lado" — in English this means *afterlife*; the phone idiom is `on the other end`); "your audios" (calque of "tus audios" — `audio` is a mass noun in English, the natural plural is `voice notes` / `voice clips` / `voice memos`).

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,7 +29,7 @@
     <string name="app_overflow_menu">More options</string>
     <string name="app_about">About</string>
     <string name="app_about_back">Back</string>
-    <string name="app_about_tagline">Porque un audio de los tuyos no es un mensaje, es un abrazo que se escucha</string>
+    <string name="app_about_tagline">A voice from your people isn\'t a message — it\'s a hug you can hear</string>
     <string name="app_about_play_branding_audio">Play brand audio</string>
     <string name="app_about_ai_gemini_name">Google Gemini</string>
     <string name="app_about_ai_gemini_role">Helped think through ideas and decide what to build</string>


### PR DESCRIPTION
### Summary

- About-screen tagline rendered Spanish (_"Porque un audio de los tuyos no es un mensaje, es un abrazo que se escucha"_) on every device whose system language is not `es-*`, because `app/src/main/res/values/strings.xml` (the English master) held the Spanish text. Bug shipped into the v2.0.0 cycle in `afdd343`; never reached prod.
- Replaced `app_about_tagline` in `values/` with the canonical English manifesto already locked across `store-listing/en-US/full_description.txt:49` and the screenshot/preview-video briefs: _"A voice from your people isn't a message — it's a hug you can hear"_. Spanish-AR (`values-es/`) untouched.
- Added a one-liner to `CLAUDE.md` § Copy & localization stating that `values/strings.xml` is the English master and `values-es/` is Spanish-AR — closes the agent-confusion gap that introduced the bug.

### Code review tips

- The English string is invariant: it must match the wording locked across all en-US store-listing surfaces (`full_description.txt:49`, `briefs/preview-video.md:17`, `briefs/screenshot-02-manifesto.svg`). Don't propose alternative phrasings here — change the store-listing copy first if a re-write is wanted.
- Apostrophes escaped with `\'` per Android XML; trailing period dropped to match the Spanish version (the screen wraps the value in curly quotes at `AboutScreen.kt:288`).
- No `### Fixed` CHANGELOG entry — bug was introduced in the same `[unreleased]` cycle, per `CLAUDE.md` § Changelog rule.

### Already tested

- [x] `./gradlew :app:testDebugUnitTest --tests '*AboutScreenTest*'` — all green; the existing `tagline is displayed` test resolves via `getString` so it follows the JVM locale.
- [x] `./gradlew check -x test` — Spotless / ktlint / detekt / Android lint (`MissingTranslation`/`ExtraTranslation`=error) all green.
- [x] `./gradlew test` — full unit suite green.
- [ ] Manual emulator check at en-US and es-AR — pending.