### PR TITLE
fix(copy): snackbar after delete reads "Audio deleted"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Deeplink `push-me://open/explore` now falls back to Home when no bundled sounds are available, avoiding a blank Explore tab
 - Share sheet filename for bundled sounds now shows the button name instead of an internal prefix
 - Custom button audio files are now named after the user-provided sound name (non-alphanumeric chars replaced by underscores) instead of the generic `Button-custom-` prefix
+- Snackbar after deleting a custom sound now reads "Audio deleted"/"Audio borrado" (was "Button deleted"/"Botón borrado") so the copy matches how users describe what they removed
 
 ### Fixed
 - The app now opens the Home tab on launch instead of the Search tab

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -204,7 +204,7 @@ private fun SnackbarEffects(
 ) {
     val deletedEvent by viewModel.deletedSoundEvent.collectAsState()
     val context = LocalContext.current
-    val buttonDeletedMessage = stringResource(R.string.app_feedback_button_deleted)
+    val audioDeletedMessage = stringResource(R.string.app_feedback_audio_deleted)
     val undoLabel = stringResource(R.string.app_undo)
     val playbackErrorMessage = stringResource(R.string.app_error_playback_failed)
     val buttonSavedTemplate = stringResource(R.string.app_feedback_button_saved)
@@ -241,7 +241,7 @@ private fun SnackbarEffects(
         if (deletedEvent == null) return@LaunchedEffect
         val result =
             snackbarHostState.showSnackbar(
-                message = buttonDeletedMessage,
+                message = audioDeletedMessage,
                 actionLabel = undoLabel,
                 duration = SnackbarDuration.Long,
             )

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -3,7 +3,7 @@
 
     <string name="app_share_chooser_title">Compartir vía</string>
     <string name="app_undo">Deshacer!</string>
-    <string name="app_feedback_button_deleted">Botón borrado</string>
+    <string name="app_feedback_audio_deleted">Audio borrado</string>
     <string name="app_feedback_button_saved">¡%1$s es tuyo!</string>
     <string name="app_feedback_generic_error_contact_support">Uh! Por favor contactá con soporte</string>
     <string name="app_navigation_menu_item_my_sounds">Mis audios</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
 
     <string name="app_share_chooser_title">Share vía</string>
     <string name="app_undo">Undo!</string>
-    <string name="app_feedback_button_deleted">Button deleted</string>
+    <string name="app_feedback_audio_deleted">Audio deleted</string>
     <string name="app_feedback_button_saved">%1$s is now yours!</string>
 <string name="app_feedback_generic_error_contact_support">Oops! I did it again, please contact support</string>
     <string name="app_navigation_menu_item_my_sounds">My Sounds</string>


### PR DESCRIPTION
### Summary
- Old "Button deleted" / "Botón borrado" snackbar framed the deletion around an internal UI concept; users describe what they removed as the audio
- Updated en + es-AR strings to "Audio deleted" / "Audio borrado"
- Renamed the resource key (`app_feedback_button_deleted` → `app_feedback_audio_deleted`) and the Compose variable to match — single call-site in `LandingScreen.kt`

### Code review tips
- The Spanish copy stays generic ("Audio borrado") rather than reaching for `Bomp` — keeps the snackbar concrete and avoids overloading the brand noun for a transient confirmation
- Resource key was renamed (not just the value) so contributors don't grep for "button" in unrelated contexts; the `ResourceName` lint check still passes (`app_` prefix preserved)

### Already tested
- [x] `./gradlew check -x test && ./gradlew test` (ktlint, detekt, Spotless, Android lint, unit tests)
- [ ] Local UI suite skipped — copy-only change is exempt per `CLAUDE.md` § Pre-push checklist