### PR TITLE
docs(claude): Android grounding sources and CLAUDE.md structure pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ./gradlew spotlessApply
 ```
 
-## Tooling & Environment
-- **Android CLI**: Available via `adb` (Android Debug Bridge), `fastboot`, and `emulator`.
+The Android command-line tools — `adb` (Android Debug Bridge), `fastboot`, and `emulator` — are on `PATH` and available directly when needed (booting the test AVD, sideloading, capturing screenshots, etc.).
 
 ## Module Architecture
 
@@ -52,11 +51,13 @@ Dependency direction: `app` → `model`, `commons_android`, `commons_file`. No d
 
 ## Persistence
 
+This section captures the long-form rationale; the one-line summary lives in § *Project-specific overrides* → Persistence.
+
 Use **Jetpack DataStore Preferences** for any new persistent key-value storage. The pattern lives in `model/.../SoundsRepository.kt` (top-level `Context.bompsStore` delegate via `preferencesDataStore(...)` + a `ReplaceFileCorruptionHandler`). Mirror it for new stores. `WelcomeStickerStore`, `DataStoreFirstFlagStore`, and `DataStoreCounterStore` are reference implementations.
 
 `SharedPreferences` is **forbidden** in this project. The grep `getSharedPreferences|EncryptedSharedPreferences` must return zero hits in `src/main` across all modules. Reviewers should reject any new SharedPrefs in PRs.
 
-When you need to keep a synchronous read API on top of DataStore (e.g. the analytics tracker, where call sites fire events right before a navigate-away to a chooser/browser and the launch could be lost), use the in-memory-cache + async-write-back pattern from `commons_android/.../DataStoreFirstFlagStore.kt` and `DataStoreCounterStore.kt`. Mirrors Firebase Analytics' own sync-API + internal-buffer design — preserves event durability when the OS suspends our process. The cache prime happens once via `runBlocking(IO)` inside the store constructor and lives inside the `StrictMode.allowThreadDiskReads` block in `AnalyticsTrackerProvider.createTracker`. `MainApplication.onCreate` warm-up dispatches the prime onto a background coroutine so it rarely blocks main in practice.
+When you need to keep a synchronous read API on top of DataStore (e.g. the analytics tracker, where call sites fire events right before a navigate-away to a chooser/browser and the launch could be lost), use the in-memory-cache + async-write-back pattern from `commons_android/.../DataStoreFirstFlagStore.kt` and `DataStoreCounterStore.kt`. Mirrors Firebase Analytics' own sync-API + internal-buffer design — preserves event durability when the OS suspends our process. The cache prime happens once via `runBlocking(IO)` inside the store constructor and lives inside the `StrictMode.allowThreadDiskReads` block in `AnalyticsTrackerProvider.createTracker`. `MainApplication.onCreate` warm-up dispatches the prime onto a background coroutine so it rarely blocks main in practice. This is the documented exception to the no-`runBlocking`-in-production rule declared in § *Project-specific overrides* → Threading; do not generalize this pattern beyond the analytics-tracker cache prime.
 
 For test data shape: every store ships a `@VisibleForTesting(otherwise = NONE) suspend fun clearForTest()` so test setUp can reset state without poking at the file system.
 
@@ -329,9 +330,7 @@ Every `.kt` source file must start with the AGPLv3 copyright block (enforced by 
 
 If `./gradlew check` fails with a Spotless violation, run `./gradlew spotlessApply` to auto-fix all files.
 
-## About screen
-
-**Do not remove or hide the About screen.** It is the "Appropriate Legal Notices" mechanism required by AGPLv3 §0. Its entry point is the TopAppBar overflow menu in `LandingScreen.kt`.
+**Do not remove or hide the About screen.** It is the "Appropriate Legal Notices" mechanism required by AGPLv3 §0 (paired with the copyright headers above). Its entry point is the TopAppBar overflow menu in `LandingScreen.kt`.
 
 ## Sources of truth for Android / Kotlin / Compose decisions
 
@@ -501,12 +500,14 @@ destinations require an explicit branch in the `when`; the `else` stays
 
 ### Backup hygiene
 
-Before adding any new SharedPreferences key or file path that could contain
-sensitive data (auth tokens, account identifiers, private user content), add
-explicit `<exclude>` entries to both `app/src/main/res/xml/app_backup_rules.xml`
-and `app/src/main/res/xml/app_data_extraction_rules.xml`. Today nothing
-sensitive is stored, so the rules are intentionally permissive (`<include>` of
-`my-prefs` and the `Music` external dir). When that changes, the exclusion
+Before adding any new DataStore preference file or persistent file path that
+could contain sensitive data (auth tokens, account identifiers, private user
+content), add explicit `<exclude>` entries to both
+`app/src/main/res/xml/app_backup_rules.xml` and
+`app/src/main/res/xml/app_data_extraction_rules.xml`. Today nothing sensitive
+is stored, so the rules are intentionally permissive — they `<include>` the
+`Music` external directory and the three DataStore preference files (`bomps`,
+`welcome-sticker`, `analytics-counters`). When that changes, the exclusion
 ships in the same commit as the new key.
 
 ### Exported components default to false
@@ -617,10 +618,8 @@ https://project-url
 - Never add a `Fixed` entry for a bug introduced in the same `[unreleased]` cycle. If end-users never experienced the regression, it has no changelog entry — git history provides the traceability
 - **User-facing first, technical under "For nerds":** within `## [unreleased]`, list user-facing changes under the standard `### Added/Changed/Fixed/Removed` headings, then put technical/contributor-only changes under a `### For nerds 🤓` subsection with `#### Added/Changed/Fixed/Removed` sub-headings (omit any that would be empty). A change is **user-facing** if a normal user would notice it: visible UI, labels, copy, behavior, permissions, performance they can feel. **Technical** means: build/CI/tooling, dependency bumps, internal refactors, test infrastructure, Play Console assets internal to the repo, README/docs, analytics instrumentation. This split applies only to `[unreleased]` and going forward — released versions stay as written
 
-## Handoff notes
+## Handoff notes & issue tracking
+
+GitHub Issues are open for external feature requests and bug reports. Out-of-scope work identified during development is noted in the PR description, not opened as a tracking issue.
 
 `handoff/` contains session handoff documents with decisions taken, key file paths, and pending work. Ignored by git. Only read these files when the user explicitly references them to continue a previous topic.
-
-## Issue tracking
-
-GitHub Issues are open for external feature requests and bug reports. Out-of-scope work identified during development is noted in the PR description; session context goes in handoff notes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,6 +333,57 @@ If `./gradlew check` fails with a Spotless violation, run `./gradlew spotlessApp
 
 **Do not remove or hide the About screen.** It is the "Appropriate Legal Notices" mechanism required by AGPLv3 §0. Its entry point is the TopAppBar overflow menu in `LandingScreen.kt`.
 
+## Sources of truth for Android / Kotlin / Compose decisions
+
+Do not invent or recall best practices from training data alone — the platform moves and so does the recommended pattern. When making a non-trivial decision in any of the areas below, **consult the authoritative source first** (WebFetch the page, or invoke the linked skill) and **cite it** in the response. If you can't reach the source, say so and mark the recommendation as a heuristic.
+
+| Area | Authoritative source |
+|---|---|
+| Jetpack Compose: state, recomposition, side-effects, performance, lifecycle-aware APIs | https://developer.android.com/develop/ui/compose |
+| Navigation in Compose | Linked skill `navigation-3` (covers Navigation 3 install/migration, deep links, multi-backstack, Hilt/ViewModel integration) |
+| XML view → Compose migration | Linked skill `migrate-xml-views-to-jetpack-compose` |
+| Edge-to-edge / system bars / insets | Linked skill `edge-to-edge` |
+| Coroutines, Flow, StateFlow, structured concurrency, dispatchers, testing with `runTest` | https://kotlinlang.org/docs/coroutines-guide.html and https://developer.android.com/kotlin/coroutines |
+| Lifecycle: `repeatOnLifecycle`, `collectAsStateWithLifecycle`, lifecycle-aware components | https://developer.android.com/topic/libraries/architecture/lifecycle |
+| App architecture (UI layer / domain / data, unidirectional data flow, ViewModel + UI state, UI events) | https://developer.android.com/topic/architecture and https://developer.android.com/topic/architecture/ui-layer/events |
+| DataStore (Preferences/Proto), migration from SharedPreferences | https://developer.android.com/topic/libraries/architecture/datastore |
+| Background work, WorkManager, foreground services, exact alarms | https://developer.android.com/develop/background-work |
+| Permissions / runtime permissions / scoped storage | https://developer.android.com/training/permissions |
+| Accessibility in Compose (semantics, traversal order, click labels, custom actions, large text) | https://developer.android.com/develop/ui/compose/accessibility — pairs with the project's WCAG 2.2 AA functional requirement (see § Accessibility) |
+| AGP 9 migration | Linked skill `agp-9-upgrade` |
+| R8 keep rules audit | Linked skill `r8-analyzer` |
+| Play Billing | Linked skill `play-billing-library-version-upgrade` |
+| Kotlin idioms, conventions, KEEP proposals | https://kotlinlang.org/docs/coding-conventions.html and KEEP at https://github.com/Kotlin/KEEP |
+| Project-specific architectural decisions | `docs/adr/*.md` — read the relevant ADR before changing the area it governs |
+
+**When to actually consult vs. answer from memory:**
+- **Do consult** when: I'm brainstorming an alternative (see § Working style in user-level CLAUDE.md), the area is version-sensitive (Compose / AGP / Material 3 evolved recently), the change touches lifecycle / threading / security / accessibility, or you'd otherwise be guessing.
+- **Skip consult** for trivial mechanical edits, copy/string changes inside the locale rules, or when the answer is purely about a project convention already documented in this file.
+- **Cite or doubt:** every recommendation grounded in one of these sources should name the source (URL or skill name). If you're not consulting, say so explicitly so I know the answer is heuristic.
+
+## Project-specific overrides (read before changing platform-touching code)
+
+These are decisions this repo took that diverge from — or narrow — the generic Android recommendation. They override the public docs *for this codebase*. If a generic best-practice answer conflicts with one of these, the override wins (or, if you think the override is wrong, raise it as a discussion before changing it; don't silently flip).
+
+- **DI: manual factories, no Hilt — deliberate small-app trade-off.** ViewModels are constructed via `viewModelFactory { initializer { ... } }` (see `SoundsViewModel.kt`). Google's official recommendation for production apps is Hilt; we chose manual factories because at the current scale (one ViewModel, four modules, no scoped repositories beyond `DataStore`-backed stores) the build/test tax of Hilt (KSP, `HiltAndroidRule`, `HiltTestApplication`, module mocking) outweighs its benefits. **Revisit when:** ViewModel/repository/scoped-dependency count grows to the point where boilerplate factories become friction, or when a feature requires `@AssistedInject`-style construction. Until then, do not introduce Hilt, Koin, or any DI framework without an ADR under `docs/adr/`.
+- **One-shot UI events: `Channel<T>` + `receiveAsFlow()` — accepted today, with caveats.** Pattern visible in `SoundsViewModel` (`_buttonSavedEvent: Channel<String>`). Note that the current Compose-team guidance leans toward **event-as-state** (event field inside `UiState` + `onEventConsumed()` callback) — see https://developer.android.com/topic/architecture/ui-layer/events. The `Channel` pattern can drop events if the app is backgrounded between emit and collect. Reuse the existing `Channel` pattern for consistency for now; **revisit** if we hit a real "lost event in background" report or when a new flow is sensitive enough that delivery guarantees matter (then migrate that flow to event-as-state).
+- **Async / state model:** `viewModelScope` + `StateFlow` for screen state. Don't add a `SharedFlow` "for events" — pick `Channel` (existing convention) or migrate to event-as-state if the case warrants the upgrade per the bullet above.
+- **Threading:** dispatchers are *constructor-injected* into ViewModels (default `Dispatchers.IO`). No `runBlocking` in production code, except the documented analytics-cache-prime exception captured in § *Persistence*. No raw `Thread { ... }` or `AsyncTask`. No work on the main thread for I/O.
+- **Persistence:** see § *Persistence* — DataStore Preferences is the chosen mechanism, `SharedPreferences` is forbidden, the sync-API pattern via in-memory cache + async write-back is the documented solution for call-sites that need synchronous reads.
+- **Networking, image loading, Room:** none of these are in the dependency graph today. If a feature requires one, raise it before adding — the addition itself is a design decision that needs an ADR, not a side-effect of a feature PR.
+- **Analytics, error tracking, StrictMode, security boundaries, design system, accessibility:** see the dedicated sections in this file. Those rules are stricter than any generic Android guidance and override it.
+
+**Each substantive override should be backed by an ADR.** This section is the **index / one-liner summary**; the long-form rationale (context, options considered, decision, consequences) lives in `docs/adr/*.md`. The pattern already exists with `0001-local-ui-test-suite.md`. New overrides added here that are non-trivial decisions — *"no Hilt — manual `viewModelFactory`"*, *"`Channel<T>` for one-shot UI events instead of event-as-state"* — should ship with (or be followed by) a matching ADR that captures the trade-offs. CLAUDE.md tells you *what* the override is; the ADR tells you *why* and *what we considered*. Treat the absence of an ADR for a substantive override as a debt to be paid, not as a green light to flip the decision silently.
+
+**Re-validate on dependency changes.** When a PR updates `gradle/libs.versions.toml`, `gradle/wrapper/gradle-wrapper.properties`, or any `build.gradle(.kts)` with library/plugin version bumps — especially Compose BOM, AGP, Kotlin, coroutines, lifecycle, DataStore, or anything that introduces a *new* dependency — re-read both this section and § *Sources of truth* in the same PR. If the upstream recommended pattern changed in the new version (e.g. Compose introduces a new lifecycle-aware API, AGP deprecates a config, a new lib enters the graph that contradicts an override), update these sections in the same PR as the bump. Dependabot bumps count — don't merge them blind. Same applies after running any of the upgrade skills (`agp-9-upgrade`, `navigation-3`, `play-billing-library-version-upgrade`, `migrate-xml-views-to-jetpack-compose`): the migration's exit criteria includes re-reading these sections.
+
+### Known migration debt
+
+Things the current codebase does that are *not* the recommended pattern. New code should use the recommended form; existing call-sites migrate when touched.
+
+- **`collectAsState()` → `collectAsStateWithLifecycle()`.** The lifecycle-aware variant stops collection in `STOPPED` state, which avoids wasted work and stale `StateFlow` references when the screen is off. New Composables collecting a ViewModel-owned `StateFlow` must use `collectAsStateWithLifecycle()`; existing call-sites migrate when their file is touched for another reason.
+- **String resources: every user-facing string via `stringResource(R.string.app_*)`.** Not technically an override (this is plain best practice for i18n + a11y + maintainability) but flagged here because it's worth catching in review. No hardcoded literals in Composables. `contentDescription` for non-decorative `Icon`/`Image` is mandatory and must come from a string resource (see § *Accessibility*); decorative assets use `contentDescription = null` explicitly.
+
 ## Pre-PR checklist
 
 Before opening a PR for any feature or bug fix, verify:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Index
+
+- **Lookup before working** — § *Sources of truth* · § *Project-specific overrides*
+- **Architecture & code conventions** — § *Module Architecture* · § *Persistence* · § *Worktree setup* · § *Android resources naming* · § *Copyright headers*
+- **Testing** — § *Bug fixes — TDD workflow* · § *Features — test coverage workflow* · § *Test naming convention* · § *Activity smoke tests* · § *Local UI test suite*
+- **Pre-merge / pre-push** — § *Pre-PR checklist* · § *Pre-push checklist*
+- **Cross-cutting code rules** — § *Analytics events* · § *Error tracking (non-fatals)* · § *StrictMode debug audit* · § *Security boundaries* · § *Accessibility (WCAG 2.2 AA)* · § *Design system*
+- **Product, brand & copy** — § *Product & brand context* · § *Repo writing language* · § *Copy & localization* · § *Store listing asset generation*
+- **Process & metadata** — § *Labels and milestone* · § *Third-party notices* · § *Changelog* · § *Handoff notes & issue tracking*
+
 ## Commands
 
 ```bash
@@ -49,6 +59,57 @@ Push Me is an Android soundboard app with 4 Gradle modules:
 
 Dependency direction: `app` → `model`, `commons_android`, `commons_file`. No dynamic features today — the Add Button flow used to live in a `:feature_addbutton` module but was promoted into `:app` since creating buttons is core to the product. Reintroduce dynamic features when freemium-style on-demand delivery is needed.
 
+## Sources of truth for Android / Kotlin / Compose decisions
+
+Do not invent or recall best practices from training data alone — the platform moves and so does the recommended pattern. When making a non-trivial decision in any of the areas below, **consult the authoritative source first** (WebFetch the page, or invoke the linked skill) and **cite it** in the response. If you can't reach the source, say so and mark the recommendation as a heuristic.
+
+| Area | Authoritative source |
+|---|---|
+| Jetpack Compose: state, recomposition, side-effects, performance, lifecycle-aware APIs | https://developer.android.com/develop/ui/compose |
+| Navigation in Compose | Linked skill `navigation-3` (covers Navigation 3 install/migration, deep links, multi-backstack, Hilt/ViewModel integration) |
+| XML view → Compose migration | Linked skill `migrate-xml-views-to-jetpack-compose` |
+| Edge-to-edge / system bars / insets | Linked skill `edge-to-edge` |
+| Coroutines, Flow, StateFlow, structured concurrency, dispatchers, testing with `runTest` | https://kotlinlang.org/docs/coroutines-guide.html and https://developer.android.com/kotlin/coroutines |
+| Lifecycle: `repeatOnLifecycle`, `collectAsStateWithLifecycle`, lifecycle-aware components | https://developer.android.com/topic/libraries/architecture/lifecycle |
+| App architecture (UI layer / domain / data, unidirectional data flow, ViewModel + UI state, UI events) | https://developer.android.com/topic/architecture and https://developer.android.com/topic/architecture/ui-layer/events |
+| DataStore (Preferences/Proto), migration from SharedPreferences | https://developer.android.com/topic/libraries/architecture/datastore |
+| Background work, WorkManager, foreground services, exact alarms | https://developer.android.com/develop/background-work |
+| Permissions / runtime permissions / scoped storage | https://developer.android.com/training/permissions |
+| Accessibility in Compose (semantics, traversal order, click labels, custom actions, large text) | https://developer.android.com/develop/ui/compose/accessibility — pairs with the project's WCAG 2.2 AA functional requirement (see § Accessibility) |
+| AGP 9 migration | Linked skill `agp-9-upgrade` |
+| R8 keep rules audit | Linked skill `r8-analyzer` |
+| Play Billing | Linked skill `play-billing-library-version-upgrade` |
+| Kotlin idioms, conventions, KEEP proposals | https://kotlinlang.org/docs/coding-conventions.html and KEEP at https://github.com/Kotlin/KEEP |
+| Project-specific architectural decisions | `docs/adr/*.md` — read the relevant ADR before changing the area it governs |
+
+**When to actually consult vs. answer from memory:**
+- **Do consult** when: I'm brainstorming an alternative (see § Working style in user-level CLAUDE.md), the area is version-sensitive (Compose / AGP / Material 3 evolved recently), the change touches lifecycle / threading / security / accessibility, or you'd otherwise be guessing.
+- **Skip consult** for trivial mechanical edits, copy/string changes inside the locale rules, or when the answer is purely about a project convention already documented in this file.
+- **Cite or doubt:** every recommendation grounded in one of these sources should name the source (URL or skill name). If you're not consulting, say so explicitly so I know the answer is heuristic.
+
+## Project-specific overrides (read before changing platform-touching code)
+
+These are decisions this repo took that diverge from — or narrow — the generic Android recommendation. They override the public docs *for this codebase*. If a generic best-practice answer conflicts with one of these, the override wins (or, if you think the override is wrong, raise it as a discussion before changing it; don't silently flip).
+
+- **DI: manual factories, no Hilt — deliberate small-app trade-off.** ViewModels are constructed via `viewModelFactory { initializer { ... } }` (see `SoundsViewModel.kt`). Google's official recommendation for production apps is Hilt; we chose manual factories because at the current scale (one ViewModel, four modules, no scoped repositories beyond `DataStore`-backed stores) the build/test tax of Hilt (KSP, `HiltAndroidRule`, `HiltTestApplication`, module mocking) outweighs its benefits. **Revisit when:** ViewModel/repository/scoped-dependency count grows to the point where boilerplate factories become friction, or when a feature requires `@AssistedInject`-style construction. Until then, do not introduce Hilt, Koin, or any DI framework without an ADR under `docs/adr/`.
+- **One-shot UI events: `Channel<T>` + `receiveAsFlow()` — accepted today, with caveats.** Pattern visible in `SoundsViewModel` (`_buttonSavedEvent: Channel<String>`). Note that the current Compose-team guidance leans toward **event-as-state** (event field inside `UiState` + `onEventConsumed()` callback) — see https://developer.android.com/topic/architecture/ui-layer/events. The `Channel` pattern can drop events if the app is backgrounded between emit and collect. Reuse the existing `Channel` pattern for consistency for now; **revisit** if we hit a real "lost event in background" report or when a new flow is sensitive enough that delivery guarantees matter (then migrate that flow to event-as-state).
+- **Async / state model:** `viewModelScope` + `StateFlow` for screen state. Don't add a `SharedFlow` "for events" — pick `Channel` (existing convention) or migrate to event-as-state if the case warrants the upgrade per the bullet above.
+- **Threading:** dispatchers are *constructor-injected* into ViewModels (default `Dispatchers.IO`). No `runBlocking` in production code, except the documented analytics-cache-prime exception captured in § *Persistence*. No raw `Thread { ... }` or `AsyncTask`. No work on the main thread for I/O.
+- **Persistence:** see § *Persistence* — DataStore Preferences is the chosen mechanism, `SharedPreferences` is forbidden, the sync-API pattern via in-memory cache + async write-back is the documented solution for call-sites that need synchronous reads.
+- **Networking, image loading, Room:** none of these are in the dependency graph today. If a feature requires one, raise it before adding — the addition itself is a design decision that needs an ADR, not a side-effect of a feature PR.
+- **Analytics, error tracking, StrictMode, security boundaries, design system, accessibility:** see the dedicated sections in this file. Those rules are stricter than any generic Android guidance and override it.
+
+**Each substantive override should be backed by an ADR.** This section is the **index / one-liner summary**; the long-form rationale (context, options considered, decision, consequences) lives in `docs/adr/*.md`. The pattern already exists with `0001-local-ui-test-suite.md`. New overrides added here that are non-trivial decisions — *"no Hilt — manual `viewModelFactory`"*, *"`Channel<T>` for one-shot UI events instead of event-as-state"* — should ship with (or be followed by) a matching ADR that captures the trade-offs. CLAUDE.md tells you *what* the override is; the ADR tells you *why* and *what we considered*. Treat the absence of an ADR for a substantive override as a debt to be paid, not as a green light to flip the decision silently.
+
+**Re-validate on dependency changes.** When a PR updates `gradle/libs.versions.toml`, `gradle/wrapper/gradle-wrapper.properties`, or any `build.gradle(.kts)` with library/plugin version bumps — especially Compose BOM, AGP, Kotlin, coroutines, lifecycle, DataStore, or anything that introduces a *new* dependency — re-read both this section and § *Sources of truth* in the same PR. If the upstream recommended pattern changed in the new version (e.g. Compose introduces a new lifecycle-aware API, AGP deprecates a config, a new lib enters the graph that contradicts an override), update these sections in the same PR as the bump. Dependabot bumps count — don't merge them blind. Same applies after running any of the upgrade skills (`agp-9-upgrade`, `navigation-3`, `play-billing-library-version-upgrade`, `migrate-xml-views-to-jetpack-compose`): the migration's exit criteria includes re-reading these sections.
+
+### Known migration debt
+
+Things the current codebase does that are *not* the recommended pattern. New code should use the recommended form; existing call-sites migrate when touched.
+
+- **`collectAsState()` → `collectAsStateWithLifecycle()`.** The lifecycle-aware variant stops collection in `STOPPED` state, which avoids wasted work and stale `StateFlow` references when the screen is off. New Composables collecting a ViewModel-owned `StateFlow` must use `collectAsStateWithLifecycle()`; existing call-sites migrate when their file is touched for another reason.
+- **String resources: every user-facing string via `stringResource(R.string.app_*)`.** Not technically an override (this is plain best practice for i18n + a11y + maintainability) but flagged here because it's worth catching in review. No hardcoded literals in Composables. `contentDescription` for non-decorative `Icon`/`Image` is mandatory and must come from a string resource (see § *Accessibility*); decorative assets use `contentDescription = null` explicitly.
+
 ## Persistence
 
 This section captures the long-form rationale; the one-line summary lives in § *Project-specific overrides* → Persistence.
@@ -61,55 +122,50 @@ When you need to keep a synchronous read API on top of DataStore (e.g. the analy
 
 For test data shape: every store ships a `@VisibleForTesting(otherwise = NONE) suspend fun clearForTest()` so test setUp can reset state without poking at the file system.
 
-## Product & brand context (when relevant)
+## Worktree setup
 
-Product specs, brand language, and canonical naming live in the sibling backlog repo at `../push-me-backlog/`. Consult it when working on user-facing strings, micro-copy, feature/level naming, gamification, or social-layer behavior — these docs are the source of truth for the in-app vocabulary:
+After creating a new worktree, always run these commands to replace the dummy `google-services.json` and copy the bundled audio files from the main worktree:
 
-- [`../push-me-backlog/docs/brand-dna.md`](../push-me-backlog/docs/brand-dna.md) — canonical terminology (Bomp, Bomper, Bompear, Escala Richter levels: Bompín / Bompazo / Bompardo / Bompión, Inmortal as cloud-state descriptor)
-- [`../push-me-backlog/CLAUDE.md`](../push-me-backlog/CLAUDE.md) — Product Language glossary and spec conventions
-- [`../push-me-backlog/backlog/`](../push-me-backlog/backlog/) — pending feature specs (the "why" behind features)
+```bash
+cp "$(git rev-parse --git-common-dir)/../app/google-services.json" app/google-services.json
+git update-index --skip-worktree app/google-services.json
+cp "$(git rev-parse --git-common-dir)/../model/src/debug/res/raw/"*.mp3 model/src/debug/res/raw/ 2>/dev/null || true
+cp "$(git rev-parse --git-common-dir)/../model/src/debug/res/raw/"*.ogg model/src/debug/res/raw/ 2>/dev/null || true
+```
+- Release signing requires `nahuelbarrios.keystore-appbundle.pkcs12` and `secure.properties` (with `key.alias`, `key.password`, `store.password`) in the project root — not committed.
+- Debug builds use the included debug keystore and work without the above.
+- Bundled audio files (`model/src/debug/res/raw/*.mp3` and `*.ogg`) are not committed. Without them the debug build still compiles and runs, but the Explore tab will be empty.
 
-Skip for refactors, dep bumps, build config, and platform-wiring fixes — those don't need brand context. If the sibling path isn't present (CI, alternate checkout layout), proceed with the in-repo strings as authoritative and surface the gap to the user.
+## Android resources naming
 
-## Repo writing language
+Every resource name must start with the `resourcePrefix` defined in the module's `build.gradle`:
 
-Contributor-facing files in this repo are written in **English**: `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, `CODE_OF_CONDUCT.md`, ADRs under `docs/adr/`, `.github/` templates, `CLAUDE.md` itself, code comments, commit messages, PR descriptions, and handoff notes. This applies to any new file you create whose audience is contributors or maintainers.
+| Module | Prefix |
+|---|---|
+| `app` | `app_` |
+| `commons_android` | `commons_android_` |
+| `commons_file` | `commons_file_` |
+| `model` | `model_` |
 
-The only exception is **embedded examples of user-facing copy**: when a doc demonstrates how a localized string should read (e.g. the ❌/✓ examples under § Copy & localization, or a snippet quoted from `strings.xml`), the example stays in its target locale (typically es-AR) so the rule is illustrated faithfully. The surrounding prose explaining the example is still in English.
+Logical sub-areas inside `:app` (e.g. the Add Button flow at `feature/addbutton/`) use a secondary prefix on top of `app_` for grouping — `app_addbutton_*`, `app_about_*`, etc. Keep new resources clustered by feature this way.
 
-User-facing surfaces (in-app strings, store listings, push notifs, Play Console "What's New", marketing emails) are out of scope for this rule and follow § Copy & localization — they ship in the target locale.
+Android Lint enforces this rule (`ResourceName` check). Violating it causes a build failure.
 
-## Copy & localization
+## Copyright headers
 
-When generating user-facing copy in any locale (in-app strings, store listings, push notifs, changelogs, emails) the output must read **native to the target locale**, not as a literal translation from another language — and must not contradict the brand DNA or the published legal policies.
+Every `.kt` source file must start with the AGPLv3 copyright block (enforced by Spotless at CI time):
 
-**Sources of truth to consult before drafting copy** (paths relative to `/Users/barrios.nahuel/Workspace/push-me/`):
+```
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+```
 
-- `../push-me-backlog/docs/brand-dna.md` — canonical terminology, reserved terms, anti-positioning bans
-- `../push-me-backlog/CLAUDE.md` — Product Language glossary (incl. which terms are gated to non-shipped features like Pro/cloud)
-- `../push-me-ghpages/privacy-policy.html` — published Privacy Policy (rights ARCO, retention, third-party data)
-- `../push-me-ghpages/data-safety.html` — published Data Safety declaration (what's collected, shared, optional)
+If `./gradlew check` fails with a Spotless violation, run `./gradlew spotlessApply` to auto-fix all files.
 
-If any of these paths is missing (CI, alternate checkout), do **not** invent the claim — flag the gap to the user and proceed with the in-repo strings as authoritative.
-
-**Default locale for in-app strings.** `app/src/main/res/values/strings.xml` is the **English** master; Spanish-AR copy lives in `values-es/strings.xml`.
-
-Hard rules:
-
-- **No calque translations.** A phrase that's natural in the source can be wrong in the target. Examples we hit and fixed during the en-US listing: "save a day" (calque of "salvar un día" — correct English idiom is `save the day`); "on the other side" (calque of "del otro lado" — in English this means *afterlife*; the phone idiom is `on the other end`); "your audios" (calque of "tus audios" — `audio` is a mass noun in English, the natural plural is `voice notes` / `voice clips` / `voice memos`).
-- **Use the target locale's idioms and collocations.** Verify with a native speaker or a current idiom reference, not Google Translate. When in doubt, prefer the simpler concrete word the audience already uses every day.
-- **Punchy register, locale-aware.** US English marketing leans on contractions, short sentences, imperative verbs, and concrete sensory nouns. Spanish-AR leans on voseo and warmth. Match the register the locale expects, not a generic "neutral" tone.
-- **Vocabulary the target audience uses.** If the source describes the input as "audios", the English version should name it the way English speakers do (`voice notes`, `voice memos`). Mapping is not 1:1.
-- **ASO awareness for store-listing copy.** For Play Console copy (title, short description, full description, screenshot headlines, feature graphic taglines), integrate the high-volume queries the target market actually searches — organically, without breaching the brand-DNA bans (`soundboard`, `audio sticker`, `panel`, `viralizá`, `share with friends/followers` as a CTA). Those are positioning bans, not vocabulary bans — a category descriptor (e.g. `voice notes`) is fine because it names the input, not the brand position.
-- **Brand-DNA invariants.** The proper nouns Bomp / Bomper / Bompear / Bompeable NEVER translate. The manifesto closing ("Un audio de los tuyos no es un mensaje, es un abrazo que se escucha." / locale-equivalent that preserves meaning) is invariant across surfaces and locales.
-- **Brand-DNA-precision check (reserved terms).** Before using any term that appears in `brand-dna.md` or the Product Language glossary, verify it is not reserved for a non-shipped feature or a specific technical state. If it is, pick a locale-native synonym instead — even if the reserved term sounds right. Today's reserved terms: `Inmortal` / `immortal` (state descriptor for a Bompión synced to cloud via Saved Games SDK — a Pro feature **not shipped yet**); `Bompardo` and `Bompión` (Escala Richter levels 4 and 5, gated by share milestones — do not apply to a generic Bomp); `Bomptástico` (internal telemetry label only, never appears in UI).
-  - ❌ "Tus Bomps son inmortales" to describe Auto Backup → ✗ `Inmortal` is reserved for the not-yet-shipped Pro cloud-sync state, this overstates the feature.
-  - ✓ "Tus Bomps quedan respaldados en tu Google Drive" — accurate, locale-native, does not borrow reserved vocabulary.
-- **Policy-contradiction check (no overclaims).** Before writing any absolute claim — e.g. `imborrable`, `permanent`, `forever`, `never lost`, `100% private`, `always`, `nunca se pierde`, `we never see your data` — open `../push-me-ghpages/privacy-policy.html` and `../push-me-ghpages/data-safety.html` and check the claim does not contradict a published statement or strip a user right declared there. Concrete invariants today: the user can delete Bomps one-by-one or by uninstall (ARCO §05); Auto Backup is user-controllable from the OS settings (PP §02); Firebase collects pseudonymous crash logs, performance, and aggregated interactions (DS §01) — copy cannot claim "no data ever leaves the device".
-  - ❌ "Tus Bomps son imborrables" → ✗ contradicts the user's right to delete declared in Privacy Policy §05 and Data Safety §02.
-  - ✓ "Tus Bomps quedan guardados hasta que vos decidas borrarlos" — preserves the user's deletion right and matches the published policy.
-- **Read-aloud check before ship.** Read every paragraph aloud as a native speaker of the target locale. Stumbles, false friends, weird tense, or "wait, what?" reactions are blockers — fix before submitting to Play.
-- **Cross-surface consistency.** If a verb pattern is `Save. Name. Bomp.` in headers, the body copy must use the same verbs ("give it a name", not "give it a label"). Cross-reference all surfaces of a locale (title, short, full, screenshots, feature graphic, video script) before shipping a locale.
+**Do not remove or hide the About screen.** It is the "Appropriate Legal Notices" mechanism required by AGPLv3 §0 (paired with the copyright headers above). Its entry point is the TopAppBar overflow menu in `LandingScreen.kt`.
 
 ## Bug fixes — TDD workflow
 
@@ -178,6 +234,73 @@ internal class MyScreenTest : AbstractRobolectricTest() {
 }
 ```
 
+## Local UI test suite
+
+Instrumented UI/functional tests live under `app/src/androidTest/`. They drive a real emulator using Compose UI Test + Espresso + UI Automator + Espresso Accessibility Checks. CircleCI intentionally does not run them — the rationale, alternatives considered, and tradeoffs are in [`docs/adr/0001-local-ui-test-suite.md`](docs/adr/0001-local-ui-test-suite.md).
+
+### Setup (one-time)
+
+```bash
+# Creates the AVD `push_me_test` (idempotent, ~5 min the first time including system image download)
+./scripts/setup-test-emulator.sh
+```
+
+### Run the full suite
+
+```bash
+# 1. Boot the emulator (background)
+emulator -avd push_me_test -no-snapshot-save -no-boot-anim &
+adb wait-for-device shell 'while [[ $(getprop sys.boot_completed) != 1 ]]; do sleep 1; done'
+
+# 2. Run all instrumented tests (UTP installs + runs natively)
+./gradlew app:connectedDebugAndroidTest
+```
+
+HTML report: `app/build/reports/androidTests/connected/debug/index.html`. Raw
+XML: `app/build/outputs/androidTest-results/connected/debug/`.
+
+### Run a single test class
+
+```bash
+./gradlew app:connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=com.github.barriosnahuel.vossosunboton.ui.home.SearchOverlayTest
+```
+
+### When to run
+
+- After any change to a Composable, ViewModel, intent flow, navigation, deep link, or persistence layer.
+- Not required for changes limited to: CHANGELOG, copy strings, README, comments, configuration of off-device tooling.
+
+## Pre-PR checklist
+
+Before opening a PR for any feature or bug fix, verify:
+
+- [ ] Happy path is covered by at least one test
+- [ ] Failure modes at system/external boundaries have tests (file I/O, MediaPlayer, permissions, network, Play feature delivery)
+- [ ] New `Activity` has a smoke test (see Activity smoke tests section)
+- [ ] New full-screen Composable with business logic has a `createComposeRule()` smoke test
+- [ ] Any skipped scenario is explicitly noted with a reason (not silently omitted)
+- [ ] Self code review: re-read every changed file as a reviewer, not as the author — look for logic gaps, missing edge cases, and unclear naming
+
+Once all items pass, run the **Pre-push checklist** below before pushing.
+
+## Pre-push checklist
+
+All linters run on CI and must pass:
+- **KtLint** — style (runs as part of `check`; auto-fix with `ktlintFormat`)
+- **Detekt** — static analysis (config: `config/detekt/detekt-config.yml`; max line length 150)
+- **Spotless** — AGPLv3 copyright headers (runs as part of `check`; auto-fix with `spotlessApply`)
+- **Android Lint** — lint rules in `config/android/android-lint.xml`
+
+Before pushing any branch, always run:
+
+```bash
+./gradlew check -x test && ./gradlew test
+```
+
+This catches the same failures CI will report (ktlint, detekt, Spotless, Android lint, unit tests) without waiting for a full CI run.
+
+**Functional changes also require the local UI test suite** (see § *Local UI test suite*). If the change touches user-facing behavior — Composables, ViewModels, intents, navigation, deep links, persistence — run the instrumented suite on an emulator before pushing. CircleCI does not execute it. Cosmetic-only changes (CHANGELOG, copy strings, README, comments) are exempt.
 
 ## Analytics events
 
@@ -205,7 +328,6 @@ naming rules, regression-test matrix, and DebugView / `adb logcat -s FA FA-SVC`
 verification commands live there. Do not shortcut the manual smoke step before
 merging; the aggregated Reports dashboards have a 24–48 h delay and do not
 confirm a single new event.
-
 
 ## Error tracking (non-fatals)
 
@@ -246,7 +368,6 @@ Hard rules that affect how to write error-handling code:
 - In tests, you can mock `Tracker` with MockK (see `PlayerControllerTest.kt`):
   `every { Tracker.track(any()) } answers { nothing }`.
 
-
 ## StrictMode debug audit
 
 Single source of truth: `app/src/debug/.../StrictModeConfigurator.kt` (debug-only,
@@ -285,184 +406,6 @@ When a new violation surfaces, choose in this order:
 Filter logcat with `adb logcat | grep StrictMode` (or scope by tag and grep:
 `adb logcat -s Tracker:E | grep StrictMode`) — operator workflow lives in
 `CONTRIBUTING.md` § "Terminal: StrictMode violations".
-
-
-## Worktree setup
-
-After creating a new worktree, always run these commands to replace the dummy `google-services.json` and copy the bundled audio files from the main worktree:
-
-```bash
-cp "$(git rev-parse --git-common-dir)/../app/google-services.json" app/google-services.json
-git update-index --skip-worktree app/google-services.json
-cp "$(git rev-parse --git-common-dir)/../model/src/debug/res/raw/"*.mp3 model/src/debug/res/raw/ 2>/dev/null || true
-cp "$(git rev-parse --git-common-dir)/../model/src/debug/res/raw/"*.ogg model/src/debug/res/raw/ 2>/dev/null || true
-```
-- Release signing requires `nahuelbarrios.keystore-appbundle.pkcs12` and `secure.properties` (with `key.alias`, `key.password`, `store.password`) in the project root — not committed.
-- Debug builds use the included debug keystore and work without the above.
-- Bundled audio files (`model/src/debug/res/raw/*.mp3` and `*.ogg`) are not committed. Without them the debug build still compiles and runs, but the Explore tab will be empty.
-
-## Android resources naming
-
-Every resource name must start with the `resourcePrefix` defined in the module's `build.gradle`:
-
-| Module | Prefix |
-|---|---|
-| `app` | `app_` |
-| `commons_android` | `commons_android_` |
-| `commons_file` | `commons_file_` |
-| `model` | `model_` |
-
-Logical sub-areas inside `:app` (e.g. the Add Button flow at `feature/addbutton/`) use a secondary prefix on top of `app_` for grouping — `app_addbutton_*`, `app_about_*`, etc. Keep new resources clustered by feature this way.
-
-Android Lint enforces this rule (`ResourceName` check). Violating it causes a build failure.
-
-## Copyright headers
-
-Every `.kt` source file must start with the AGPLv3 copyright block (enforced by Spotless at CI time):
-
-```
-/*
- * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
- * SPDX-License-Identifier: AGPL-3.0-only
- * See LICENSE in the project root for full license information.
- */
-```
-
-If `./gradlew check` fails with a Spotless violation, run `./gradlew spotlessApply` to auto-fix all files.
-
-**Do not remove or hide the About screen.** It is the "Appropriate Legal Notices" mechanism required by AGPLv3 §0 (paired with the copyright headers above). Its entry point is the TopAppBar overflow menu in `LandingScreen.kt`.
-
-## Sources of truth for Android / Kotlin / Compose decisions
-
-Do not invent or recall best practices from training data alone — the platform moves and so does the recommended pattern. When making a non-trivial decision in any of the areas below, **consult the authoritative source first** (WebFetch the page, or invoke the linked skill) and **cite it** in the response. If you can't reach the source, say so and mark the recommendation as a heuristic.
-
-| Area | Authoritative source |
-|---|---|
-| Jetpack Compose: state, recomposition, side-effects, performance, lifecycle-aware APIs | https://developer.android.com/develop/ui/compose |
-| Navigation in Compose | Linked skill `navigation-3` (covers Navigation 3 install/migration, deep links, multi-backstack, Hilt/ViewModel integration) |
-| XML view → Compose migration | Linked skill `migrate-xml-views-to-jetpack-compose` |
-| Edge-to-edge / system bars / insets | Linked skill `edge-to-edge` |
-| Coroutines, Flow, StateFlow, structured concurrency, dispatchers, testing with `runTest` | https://kotlinlang.org/docs/coroutines-guide.html and https://developer.android.com/kotlin/coroutines |
-| Lifecycle: `repeatOnLifecycle`, `collectAsStateWithLifecycle`, lifecycle-aware components | https://developer.android.com/topic/libraries/architecture/lifecycle |
-| App architecture (UI layer / domain / data, unidirectional data flow, ViewModel + UI state, UI events) | https://developer.android.com/topic/architecture and https://developer.android.com/topic/architecture/ui-layer/events |
-| DataStore (Preferences/Proto), migration from SharedPreferences | https://developer.android.com/topic/libraries/architecture/datastore |
-| Background work, WorkManager, foreground services, exact alarms | https://developer.android.com/develop/background-work |
-| Permissions / runtime permissions / scoped storage | https://developer.android.com/training/permissions |
-| Accessibility in Compose (semantics, traversal order, click labels, custom actions, large text) | https://developer.android.com/develop/ui/compose/accessibility — pairs with the project's WCAG 2.2 AA functional requirement (see § Accessibility) |
-| AGP 9 migration | Linked skill `agp-9-upgrade` |
-| R8 keep rules audit | Linked skill `r8-analyzer` |
-| Play Billing | Linked skill `play-billing-library-version-upgrade` |
-| Kotlin idioms, conventions, KEEP proposals | https://kotlinlang.org/docs/coding-conventions.html and KEEP at https://github.com/Kotlin/KEEP |
-| Project-specific architectural decisions | `docs/adr/*.md` — read the relevant ADR before changing the area it governs |
-
-**When to actually consult vs. answer from memory:**
-- **Do consult** when: I'm brainstorming an alternative (see § Working style in user-level CLAUDE.md), the area is version-sensitive (Compose / AGP / Material 3 evolved recently), the change touches lifecycle / threading / security / accessibility, or you'd otherwise be guessing.
-- **Skip consult** for trivial mechanical edits, copy/string changes inside the locale rules, or when the answer is purely about a project convention already documented in this file.
-- **Cite or doubt:** every recommendation grounded in one of these sources should name the source (URL or skill name). If you're not consulting, say so explicitly so I know the answer is heuristic.
-
-## Project-specific overrides (read before changing platform-touching code)
-
-These are decisions this repo took that diverge from — or narrow — the generic Android recommendation. They override the public docs *for this codebase*. If a generic best-practice answer conflicts with one of these, the override wins (or, if you think the override is wrong, raise it as a discussion before changing it; don't silently flip).
-
-- **DI: manual factories, no Hilt — deliberate small-app trade-off.** ViewModels are constructed via `viewModelFactory { initializer { ... } }` (see `SoundsViewModel.kt`). Google's official recommendation for production apps is Hilt; we chose manual factories because at the current scale (one ViewModel, four modules, no scoped repositories beyond `DataStore`-backed stores) the build/test tax of Hilt (KSP, `HiltAndroidRule`, `HiltTestApplication`, module mocking) outweighs its benefits. **Revisit when:** ViewModel/repository/scoped-dependency count grows to the point where boilerplate factories become friction, or when a feature requires `@AssistedInject`-style construction. Until then, do not introduce Hilt, Koin, or any DI framework without an ADR under `docs/adr/`.
-- **One-shot UI events: `Channel<T>` + `receiveAsFlow()` — accepted today, with caveats.** Pattern visible in `SoundsViewModel` (`_buttonSavedEvent: Channel<String>`). Note that the current Compose-team guidance leans toward **event-as-state** (event field inside `UiState` + `onEventConsumed()` callback) — see https://developer.android.com/topic/architecture/ui-layer/events. The `Channel` pattern can drop events if the app is backgrounded between emit and collect. Reuse the existing `Channel` pattern for consistency for now; **revisit** if we hit a real "lost event in background" report or when a new flow is sensitive enough that delivery guarantees matter (then migrate that flow to event-as-state).
-- **Async / state model:** `viewModelScope` + `StateFlow` for screen state. Don't add a `SharedFlow` "for events" — pick `Channel` (existing convention) or migrate to event-as-state if the case warrants the upgrade per the bullet above.
-- **Threading:** dispatchers are *constructor-injected* into ViewModels (default `Dispatchers.IO`). No `runBlocking` in production code, except the documented analytics-cache-prime exception captured in § *Persistence*. No raw `Thread { ... }` or `AsyncTask`. No work on the main thread for I/O.
-- **Persistence:** see § *Persistence* — DataStore Preferences is the chosen mechanism, `SharedPreferences` is forbidden, the sync-API pattern via in-memory cache + async write-back is the documented solution for call-sites that need synchronous reads.
-- **Networking, image loading, Room:** none of these are in the dependency graph today. If a feature requires one, raise it before adding — the addition itself is a design decision that needs an ADR, not a side-effect of a feature PR.
-- **Analytics, error tracking, StrictMode, security boundaries, design system, accessibility:** see the dedicated sections in this file. Those rules are stricter than any generic Android guidance and override it.
-
-**Each substantive override should be backed by an ADR.** This section is the **index / one-liner summary**; the long-form rationale (context, options considered, decision, consequences) lives in `docs/adr/*.md`. The pattern already exists with `0001-local-ui-test-suite.md`. New overrides added here that are non-trivial decisions — *"no Hilt — manual `viewModelFactory`"*, *"`Channel<T>` for one-shot UI events instead of event-as-state"* — should ship with (or be followed by) a matching ADR that captures the trade-offs. CLAUDE.md tells you *what* the override is; the ADR tells you *why* and *what we considered*. Treat the absence of an ADR for a substantive override as a debt to be paid, not as a green light to flip the decision silently.
-
-**Re-validate on dependency changes.** When a PR updates `gradle/libs.versions.toml`, `gradle/wrapper/gradle-wrapper.properties`, or any `build.gradle(.kts)` with library/plugin version bumps — especially Compose BOM, AGP, Kotlin, coroutines, lifecycle, DataStore, or anything that introduces a *new* dependency — re-read both this section and § *Sources of truth* in the same PR. If the upstream recommended pattern changed in the new version (e.g. Compose introduces a new lifecycle-aware API, AGP deprecates a config, a new lib enters the graph that contradicts an override), update these sections in the same PR as the bump. Dependabot bumps count — don't merge them blind. Same applies after running any of the upgrade skills (`agp-9-upgrade`, `navigation-3`, `play-billing-library-version-upgrade`, `migrate-xml-views-to-jetpack-compose`): the migration's exit criteria includes re-reading these sections.
-
-### Known migration debt
-
-Things the current codebase does that are *not* the recommended pattern. New code should use the recommended form; existing call-sites migrate when touched.
-
-- **`collectAsState()` → `collectAsStateWithLifecycle()`.** The lifecycle-aware variant stops collection in `STOPPED` state, which avoids wasted work and stale `StateFlow` references when the screen is off. New Composables collecting a ViewModel-owned `StateFlow` must use `collectAsStateWithLifecycle()`; existing call-sites migrate when their file is touched for another reason.
-- **String resources: every user-facing string via `stringResource(R.string.app_*)`.** Not technically an override (this is plain best practice for i18n + a11y + maintainability) but flagged here because it's worth catching in review. No hardcoded literals in Composables. `contentDescription` for non-decorative `Icon`/`Image` is mandatory and must come from a string resource (see § *Accessibility*); decorative assets use `contentDescription = null` explicitly.
-
-## Pre-PR checklist
-
-Before opening a PR for any feature or bug fix, verify:
-
-- [ ] Happy path is covered by at least one test
-- [ ] Failure modes at system/external boundaries have tests (file I/O, MediaPlayer, permissions, network, Play feature delivery)
-- [ ] New `Activity` has a smoke test (see Activity smoke tests section)
-- [ ] New full-screen Composable with business logic has a `createComposeRule()` smoke test
-- [ ] Any skipped scenario is explicitly noted with a reason (not silently omitted)
-- [ ] Self code review: re-read every changed file as a reviewer, not as the author — look for logic gaps, missing edge cases, and unclear naming
-
-Once all items pass, run the **Pre-push checklist** below before pushing.
-
-## Pre-push checklist
-
-All linters run on CI and must pass:
-- **KtLint** — style (runs as part of `check`; auto-fix with `ktlintFormat`)
-- **Detekt** — static analysis (config: `config/detekt/detekt-config.yml`; max line length 150)
-- **Spotless** — AGPLv3 copyright headers (runs as part of `check`; auto-fix with `spotlessApply`)
-- **Android Lint** — lint rules in `config/android/android-lint.xml`
-
-Before pushing any branch, always run:
-
-```bash
-./gradlew check -x test && ./gradlew test
-```
-
-This catches the same failures CI will report (ktlint, detekt, Spotless, Android lint, unit tests) without waiting for a full CI run.
-
-**Functional changes also require the local UI test suite** (see next section). If the change touches user-facing behavior — Composables, ViewModels, intents, navigation, deep links, persistence — run the instrumented suite on an emulator before pushing. CircleCI does not execute it. Cosmetic-only changes (CHANGELOG, copy strings, README, comments) are exempt.
-
-## Local UI test suite
-
-Instrumented UI/functional tests live under `app/src/androidTest/`. They drive a real emulator using Compose UI Test + Espresso + UI Automator + Espresso Accessibility Checks. CircleCI intentionally does not run them — the rationale, alternatives considered, and tradeoffs are in [`docs/adr/0001-local-ui-test-suite.md`](docs/adr/0001-local-ui-test-suite.md).
-
-### Setup (one-time)
-
-```bash
-# Creates the AVD `push_me_test` (idempotent, ~5 min the first time including system image download)
-./scripts/setup-test-emulator.sh
-```
-
-### Run the full suite
-
-```bash
-# 1. Boot the emulator (background)
-emulator -avd push_me_test -no-snapshot-save -no-boot-anim &
-adb wait-for-device shell 'while [[ $(getprop sys.boot_completed) != 1 ]]; do sleep 1; done'
-
-# 2. Run all instrumented tests (UTP installs + runs natively)
-./gradlew app:connectedDebugAndroidTest
-```
-
-HTML report: `app/build/reports/androidTests/connected/debug/index.html`. Raw
-XML: `app/build/outputs/androidTest-results/connected/debug/`.
-
-### Run a single test class
-
-```bash
-./gradlew app:connectedDebugAndroidTest \
-  -Pandroid.testInstrumentationRunnerArguments.class=com.github.barriosnahuel.vossosunboton.ui.home.SearchOverlayTest
-```
-
-### When to run
-
-- After any change to a Composable, ViewModel, intent flow, navigation, deep link, or persistence layer.
-- Not required for changes limited to: CHANGELOG, copy strings, README, comments, configuration of off-device tooling.
-
-## Accessibility (WCAG 2.2 AA)
-
-All UI development and generated assets (store listing, What's New, changelogs) must target **WCAG 2.2 Level AA**. Key requirements:
-
-- **Contrast – text (1.4.3):** ≥ 4.5:1 for normal text; ≥ 3:1 for large text (≥ 18 sp or ≥ 14 sp bold)
-- **Contrast – non-text (1.4.11):** ≥ 3:1 for interactive UI components (icon-only buttons, input borders, focus indicators)
-- **Color not sole indicator (1.4.1):** Never use color alone to convey state — pair with an icon, label, or pattern
-- **Content descriptions (1.1.1):** Every `Icon`/`Image` conveying information needs a non-null `contentDescription`; purely decorative assets use `contentDescription = null`
-- **Touch targets (2.5.8):** Minimum 24 × 24 dp; prefer 48 × 48 dp for primary actions
-- **Labels match names (2.5.3):** Visible button/field labels must match the accessible name used by screen readers
-
-Verify contrast when adding or changing colors. Use the [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/) or the Material Theme Builder. The brand palette in `AppTheme.kt` was designed to meet AA across all color roles. **All critical role pairs are automatically verified by `AppThemeContrastTest`** — if you change the palette and a test fails, fix the theme, not the test.
 
 ## Security boundaries
 
@@ -520,23 +463,18 @@ system share sheet, deep link, etc.). The two exported activities today are
 `LandingActivity` (LAUNCHER + `push-me://open` deep link) and
 `AddButtonActivity` (system share-sheet `ACTION_SEND` with `audio/*`).
 
-## Store listing asset generation
+## Accessibility (WCAG 2.2 AA)
 
-Store listing PNGs (icon, feature graphic) are rendered from SVG masters under `store-listing/`. The canonical pipeline is **`rsvg-convert`** (`brew install librsvg`) — fast, CLI, reproducible, no GUI. Use Inkscape only when you need to tweak typography by hand before export.
+All UI development and generated assets (store listing, What's New, changelogs) must target **WCAG 2.2 Level AA**. Key requirements:
 
-Before exporting any asset, verify the required fonts are installed system-wide. The brand stack is **Inter** (Roboto + system-ui as fallbacks). The Inter distribution lives zipped at `store-listing/brand/fonts/Inter.zip` (committed under SIL OFL — `OFL.txt` is inside the archive). Install on macOS with:
+- **Contrast – text (1.4.3):** ≥ 4.5:1 for normal text; ≥ 3:1 for large text (≥ 18 sp or ≥ 14 sp bold)
+- **Contrast – non-text (1.4.11):** ≥ 3:1 for interactive UI components (icon-only buttons, input borders, focus indicators)
+- **Color not sole indicator (1.4.1):** Never use color alone to convey state — pair with an icon, label, or pattern
+- **Content descriptions (1.1.1):** Every `Icon`/`Image` conveying information needs a non-null `contentDescription`; purely decorative assets use `contentDescription = null`
+- **Touch targets (2.5.8):** Minimum 24 × 24 dp; prefer 48 × 48 dp for primary actions
+- **Labels match names (2.5.3):** Visible button/field labels must match the accessible name used by screen readers
 
-```bash
-unzip -j -o store-listing/brand/fonts/Inter.zip "*.ttf" -d ~/Library/Fonts/
-```
-
-(`-j` flattens the nested `static/` subdirectory; `-o` overwrites silently.)
-
-If a future asset needs a different font family, drop its zipped distribution at `store-listing/brand/fonts/<Family>.zip` (license file inside) and document the install step here.
-
-The full human walkthrough — tooling tradeoffs, exact export commands, screenshot capture from the running emulator — lives in `CONTRIBUTING.md` § "Store listing".
-
-When writing locale copy (title, short, full description, screenshot headlines, feature graphic tagline), see § "Copy & localization" for naturalness, idiom, and ASO rules.
+Verify contrast when adding or changing colors. Use the [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/) or the Material Theme Builder. The brand palette in `AppTheme.kt` was designed to meet AA across all color roles. **All critical role pairs are automatically verified by `AppThemeContrastTest`** — if you change the palette and a test fails, fix the theme, not the test.
 
 ## Design system
 
@@ -576,6 +514,74 @@ The app uses the **Neo-Club** palette (ink × acid). Single source of truth: `ap
 - **Never hardcode a color literal in a component** (e.g. `Color(0xFF2E7D32)`). Use the closest semantic role from `AppTheme.kt`.
 - **Components inside always-dark bars** (TopAppBar using `secondary`): use `primaryContainer` (= Acid400 in both modes) for accent elements like cursor, underline, and icons — not `primary`, which is AcidDark in light mode and nearly invisible on a dark bar.
 - **Adding a new color:** add the constant to `AppTheme.kt`, map it to an M3 role in both `LightColors` and `DarkColors`, then add a contrast assertion for the relevant pair in `AppThemeContrastTest`.
+
+## Product & brand context (when relevant)
+
+Product specs, brand language, and canonical naming live in the sibling backlog repo at `../push-me-backlog/`. Consult it when working on user-facing strings, micro-copy, feature/level naming, gamification, or social-layer behavior — these docs are the source of truth for the in-app vocabulary:
+
+- [`../push-me-backlog/docs/brand-dna.md`](../push-me-backlog/docs/brand-dna.md) — canonical terminology (Bomp, Bomper, Bompear, Escala Richter levels: Bompín / Bompazo / Bompardo / Bompión, Inmortal as cloud-state descriptor)
+- [`../push-me-backlog/CLAUDE.md`](../push-me-backlog/CLAUDE.md) — Product Language glossary and spec conventions
+- [`../push-me-backlog/backlog/`](../push-me-backlog/backlog/) — pending feature specs (the "why" behind features)
+
+Skip for refactors, dep bumps, build config, and platform-wiring fixes — those don't need brand context. If the sibling path isn't present (CI, alternate checkout layout), proceed with the in-repo strings as authoritative and surface the gap to the user.
+
+## Repo writing language
+
+Contributor-facing files in this repo are written in **English**: `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, `CODE_OF_CONDUCT.md`, ADRs under `docs/adr/`, `.github/` templates, `CLAUDE.md` itself, code comments, commit messages, PR descriptions, and handoff notes. This applies to any new file you create whose audience is contributors or maintainers.
+
+The only exception is **embedded examples of user-facing copy**: when a doc demonstrates how a localized string should read (e.g. the ❌/✓ examples under § Copy & localization, or a snippet quoted from `strings.xml`), the example stays in its target locale (typically es-AR) so the rule is illustrated faithfully. The surrounding prose explaining the example is still in English.
+
+User-facing surfaces (in-app strings, store listings, push notifs, Play Console "What's New", marketing emails) are out of scope for this rule and follow § Copy & localization — they ship in the target locale.
+
+## Copy & localization
+
+When generating user-facing copy in any locale (in-app strings, store listings, push notifs, changelogs, emails) the output must read **native to the target locale**, not as a literal translation from another language — and must not contradict the brand DNA or the published legal policies.
+
+**Sources of truth to consult before drafting copy** (paths relative to `/Users/barrios.nahuel/Workspace/push-me/`):
+
+- `../push-me-backlog/docs/brand-dna.md` — canonical terminology, reserved terms, anti-positioning bans
+- `../push-me-backlog/CLAUDE.md` — Product Language glossary (incl. which terms are gated to non-shipped features like Pro/cloud)
+- `../push-me-ghpages/privacy-policy.html` — published Privacy Policy (rights ARCO, retention, third-party data)
+- `../push-me-ghpages/data-safety.html` — published Data Safety declaration (what's collected, shared, optional)
+
+If any of these paths is missing (CI, alternate checkout), do **not** invent the claim — flag the gap to the user and proceed with the in-repo strings as authoritative.
+
+**Default locale for in-app strings.** `app/src/main/res/values/strings.xml` is the **English** master; Spanish-AR copy lives in `values-es/strings.xml`.
+
+Hard rules:
+
+- **No calque translations.** A phrase that's natural in the source can be wrong in the target. Examples we hit and fixed during the en-US listing: "save a day" (calque of "salvar un día" — correct English idiom is `save the day`); "on the other side" (calque of "del otro lado" — in English this means *afterlife*; the phone idiom is `on the other end`); "your audios" (calque of "tus audios" — `audio` is a mass noun in English, the natural plural is `voice notes` / `voice clips` / `voice memos`).
+- **Use the target locale's idioms and collocations.** Verify with a native speaker or a current idiom reference, not Google Translate. When in doubt, prefer the simpler concrete word the audience already uses every day.
+- **Punchy register, locale-aware.** US English marketing leans on contractions, short sentences, imperative verbs, and concrete sensory nouns. Spanish-AR leans on voseo and warmth. Match the register the locale expects, not a generic "neutral" tone.
+- **Vocabulary the target audience uses.** If the source describes the input as "audios", the English version should name it the way English speakers do (`voice notes`, `voice memos`). Mapping is not 1:1.
+- **ASO awareness for store-listing copy.** For Play Console copy (title, short description, full description, screenshot headlines, feature graphic taglines), integrate the high-volume queries the target market actually searches — organically, without breaching the brand-DNA bans (`soundboard`, `audio sticker`, `panel`, `viralizá`, `share with friends/followers` as a CTA). Those are positioning bans, not vocabulary bans — a category descriptor (e.g. `voice notes`) is fine because it names the input, not the brand position.
+- **Brand-DNA invariants.** The proper nouns Bomp / Bomper / Bompear / Bompeable NEVER translate. The manifesto closing ("Un audio de los tuyos no es un mensaje, es un abrazo que se escucha." / locale-equivalent that preserves meaning) is invariant across surfaces and locales.
+- **Brand-DNA-precision check (reserved terms).** Before using any term that appears in `brand-dna.md` or the Product Language glossary, verify it is not reserved for a non-shipped feature or a specific technical state. If it is, pick a locale-native synonym instead — even if the reserved term sounds right. Today's reserved terms: `Inmortal` / `immortal` (state descriptor for a Bompión synced to cloud via Saved Games SDK — a Pro feature **not shipped yet**); `Bompardo` and `Bompión` (Escala Richter levels 4 and 5, gated by share milestones — do not apply to a generic Bomp); `Bomptástico` (internal telemetry label only, never appears in UI).
+  - ❌ "Tus Bomps son inmortales" to describe Auto Backup → ✗ `Inmortal` is reserved for the not-yet-shipped Pro cloud-sync state, this overstates the feature.
+  - ✓ "Tus Bomps quedan respaldados en tu Google Drive" — accurate, locale-native, does not borrow reserved vocabulary.
+- **Policy-contradiction check (no overclaims).** Before writing any absolute claim — e.g. `imborrable`, `permanent`, `forever`, `never lost`, `100% private`, `always`, `nunca se pierde`, `we never see your data` — open `../push-me-ghpages/privacy-policy.html` and `../push-me-ghpages/data-safety.html` and check the claim does not contradict a published statement or strip a user right declared there. Concrete invariants today: the user can delete Bomps one-by-one or by uninstall (ARCO §05); Auto Backup is user-controllable from the OS settings (PP §02); Firebase collects pseudonymous crash logs, performance, and aggregated interactions (DS §01) — copy cannot claim "no data ever leaves the device".
+  - ❌ "Tus Bomps son imborrables" → ✗ contradicts the user's right to delete declared in Privacy Policy §05 and Data Safety §02.
+  - ✓ "Tus Bomps quedan guardados hasta que vos decidas borrarlos" — preserves the user's deletion right and matches the published policy.
+- **Read-aloud check before ship.** Read every paragraph aloud as a native speaker of the target locale. Stumbles, false friends, weird tense, or "wait, what?" reactions are blockers — fix before submitting to Play.
+- **Cross-surface consistency.** If a verb pattern is `Save. Name. Bomp.` in headers, the body copy must use the same verbs ("give it a name", not "give it a label"). Cross-reference all surfaces of a locale (title, short, full, screenshots, feature graphic, video script) before shipping a locale.
+
+## Store listing asset generation
+
+Store listing PNGs (icon, feature graphic) are rendered from SVG masters under `store-listing/`. The canonical pipeline is **`rsvg-convert`** (`brew install librsvg`) — fast, CLI, reproducible, no GUI. Use Inkscape only when you need to tweak typography by hand before export.
+
+Before exporting any asset, verify the required fonts are installed system-wide. The brand stack is **Inter** (Roboto + system-ui as fallbacks). The Inter distribution lives zipped at `store-listing/brand/fonts/Inter.zip` (committed under SIL OFL — `OFL.txt` is inside the archive). Install on macOS with:
+
+```bash
+unzip -j -o store-listing/brand/fonts/Inter.zip "*.ttf" -d ~/Library/Fonts/
+```
+
+(`-j` flattens the nested `static/` subdirectory; `-o` overwrites silently.)
+
+If a future asset needs a different font family, drop its zipped distribution at `store-listing/brand/fonts/<Family>.zip` (license file inside) and document the install step here.
+
+The full human walkthrough — tooling tradeoffs, exact export commands, screenshot capture from the running emulator — lives in `CONTRIBUTING.md` § "Store listing".
+
+When writing locale copy (title, short, full description, screenshot headlines, feature graphic tagline), see § "Copy & localization" for naturalness, idiom, and ASO rules.
 
 ## Labels and milestone
 


### PR DESCRIPTION
### Summary

- § *Sources of truth* registers authoritative refs (developer.android.com, linked skills, KEEP, ADRs) so decisions cite a source instead of training-data guesswork.
- § *Project-specific overrides* + § *Known migration debt* capture divergences from the generic Android recommendation (no Hilt, `Channel<T>` for one-shots with revisit caveat, `collectAsState` → `collectAsStateWithLifecycle` migration).
- Structure pass: bidirectional cross-refs § Persistence ↔ § Project overrides, refreshed § Backup hygiene to DataStore reality (drops stale `my-prefs` prose), merges stub sections, reorder by domain, Index TOC.

### Code review tips

- `bcf0148` is mostly *line movement* — diff size misleads. Verify section content before/after.
- § *Backup hygiene* described `my-prefs`, which no longer exists in code (`grep my-prefs` → 0 code hits before this PR).
- § *Project overrides* flags `Channel<T>` for events as "revisit" — Compose guidance leans toward event-as-state.

### Already tested

- `grep my-prefs CLAUDE.md` → 0 hits ✓
- `grep "^## "` → 30 sections, domain order ✓
- Cross-refs bidirectional ✓
- Skipped gradle check / UI tests — doc-only, no code.
- No CHANGELOG — contributor doc, not user-visible.