### PR TITLE
Fix StrictMode disk-read violations on main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 #### Changed
 - Migrated sound metadata persistence from SharedPreferences to Jetpack DataStore Preferences with a single JSON-encoded payload, exposed as a reactive `Flow<List<Sound>>` from the new `SoundsRepository`; safer concurrent writes, no main-thread IO, and corrupted-payload recovery via Crashlytics-reported fallback to an empty list
-- StrictMode debug audit: switched both ThreadPolicy and VmPolicy to `detectAll()` (forward-compat for new detectors) keeping `detectNonSdkApiUsage()` explicit; replaced `penaltyLog()` with a single `Timber.tag("StrictMode").e(...)` call inside the `penaltyListener` gated by a `KNOWN_THIRD_PARTY_VIOLATIONS` matcher list, so known noise (Firebase Analytics / Crashlytics / Datatransport CCT, Compose `dispatchOnScrollChanged`, Espresso reflection, framework `SurfaceControl` finalize, framework Activity-destroy GC) is silenced in both logcat and Crashlytics with one decision; unknown violations now crash the debug process so they cannot slip past unnoticed; Firebase init disk reads wrapped at the call-site via scoped `allowThreadDiskReads` in `AnalyticsTrackerProvider`
+- StrictMode debug audit: switched both ThreadPolicy and VmPolicy to `detectAll()` (forward-compat for new detectors) keeping `detectNonSdkApiUsage()` explicit; route every surviving violation through `Tracker.track` so each one prints a single line under the `Tracker` tag with `"StrictMode: <ViolationClass>"` in the message (greppable via `adb logcat | grep StrictMode`); known noise (Firebase Analytics / Crashlytics / Datatransport CCT, Compose `dispatchOnScrollChanged`, Espresso reflection, framework `SurfaceControl` finalize, framework Activity-destroy GC) is silenced in both logcat and Crashlytics with one decision; unknown violations now crash the debug process so they cannot slip past unnoticed; Firebase init disk reads wrapped at the call-site via scoped `allowThreadDiskReads` in `AnalyticsTrackerProvider`
 - Rewrote `README.md` to reflect v2.0 reality: refreshed brand to Bomp, refreshed version/API/CI badges, replaced feature list with current capabilities aligned to brand-DNA vocabulary, added Google Play badge and GitHub Pages link, removed obsolete Codacy badge and "What's next" section
 - Enabled Gradle configuration cache to speed up incremental builds and CI runs
 - Promoted the Add Button flow from a `:feature_addbutton` dynamic feature module into the core `:app` module (creating buttons is core, not a freemium add-on); eliminates the bundletool wrapper script and lets the local UI test suite run as plain `./gradlew app:connectedDebugAndroidTest`
@@ -84,6 +84,9 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - KTLint migrated to JLLeitschuh plugin with KTLint 1.5.0
 - Resolved all Kotlin compiler and Gradle DSL deprecation warnings for a clean build log
 - Bundled audio files removed from version control; bottom navigation bar hidden in release builds (Explore tab only appears in debug when audio files are manually placed)
+
+#### Fixed
+- `ShareFeature.share` now runs file-system access (`getFile` + first-time `copy` of bundled raw resources) on `Dispatchers.IO`, eliminating a long-standing main-thread disk write that could cause jank the first time a bundled sound was shared
 
 #### Removed
 - Removed `techstack.md` and its companion `techstack.yml` (StackShare.io config that broke after the repo rename to `bomp` and was no longer maintained — last meaningful update predated the v2.0 Compose rewrite)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,12 +243,16 @@ never reaches release builds). Both ThreadPolicy and VmPolicy use `detectAll()`
 plus an explicit `detectNonSdkApiUsage()`; **`penaltyLog()` and `penaltyDeath()`
 are intentionally not set on the builders** — both fire before `penaltyListener`
 and bypass the filter. Every detected violation flows through `reportViolation()`,
-which filters via `KNOWN_THIRD_PARTY_VIOLATIONS` and on a hit emits one Timber
-`StrictMode` log, records a Crashlytics non-fatal via `Tracker.track`, AND posts
-a throw to the main looper so the process dies. Unknown violations crash debug
-runs and the instrumented suite until a matcher is added — by design, so nothing
-slips past silently. Logcat, Crashlytics and process state stay in sync — the
-matcher list is the only way to silence any of them.
+which filters via `KNOWN_THIRD_PARTY_VIOLATIONS` and on a hit calls
+`Tracker.track(StrictModeException(violation))` AND posts a throw to the main
+looper so the process dies. The wrapper exception's message is
+`"StrictMode: <ViolationClassName>"`, so the single logcat line emitted by
+`Tracker.track` reads `Tracking error to Firebase Crashlytics: StrictMode: <…>`
+under the `Tracker` tag — searchable via `grep StrictMode` without a dedicated
+tag. Unknown violations crash debug runs and the instrumented suite until a
+matcher is added — by design, so nothing slips past silently. Logcat, Crashlytics
+and process state stay in sync — the matcher list is the only way to silence any
+of them.
 
 When a new violation surfaces, choose in this order:
 
@@ -267,7 +271,8 @@ When a new violation surfaces, choose in this order:
    classes are obfuscated and unstable (GMS Dynamite modules ship as `m7.*` etc.
    and the loader / module identifier lives in `StackTraceElement.fileName`).
 
-Filter logcat with `adb logcat -s StrictMode:E` — operator workflow lives in
+Filter logcat with `adb logcat | grep StrictMode` (or scope by tag and grep:
+`adb logcat -s Tracker:E | grep StrictMode`) — operator workflow lives in
 `CONTRIBUTING.md` § "Terminal: StrictMode violations".
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,10 +142,16 @@ You can filter logcat messages by:
 
 ### Terminal: StrictMode violations 🚨
 
-The debug build's `StrictModeConfigurator` silences known third-party noise and only logs surviving violations. To see what hit the dashboard during a session or test run:
+The debug build's `StrictModeConfigurator` silences known third-party noise and routes every surviving violation through `Tracker.track`, so the logcat line uses the `Tracker` tag and the message starts with `StrictMode: <ViolationClass>`. The cleanest filter is to grep for the prefix:
 
 ```bash
-adb logcat -d -s StrictMode:E
+adb logcat -d | grep StrictMode
+```
+
+If you also want to scope by tag (cuts unrelated `Tracker.track` non-fatals from MediaPlayer, etc.), combine:
+
+```bash
+adb logcat -d -s Tracker:E | grep StrictMode
 ```
 
 Empty output means every detected violation matched a `KnownThirdPartyViolation` entry — none reached Crashlytics either. Anything that does show up either has a top frame in our package (`com.github.barriosnahuel.vossosunboton.*`) and needs fixing, or comes from a new SDK / framework version that should be added to the matcher list. The decision tree is in `CLAUDE.md` § "StrictMode debug audit".

--- a/app/src/debug/java/com/github/barriosnahuel/vossosunboton/StrictModeConfigurator.kt
+++ b/app/src/debug/java/com/github/barriosnahuel/vossosunboton/StrictModeConfigurator.kt
@@ -10,7 +10,6 @@ import android.os.Handler
 import android.os.Looper
 import android.os.StrictMode
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Trackable
-import timber.log.Timber
 import java.util.concurrent.Executors
 
 internal object StrictModeConfigurator {
@@ -60,9 +59,12 @@ private fun setupVirtualMachinePolicy(trackable: Trackable) {
 /**
  * Single decision point for both ThreadPolicy and VmPolicy violations:
  *  - filtered third-party noise → silent (not in logcat, not in Crashlytics)
- *  - everything else → uniform `Timber.tag("StrictMode").e(...)` line in logcat (DebugTree),
- *    breadcrumb in Crashlytics (ErrorTrackerTree), a non-fatal via `Tracker.track`, AND a process kill so the
- *    dev cannot miss it during local runs.
+ *  - everything else → a single non-fatal via `Tracker.track` (one logcat line under the `Tracker` tag with
+ *    "Tracking error to Firebase Crashlytics: StrictMode: <ViolationClass>" and the stacktrace inline,
+ *    plus the Crashlytics dashboard entry), AND a process kill so the dev cannot miss it during local runs.
+ *
+ * The "StrictMode" identifier travels in the wrapper exception's message (see [StrictModeException]) so
+ * `adb logcat | grep StrictMode` finds violations without needing a dedicated logcat tag.
  *
  * `penaltyLog()` and `penaltyDeath()` are intentionally NOT set on the builders. `penaltyDeath()` would fire
  * before `penaltyListener` and bypass our filter, killing the process on every Compose scroll / Espresso
@@ -79,7 +81,6 @@ private fun reportViolation(
     violation: Throwable,
 ) {
     if (!shouldReportToCrashlytics(violation)) return
-    Timber.tag(LOG_TAG).e(violation, "policy violation: %s", violation.javaClass.simpleName)
     trackable.track(StrictModeException(violation))
     Handler(Looper.getMainLooper()).post { throw StrictModeException(violation) }
 }
@@ -125,8 +126,6 @@ private data class KnownThirdPartyViolation(
         return true
     }
 }
-
-private const val LOG_TAG = "StrictMode"
 
 private val KNOWN_THIRD_PARTY_VIOLATIONS =
     listOf(
@@ -197,6 +196,12 @@ private val KNOWN_THIRD_PARTY_VIOLATIONS =
         ),
     )
 
+/**
+ * Wraps a raw `android.os.strictmode.Violation` so the message starts with `"StrictMode: <ViolationClass>"`.
+ * That prefix becomes the searchable identifier in logcat (`adb logcat | grep StrictMode`) and in Crashlytics,
+ * since the wrapper `Tracker.track` logs `throwable.message`. The original violation is preserved as `cause`,
+ * so the full stacktrace remains intact for debugging.
+ */
 private class StrictModeException(
     violation: Throwable,
-) : RuntimeException(violation)
+) : RuntimeException("StrictMode: ${violation.javaClass.simpleName}", violation)

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
@@ -52,7 +52,6 @@ private class AddButtonFeatureImpl : AddButtonFeature {
     ): Deferred<Int> {
         val sanitizedName = name.replace(Regex("[^a-zA-Z0-9._-]"), "_")
         val fileName = "$sanitizedName-${System.currentTimeMillis()}.mp3"
-        val targetFile = getFile(context, fileName)
 
         @OptIn(DelicateCoroutinesApi::class)
         return GlobalScope.async(Dispatchers.IO) {
@@ -61,6 +60,9 @@ private class AddButtonFeatureImpl : AddButtonFeature {
             if (validateAudioUri(context, parsed) != ValidationResult.Ok) {
                 return@async feedbackMessage
             }
+            // getFile() resolves context.getExternalFilesDir(...), which performs disk I/O —
+            // keep it inside the IO dispatcher so StrictMode does not flag it on the main thread.
+            val targetFile = getFile(context, fileName)
             try {
                 FileOutputStream(targetFile).use { fileOutputStream ->
                     context.contentResolver.openInputStream(parsed).use { inputStream ->

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -228,25 +229,34 @@ private fun AudioPreview(
     var isReady by remember { mutableStateOf(false) }
     var durationMs by remember { mutableStateOf(0) }
 
-    DisposableEffect(fileName) {
-        try {
-            val file = getFile(context, fileName)
-            player.setDataSource(file.absolutePath)
-            player.prepare()
-            durationMs = player.duration
-            player.setOnCompletionListener {
-                isPlaying = false
-                sliderPosition = 0f
+    LaunchedEffect(fileName) {
+        val prepared =
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    val file = getFile(context, fileName)
+                    player.setDataSource(file.absolutePath)
+                    player.prepare()
+                    player.duration
+                }
             }
-            isReady = true
-        } catch (e: IOException) {
-            Timber.w(e, "Could not load audio preview for file: %s", fileName)
-        } catch (e: IllegalStateException) {
-            Timber.w(e, "MediaPlayer in invalid state for file: %s", fileName)
-        }
-        onDispose {
-            player.release()
-        }
+        prepared
+            .onSuccess { duration ->
+                durationMs = duration
+                player.setOnCompletionListener {
+                    isPlaying = false
+                    sliderPosition = 0f
+                }
+                isReady = true
+            }.onFailure { e ->
+                when (e) {
+                    is IOException -> Timber.w(e, "Could not load audio preview for file: %s", fileName)
+                    is IllegalStateException -> Timber.w(e, "MediaPlayer in invalid state for file: %s", fileName)
+                    else -> throw e
+                }
+            }
+    }
+    DisposableEffect(Unit) {
+        onDispose { player.release() }
     }
 
     if (isReady) {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
@@ -17,6 +17,8 @@ import com.github.barriosnahuel.vossosunboton.commons.android.analytics.Analytic
 import com.github.barriosnahuel.vossosunboton.commons.file.copy
 import com.github.barriosnahuel.vossosunboton.commons.file.getFile
 import com.github.barriosnahuel.vossosunboton.model.Sound
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.io.FileOutputStream
 
@@ -25,7 +27,7 @@ internal interface ShareFeature {
      * @param surface canonical screen_name from `CanonicalScreenName` describing where the share originated.
      * @throws IllegalStateException when any required parameter is `null`
      */
-    fun share(
+    suspend fun share(
         context: Context,
         sound: Sound,
         surface: String,
@@ -43,14 +45,17 @@ private class ShareFeatureImpl : ShareFeature {
      * For more info check
      * [developer.android.com/training/secure-file-sharing/setup-sharing](https://developer.android.com/training/secure-file-sharing/setup-sharing)
      */
-    override fun share(
+    override suspend fun share(
         context: Context,
         sound: Sound,
         surface: String,
     ) {
         Timber.d("Trying to share button: %s", sound.name)
 
-        val buttonFileContentUri = getContentUriForSound(sound, context)
+        // Resolving the file path and (for bundled sounds, first share only) copying raw resources to disk
+        // both touch the file system. Run that part on IO; startActivity + analytics stay on the caller's
+        // Main dispatcher because Android's chooser expects the launching call on the UI thread.
+        val buttonFileContentUri = withContext(Dispatchers.IO) { getContentUriForSound(sound, context) }
         val shareIntent = Intent()
         shareIntent.action = Intent.ACTION_SEND
         shareIntent.type = "audio/*"

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -162,7 +162,7 @@ fun LandingScreen(viewModel: SoundsViewModel) {
                     } else {
                         CanonicalScreenName.EXPLORE_SOUNDS
                     }
-                ShareFeature.instance.share(context, sound, surface)
+                coroutineScope.launch { ShareFeature.instance.share(context, sound, surface) }
             },
             onDelete = { sound -> viewModel.deleteSound(sound) },
             onPinClick = { sound -> viewModel.togglePin(sound) },
@@ -183,7 +183,11 @@ fun LandingScreen(viewModel: SoundsViewModel) {
             onClose = viewModel::hideSearch,
             onPlayClick = viewModel::playOrStop,
             onSeek = viewModel::seekTo,
-            onShareClick = { sound -> ShareFeature.instance.share(context, sound, CanonicalScreenName.SEARCH_SOUND) },
+            onShareClick = { sound ->
+                coroutineScope.launch {
+                    ShareFeature.instance.share(context, sound, CanonicalScreenName.SEARCH_SOUND)
+                }
+            },
             onPinClick = viewModel::togglePin,
             onDelete = { sound ->
                 viewModel.hideSearch()

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
@@ -25,6 +25,7 @@ import io.mockk.every
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.spyk
+import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -72,7 +73,7 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
         every { mockedContext.startActivity(any()) } throws ActivityNotFoundException("no app handles audio share")
 
         try {
-            ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS)
+            runBlocking { ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
         } catch (_: ActivityNotFoundException) {
             // expected — propagates so the caller can show an error UI
         }
@@ -157,7 +158,7 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
         val slot = slot<Intent>()
         every { mockedContext.startActivity(capture(slot)) } answers { nothing }
 
-        ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS)
+        runBlocking { ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
 
         return slotFile.captured
     }
@@ -171,7 +172,7 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
         val slot = slot<Intent>()
         every { mockedContext.startActivity(capture(slot)) } answers { nothing }
 
-        ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS)
+        runBlocking { ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
 
         return slot.captured
     }

--- a/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/error/Trackable.kt
+++ b/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/error/Trackable.kt
@@ -30,9 +30,7 @@ interface Trackable {
  */
 object Tracker : Trackable {
     override fun track(throwable: Throwable) {
-        Timber.e("Tracking error to Firebase Crashlytics: %s", throwable.message)
-        throwable.printStackTrace()
-
+        Timber.e(throwable, "Tracking error to Firebase Crashlytics: %s", throwable.message)
         FirebaseCrashlytics.getInstance().recordException(throwable)
     }
 

--- a/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepository.kt
+++ b/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepository.kt
@@ -65,9 +65,9 @@ class SoundsRepository(
      * `.shareIn(scope, SharingStarted.WhileSubscribed(), replay = 1)` at a process-lived scope.
      */
     val sounds: Flow<List<Sound>> =
-        storedSounds.map { stored ->
-            mergeWithBundled(stored, PackagedAudios.get(context))
-        }
+        storedSounds
+            .map { stored -> mergeWithBundled(stored, PackagedAudios.get(context)) }
+            .flowOn(Dispatchers.IO)
 
     val durations: Flow<Map<String, Int>> =
         storedSounds


### PR DESCRIPTION
## Summary

- Finishes uncompleted work from https://github.com/barriosnahuel/bomp/pull/1097
- **Move every `getFile`/`File.exists`/`MediaPlayer.prepare`/`copy` call off main thread** in 4 places: `AddButtonFeature.saveNewButtonAsync`, `SoundsRepository.sounds` (the `.map { mergeWithBundled }` was downstream of `flowOn(IO)` and ran on the collector), `AddButtonScreen.AudioPreview` (`DisposableEffect` → `LaunchedEffect + withContext(IO)` + a separate `DisposableEffect(Unit)` for `player.release()`), `ShareFeature.share` (now `suspend`, with both `LandingScreen` call-sites wrapped in `coroutineScope.launch`).
- **One greppable line per violation** in logcat: `Tracker.track` consolidates `Timber.e + printStackTrace` into a single `Timber.e(throwable, …)`; `StrictModeConfigurator.reportViolation` drops its redundant `Timber.tag("StrictMode").e(...)`; `StrictModeException.message` now reads `"StrictMode: <ViolationClass>"` so `adb logcat | grep StrictMode` keeps working without a dedicated tag. Docs (`CONTRIBUTING.md`, `CLAUDE.md`) updated.

## Code review tips

- `Trackable.kt` change is global — every `Tracker.track` call-site (PlayerControllerImpl, AboutScreen, StrictModeConfigurator) now gets one line with stack inline instead of two. Verify the format is acceptable for the other call-sites.
- `AudioPreview` cleanup is split intentionally: `LaunchedEffect(fileName)` handles prepare; `DisposableEffect(Unit)` handles `player.release()` so it survives `fileName` recompositions.
- `ShareFeatureTest` switched to `runBlocking` for `share` calls — minimal change, no test logic moved.
- `getContentUriForSound` stays sync; only the call-site is wrapped in `withContext(IO)` so `startActivity` + analytics still run on Main.

## Already tested

- [x] `./gradlew check -x test` (ktlint, detekt, spotless, Android lint)
- [x] `./gradlew test` (full unit test suite)
- [ ] `./gradlew app:connectedDebugAndroidTest` — pending local emulator run; touches Composables (`AudioPreview`) and a click handler in `LandingScreen`
- [ ] Manual smoke on emulator: cold start, add bomp, edit bomp (audio preview), share bundled (first time → `copy` path), share custom — confirm zero `DiskReadViolation` and one greppable line if any other violation surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)