### PR TITLE
fix(test): stabilize CI — de-flake AddButton edit and DataStore store tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 #### Fixed
 - `ShareFeature.share` now runs file-system access (`getFile` + first-time `copy` of bundled raw resources) on `Dispatchers.IO`, eliminating a long-standing main-thread disk write that could cause jank the first time a bundled sound was shared
+- `AddButtonEditFlowTest.saveWithValidNameNavigatesBackToLandingWithRenamedExtra` no longer flakes (~25–50% rate). `Intents.intended()` routes through `Espresso.onView(isRoot()).check(...)` when a resumed activity exists, which trips the class-wide ATF run from `AbstractUiTest` against a mid-transition view tree. Switched to inspecting `Intents.getIntents()` directly and matching with plain Kotlin — keeps the recorded-intent assertion without touching the view hierarchy
 
 #### Removed
 - Removed `techstack.md` and its companion `techstack.yml` (StackShare.io config that broke after the repo rename to `bomp` and was no longer maintained — last meaningful update predated the v2.0 Compose rewrite)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 #### Fixed
 - `ShareFeature.share` now runs file-system access (`getFile` + first-time `copy` of bundled raw resources) on `Dispatchers.IO`, eliminating a long-standing main-thread disk write that could cause jank the first time a bundled sound was shared
 - `AddButtonEditFlowTest.saveWithValidNameNavigatesBackToLandingWithRenamedExtra` no longer flakes (~25–50% rate). `Intents.intended()` routes through `Espresso.onView(isRoot()).check(...)` when a resumed activity exists, which trips the class-wide ATF run from `AbstractUiTest` against a mid-transition view tree. Switched to inspecting `Intents.getIntents()` directly and matching with plain Kotlin — keeps the recorded-intent assertion without touching the view hierarchy
+- `DataStoreCounterStoreTest` and `DataStoreFirstFlagStoreTest` no longer rely on a fixed 250 ms `Thread.sleep` to wait for fire-and-forget DataStore writes. The wait started losing the race after the androidx.datastore-preferences 1.1.7 → 1.2.1 bump (Counter test failed on Robolectric SDK 23/33). Inject the writeback scope and join its child jobs deterministically before asserting disk state
 
 #### Removed
 - Removed `techstack.md` and its companion `techstack.yml` (StackShare.io config that broke after the repo rename to `bomp` and was no longer maintained — last meaningful update predated the v2.0 Compose rewrite)

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonEditFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonEditFlowTest.kt
@@ -18,11 +18,10 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.test.core.app.ActivityScenario
-import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intending
 import androidx.test.espresso.intent.matcher.ComponentNameMatchers.hasClassName
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
-import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.barriosnahuel.vossosunboton.AbstractUiTest
 import com.github.barriosnahuel.vossosunboton.R
@@ -76,6 +75,8 @@ internal class AddButtonEditFlowTest : AbstractUiTest() {
     fun saveWithValidNameNavigatesBackToLandingWithRenamedExtra() {
         val sound = TestData.seedCustomSounds(context, count = 1).single()
         val newName = "renamed_custom"
+        // Stub the LandingActivity launch so the framework does not actually start it (ActivityScenario only owns
+        // AddButtonActivity, and resolving LandingActivity here would race against AddButtonActivity finishing).
         intending(hasComponent(hasClassName(LandingActivity::class.java.name)))
             .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, null))
 
@@ -84,14 +85,17 @@ internal class AddButtonEditFlowTest : AbstractUiTest() {
             nameField().performTextClearance()
             nameField().performTextInput(newName)
             composeRule.onNodeWithText(context.getString(R.string.app_addbutton_save_changes)).performClick()
+            // Inspect Intents.getIntents() directly instead of Intents.intended(): when a resumed activity exists,
+            // intended() routes the matcher through Espresso.onView(isRoot()).check(...), which triggers the
+            // class-wide ATF run from AbstractUiTest. The view tree is mid-transition (AddButtonActivity finishing,
+            // LandingActivity launch stubbed), so the Espresso check throws AssertionError, runCatching swallows
+            // it, and the wait times out — even though the intent was already in the recorded list.
             composeRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) {
-                // Hamcrest 1.3 (transitive in the test APK) lacks the 2-arg `allOf` Kotlin
-                // compiles to. Stick to one matcher per intended() call.
-                runCatching {
-                    intended(hasComponent(hasClassName(LandingActivity::class.java.name)))
-                    intended(hasExtra(LandingActivity.EXTRA_BUTTON_RENAMED, true))
-                    intended(hasExtra(LandingActivity.EXTRA_BUTTON_NAME, newName))
-                }.isSuccess
+                Intents.getIntents().any { intent ->
+                    intent.component?.className == LandingActivity::class.java.name &&
+                        intent.getBooleanExtra(LandingActivity.EXTRA_BUTTON_RENAMED, false) &&
+                        intent.getStringExtra(LandingActivity.EXTRA_BUTTON_NAME) == newName
+                }
             }
         }
     }

--- a/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/DataStoreCounterStoreTest.kt
+++ b/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/DataStoreCounterStoreTest.kt
@@ -9,9 +9,16 @@ import android.content.Context
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.job
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -23,12 +30,19 @@ import org.robolectric.annotation.Config
 internal class DataStoreCounterStoreTest {
     private lateinit var context: Context
     private lateinit var store: DataStoreCounterStore
+    private lateinit var writebackScope: CoroutineScope
 
     @Before
     fun setUp() {
         context = ApplicationProvider.getApplicationContext()
-        store = DataStoreCounterStore(context)
+        writebackScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        store = DataStoreCounterStore(context, writebackScope)
         runBlocking { store.clearForTest() }
+    }
+
+    @After
+    fun tearDown() {
+        writebackScope.cancel()
     }
 
     @Test
@@ -83,8 +97,7 @@ internal class DataStoreCounterStoreTest {
                     launch { store.increment("converge") }
                 }
             }
-            // Give the launched disk writes a moment to drain through Dispatchers.IO.
-            Thread.sleep(WRITE_BACK_GRACE_MS)
+            drainWritebacks()
 
             val freshStore = DataStoreCounterStore(context)
             assertThat(store.get("converge")).isEqualTo(100L)
@@ -95,7 +108,7 @@ internal class DataStoreCounterStoreTest {
     fun `state survives instantiating a new store backed by the same DataStore file`() =
         runBlocking {
             repeat(7) { store.increment("persist") }
-            Thread.sleep(WRITE_BACK_GRACE_MS)
+            drainWritebacks()
 
             val freshStore = DataStoreCounterStore(context)
 
@@ -106,7 +119,7 @@ internal class DataStoreCounterStoreTest {
     fun `clearForTest wipes both in-memory cache and disk state`() =
         runBlocking {
             store.increment("foo")
-            Thread.sleep(WRITE_BACK_GRACE_MS)
+            drainWritebacks()
 
             store.clearForTest()
 
@@ -115,7 +128,14 @@ internal class DataStoreCounterStoreTest {
             assertThat(freshStore.get("foo")).isEqualTo(0L)
         }
 
-    companion object {
-        private const val WRITE_BACK_GRACE_MS = 250L
+    /**
+     * Joins every fire-and-forget `scope.launch { store.edit { ... } }` registered by [DataStoreCounterStore.increment]
+     * (and friends). Replaces a `Thread.sleep` grace period so the assertions that read disk state run after every
+     * pending write has actually committed — the previous fixed-time wait raced under the bumped DataStore 1.2.x.
+     */
+    private suspend fun drainWritebacks() {
+        writebackScope.coroutineContext.job.children
+            .toList()
+            .joinAll()
     }
 }

--- a/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/DataStoreFirstFlagStoreTest.kt
+++ b/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/DataStoreFirstFlagStoreTest.kt
@@ -9,9 +9,16 @@ import android.content.Context
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.job
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -23,12 +30,19 @@ import org.robolectric.annotation.Config
 internal class DataStoreFirstFlagStoreTest {
     private lateinit var context: Context
     private lateinit var store: DataStoreFirstFlagStore
+    private lateinit var writebackScope: CoroutineScope
 
     @Before
     fun setUp() {
         context = ApplicationProvider.getApplicationContext()
-        store = DataStoreFirstFlagStore(context)
+        writebackScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        store = DataStoreFirstFlagStore(context, writebackScope)
         runBlocking { store.clearForTest() }
+    }
+
+    @After
+    fun tearDown() {
+        writebackScope.cancel()
     }
 
     @Test
@@ -74,9 +88,7 @@ internal class DataStoreFirstFlagStoreTest {
     fun `state survives instantiating a new store backed by the same DataStore file`() =
         runBlocking {
             store.markFired("persist-me")
-            // Give the fire-and-forget disk write a moment to commit before instantiating the
-            // second store (which primes its cache from disk).
-            Thread.sleep(WRITE_BACK_GRACE_MS)
+            drainWritebacks()
 
             val freshStore = DataStoreFirstFlagStore(context)
 
@@ -87,7 +99,7 @@ internal class DataStoreFirstFlagStoreTest {
     fun `clearForTest wipes both in-memory cache and disk state`() =
         runBlocking {
             store.markFired("foo")
-            Thread.sleep(WRITE_BACK_GRACE_MS)
+            drainWritebacks()
 
             store.clearForTest()
 
@@ -96,10 +108,14 @@ internal class DataStoreFirstFlagStoreTest {
             assertThat(freshStore.isFirstTime("foo")).isTrue()
         }
 
-    companion object {
-        // Async write-back via SupervisorJob + Dispatchers.IO; tiny disk write completes within
-        // tens of ms even under Robolectric. 250 ms is generous enough to be reliable without
-        // padding total test time noticeably.
-        private const val WRITE_BACK_GRACE_MS = 250L
+    /**
+     * Joins every fire-and-forget `scope.launch { store.edit { ... } }` registered by
+     * [DataStoreFirstFlagStore.markFired] / [DataStoreFirstFlagStore.consumeFirstTime]. Replaces a fixed-time
+     * `Thread.sleep` so disk-state assertions run after every pending write has actually committed.
+     */
+    private suspend fun drainWritebacks() {
+        writebackScope.coroutineContext.job.children
+            .toList()
+            .joinAll()
     }
 }


### PR DESCRIPTION
## Summary
- Stabilizes three flaky JVM/instrumented tests grouped together as one CI-stabilization PR.
- `AddButtonEditFlowTest.saveWithValidNameNavigatesBackToLandingWithRenamedExtra` (~25–50% flake): `Intents.intended()` routes the matcher through `Espresso.onView(isRoot()).check(...)` when a resumed activity exists, which fires the class-wide ATF run wired up in `AbstractUiTest` against a mid-transition view tree. The intent is in `recordedIntents` (verified via reflection), the matcher just can't run cleanly. Fix: read `Intents.getIntents()` directly and match in plain Kotlin.
- `DataStoreCounterStoreTest` (failing on Robolectric SDK 23/33 after the androidx.datastore-preferences 1.1.7 → 1.2.1 bump in #1103) and `DataStoreFirstFlagStoreTest` (same idiom, next likely flake): replace `Thread.sleep(250 ms)` with deterministic `scope.coroutineContext.job.children.joinAll()` to drain fire-and-forget DataStore writes before asserting disk state.

## Code review tips
- All three fixes are test-only — no production code changed.
- The `Intents.getIntents()` switch keeps `intending(...).respondWith(...)` so the framework still does not actually launch LandingActivity into the AddButtonActivity-owned scenario.
- The store tests inject the writeback scope via the existing constructor parameter (no new prod surface), cancel it in `@After`, and call `joinAll` via a small private helper. The two store-test files stay symmetric.

## Already tested
- [x] `AddButtonEditFlowTest` reproduced 6/12 fails on emulator → 15/15 passes after fix
- [x] `DataStoreCounterStoreTest` reproduced via user report → 10/10 passes after fix
- [x] `DataStoreFirstFlagStoreTest` 10/10 passes after fix
- [x] Full instrumented suite: 51 tests, 2 skipped, 0 failed
- [x] `./gradlew check -x test` (KtLint, Detekt, Spotless, Android Lint) — green
- [x] `./gradlew test` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)