### PR TITLE
test(welcome): close race in two SoundsViewModelTest cases

### DIFF
--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
@@ -13,7 +13,10 @@ import com.github.barriosnahuel.vossosunboton.feature.welcome.WelcomeStickerStor
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.model.data.manager.SoundsRepository
 import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.mockk.verify
@@ -472,11 +475,13 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    private fun givenAViewModel(): SoundsViewModel {
+    private fun givenAViewModel(welcomeStore: WelcomeStickerStore? = null): SoundsViewModel {
+        val context = ApplicationProvider.getApplicationContext<android.app.Application>()
         val vm =
             SoundsViewModel(
-                ApplicationProvider.getApplicationContext(),
+                context,
                 ioDispatcher = UnconfinedTestDispatcher(),
+                welcomeStore = welcomeStore ?: WelcomeStickerStore(context),
             )
         runBlocking { vm.isInitialLoadComplete.first { it } }
         return vm
@@ -569,8 +574,11 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `restoreSound on welcome restores visibility and clears prefs flag`() {
-        val viewModel = givenAViewModel()
+    fun `restoreSound on welcome restores visibility and asks the store to restore`() {
+        val welcomeStore = mockk<WelcomeStickerStore>(relaxed = true)
+        coEvery { welcomeStore.isActive() } returns true
+        coEvery { welcomeStore.wasRestored() } returns false
+        val viewModel = givenAViewModel(welcomeStore = welcomeStore)
         val welcomeTitle =
             ApplicationProvider
                 .getApplicationContext<android.content.Context>()
@@ -582,23 +590,18 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
 
         assertThat(viewModel.welcomeStickerVisible.value).isTrue()
         assertThat(viewModel.sounds.value.any { it.name == welcomeTitle }).isTrue()
-        // The disk write happens via viewModelScope.launch(ioDispatcher) → withContext(IO) →
-        // store.edit. UnconfinedTestDispatcher runs the outer launch in line, but the
-        // withContext(IO) switches to real IO threads — poll until the disk reflects the restore.
-        val store = WelcomeStickerStore(ApplicationProvider.getApplicationContext())
-        runBlocking {
-            withTimeoutOrNull(5_000L) {
-                while (!store.isActive()) {
-                    kotlinx.coroutines.delay(25L)
-                }
-            }
-            assertThat(store.isActive()).isTrue()
-        }
+        // Behavior assertion only — disk persistence is covered by `WelcomeStickerStoreTest`.
+        // The previous version polled a fresh store instance, which raced with the IO write and
+        // could permanently cache a stale read.
+        coVerify { welcomeStore.restore() }
     }
 
     @Test
     fun `confirmDelete on welcome calls welcomeStore consume and skips repo delete`() {
-        val viewModel = givenAViewModel()
+        val welcomeStore = mockk<WelcomeStickerStore>(relaxed = true)
+        coEvery { welcomeStore.isActive() } returns true
+        coEvery { welcomeStore.wasRestored() } returns false
+        val viewModel = givenAViewModel(welcomeStore = welcomeStore)
         val welcomeTitle =
             ApplicationProvider
                 .getApplicationContext<android.content.Context>()
@@ -608,16 +611,8 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
 
         viewModel.confirmDelete()
 
-        // See the restoreSound test above for the polling rationale.
-        val store = WelcomeStickerStore(ApplicationProvider.getApplicationContext())
-        runBlocking {
-            withTimeoutOrNull(5_000L) {
-                while (store.isActive()) {
-                    kotlinx.coroutines.delay(25L)
-                }
-            }
-            assertThat(store.isActive()).isFalse()
-        }
+        // See the restoreSound test above for the rationale on verifying behavior over disk.
+        coVerify { welcomeStore.consume() }
         assertThat(viewModel.deletedSoundEvent.value).isNull()
     }
 


### PR DESCRIPTION
### Summary
- `confirmDelete on welcome calls welcomeStore consume and skips repo delete` flaked on develop CI after merging the previous PR; local `clean build` and instrumented suite both stay green.
- Root cause: the test built a fresh `WelcomeStickerStore` after `confirmDelete()` and polled `isActive()`. The store caches the first read in memory and never revalidates, so when the IO write was still in flight at first poll the cache locked in the stale `consumed=false` and the loop timed out (no amount of timeout extension would have helped — the cache is one-way sticky).
- Fix: inject a mocked `WelcomeStickerStore` through the existing ctor param and `coVerify { consume() }` / `coVerify { restore() }`. Disk persistence already has end-to-end coverage in `WelcomeStickerStoreTest`.
- Same defect lived dormant in `restoreSound on welcome restores visibility and clears prefs flag` with inverted polarity — refactored too and renamed to `… asks the store to restore` to reflect the new contract.

### Code review tips
- `givenAViewModel` now takes an optional `welcomeStore` and falls back to a real one when none is passed, so the rest of the suite is unchanged.
- The mocked store needs `coEvery { isActive() } returns true` and `coEvery { wasRestored() } returns false` so the welcome lands at row 0 and the existing assertions on `_welcomeStickerVisible` / `sounds` still hold.
- No production code touched. `WelcomeStickerStore`'s cache-then-async-write is intentional for production; only the tests had to stop bypassing it.
- No CHANGELOG entry: per `CLAUDE.md` § Changelog, regressions never seen by end-users (CI-only flake introduced in the same `[unreleased]` cycle as the DataStore migration) don't get a `Fixed` line.

### Already tested
- [x] `./gradlew :app:testDebugUnitTest --tests "...SoundsViewModelTest"` — both refactored tests pass at SDK 23, 33, default; runtime per case dropped from ~5 s polling to ~0.1 s.
- [x] `./gradlew check -x test` — ktlint, detekt, Spotless, Android Lint all green.
- [x] `./gradlew test` — full unit suite green.
- [x] `./gradlew app:connectedDebugAndroidTest` on `push_me_test` AVD — 49/51 passed, 2 expected skips (locale-AR and bundled-audio gated).