### PR TITLE
test: race-safe wait extensions for ComposeTestRule + suite-wide adoption

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,22 @@ HTML report: `app/build/reports/androidTests/connected/debug/index.html`. Raw XM
 - After any change to a Composable, ViewModel, intent flow, navigation, deep link, or persistence layer.
 - Not required for: CHANGELOG, copy strings, README, comments, off-device tooling config.
 
+### Synchronization (avoid bare `waitForIdle()` for state-dependent nodes)
+
+`composeRule.waitForIdle()` waits only for Compose recompositions to settle — it does **not** wait for the `DataStore-read → StateFlow-emit → render` chain to finish seeding the screen. An immediate `performClick`/`assertIsDisplayed` after `waitForIdle()` resolves against whatever semantics tree exists *now*, which is the canonical instrumented-test race in this repo (PR #1111 fixed two cases of this exact shape).
+
+For any node whose existence depends on ViewModel/DataStore-emitted state, use the `awaitNode*` extensions on `ComposeTestRule` defined in `app/src/androidTest/.../ComposeTestExtensions.kt`:
+
+```kotlin
+composeRule.awaitNodeWithContentDescription(pinLabel()).performClick()
+composeRule.awaitNodeWithText(homeTabLabel()).assertIsDisplayed()
+composeRule.awaitNode(hasSetTextAction()).performTextInput(name)
+```
+
+These extensions fuse `waitUntil { onAllNodes(matcher).fetchSemanticsNodes().isNotEmpty() }` with the lookup and return a `SemanticsNodeInteraction`, so the call site is shorter than the unsafe form — the right thing is the easy thing.
+
+`waitForIdle()` (or an inline `waitUntil { onAllNodes(...).isNotEmpty() }`) is still the correct call in four cases: (a) after a deterministic UI action (`performClick`, `pressBack`) where you just need recomposition to flush before the next assertion, (b) before negative assertions like `onAllNodes(...).assertCountEquals(0)` (the helper waits for *presence*; absence needs the inverse predicate, which is rare enough not to factor), (c) before `onAllNodes(...).onFirst()` chains (the helper does not yet cover the "first of N" shape — keep the inline `waitUntil` in those spots), (d) when the matcher would resolve to *more than one* node in the tree (e.g. a search query the user typed also appears in a result card and in the underlying screen behind the overlay) — the helper's terminal `onNodeWithText`/`onNodeWithContentDescription`/`onNode` throws on multi-match, so use `waitUntil { onAllNodes(matcher).fetchSemanticsNodes().isNotEmpty() }` and assert presence directly.
+
 ## Pre-PR checklist
 
 Before opening a PR for any feature or bug fix, verify:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ Instrumented UI/functional tests live under `app/src/androidTest/`. They drive a
 ### Setup (one-time)
 
 ```bash
-# Creates the AVD `push_me_test` (idempotent, ~5 min the first time including system image download)
+# Creates the AVD `Android_14_API_34` (idempotent, ~5 min the first time including system image download)
 ./scripts/setup-test-emulator.sh
 ```
 
@@ -242,7 +242,7 @@ Instrumented UI/functional tests live under `app/src/androidTest/`. They drive a
 
 ```bash
 # 1. Boot the emulator (background)
-emulator -avd push_me_test -no-snapshot-save -no-boot-anim &
+emulator -avd Android_14_API_34 -no-snapshot-save -no-boot-anim &
 adb wait-for-device shell 'while [[ $(getprop sys.boot_completed) != 1 ]]; do sleep 1; done'
 
 # 2. Run all instrumented tests (UTP installs + runs natively)
@@ -265,9 +265,7 @@ HTML report: `app/build/reports/androidTests/connected/debug/index.html`. Raw XM
 
 ### Synchronization (avoid bare `waitForIdle()` for state-dependent nodes)
 
-`composeRule.waitForIdle()` waits only for Compose recompositions to settle — it does **not** wait for the `DataStore-read → StateFlow-emit → render` chain to finish seeding the screen. An immediate `performClick`/`assertIsDisplayed` after `waitForIdle()` resolves against whatever semantics tree exists *now*, which is the canonical instrumented-test race in this repo (PR #1111 fixed two cases of this exact shape).
-
-For any node whose existence depends on ViewModel/DataStore-emitted state, use the `awaitNode*` extensions on `ComposeTestRule` defined in `app/src/androidTest/.../ComposeTestExtensions.kt`:
+`waitForIdle()` only flushes Compose recompositions — not the `DataStore → StateFlow → render` chain (canonical race in this repo, PR #1111). For nodes whose existence depends on ViewModel/DataStore state, use the `awaitNode*` helpers in `app/src/androidTest/.../ComposeTestExtensions.kt` (rationale in KDoc):
 
 ```kotlin
 composeRule.awaitNodeWithContentDescription(pinLabel()).performClick()
@@ -275,9 +273,7 @@ composeRule.awaitNodeWithText(homeTabLabel()).assertIsDisplayed()
 composeRule.awaitNode(hasSetTextAction()).performTextInput(name)
 ```
 
-These extensions fuse `waitUntil { onAllNodes(matcher).fetchSemanticsNodes().isNotEmpty() }` with the lookup and return a `SemanticsNodeInteraction`, so the call site is shorter than the unsafe form — the right thing is the easy thing.
-
-`waitForIdle()` (or an inline `waitUntil { onAllNodes(...).isNotEmpty() }`) is still the correct call in four cases: (a) after a deterministic UI action (`performClick`, `pressBack`) where you just need recomposition to flush before the next assertion, (b) before negative assertions like `onAllNodes(...).assertCountEquals(0)` (the helper waits for *presence*; absence needs the inverse predicate, which is rare enough not to factor), (c) before `onAllNodes(...).onFirst()` chains (the helper does not yet cover the "first of N" shape — keep the inline `waitUntil` in those spots), (d) when the matcher would resolve to *more than one* node in the tree (e.g. a search query the user typed also appears in a result card and in the underlying screen behind the overlay) — the helper's terminal `onNodeWithText`/`onNodeWithContentDescription`/`onNode` throws on multi-match, so use `waitUntil { onAllNodes(matcher).fetchSemanticsNodes().isNotEmpty() }` and assert presence directly.
+Bare `waitForIdle()` / `waitUntil { onAllNodes(...).isNotEmpty() }` is still correct after deterministic actions (`performClick`, `pressBack`); before negative assertions like `assertCountEquals(0)`; before `.onFirst()` chains; and when the matcher would multi-match — the helpers' terminal `onNode*` throws on multi-match.
 
 ## Pre-PR checklist
 

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ComposeTestExtensions.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ComposeTestExtensions.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton
+
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+
+/**
+ * Default timeout for [awaitNode] / [awaitNodeWithText] / [awaitNodeWithContentDescription].
+ *
+ * Five seconds is the same value tests have used inline since the suite landed; long enough to
+ * cover the DataStore-read → StateFlow-emit → Compose-render chain on a cold-started emulator,
+ * short enough that a real failure surfaces before the JUnit timeout.
+ */
+internal const val WAIT_TIMEOUT_MS: Long = 5_000L
+
+/**
+ * Wait until at least one node matching [matcher] is in the semantics tree, then return the
+ * single-node interaction. Use this whenever a click/assertion targets a node whose existence
+ * depends on ViewModel/DataStore-emitted state — `composeRule.waitForIdle()` waits only for
+ * Compose recompositions to settle, not for upstream coroutines to finish seeding the screen.
+ *
+ * Returns the same [SemanticsNodeInteraction] that `onNode(matcher)` would have returned, so
+ * callers can chain `.performClick()`, `.assertIsDisplayed()`, etc. directly.
+ */
+internal fun ComposeTestRule.awaitNode(
+    matcher: SemanticsMatcher,
+    timeoutMillis: Long = WAIT_TIMEOUT_MS,
+): SemanticsNodeInteraction {
+    waitUntil(timeoutMillis) {
+        onAllNodes(matcher).fetchSemanticsNodes().isNotEmpty()
+    }
+    return onNode(matcher)
+}
+
+/**
+ * [awaitNode] specialised for `hasText(text)` — the most common flake shape in this suite.
+ */
+internal fun ComposeTestRule.awaitNodeWithText(
+    text: String,
+    timeoutMillis: Long = WAIT_TIMEOUT_MS,
+): SemanticsNodeInteraction {
+    waitUntil(timeoutMillis) {
+        onAllNodes(hasText(text)).fetchSemanticsNodes().isNotEmpty()
+    }
+    return onNodeWithText(text)
+}
+
+/**
+ * [awaitNode] specialised for [androidx.compose.ui.test.hasContentDescription] — pairs with
+ * the IconButton-heavy parts of the UI (bottom nav, top bar, swipe-action accents).
+ */
+internal fun ComposeTestRule.awaitNodeWithContentDescription(
+    label: String,
+    timeoutMillis: Long = WAIT_TIMEOUT_MS,
+): SemanticsNodeInteraction {
+    waitUntil(timeoutMillis) {
+        onAllNodesWithContentDescription(label).fetchSemanticsNodes().isNotEmpty()
+    }
+    return onNodeWithContentDescription(label)
+}

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonCreateFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonCreateFlowTest.kt
@@ -15,6 +15,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.barriosnahuel.vossosunboton.AbstractUiTest
 import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithText
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -41,8 +42,7 @@ internal class AddButtonCreateFlowTest : AbstractUiTest() {
     @Test
     fun createModeWithUriRendersSaveButtonAndForm() {
         ActivityScenario.launch<AddButtonActivity>(launchIntent(uri = SAMPLE_URI)).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText(context.getString(R.string.app_addbutton_save)).assertIsDisplayed()
+            composeRule.awaitNodeWithText(context.getString(R.string.app_addbutton_save)).assertIsDisplayed()
             composeRule.onNodeWithText(context.getString(R.string.app_addbutton_name)).assertIsDisplayed()
         }
     }
@@ -50,11 +50,9 @@ internal class AddButtonCreateFlowTest : AbstractUiTest() {
     @Test
     fun saveWithBlankNameShowsRequiredError() {
         ActivityScenario.launch<AddButtonActivity>(launchIntent(uri = SAMPLE_URI)).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText(context.getString(R.string.app_addbutton_save)).performClick()
-            composeRule.waitForIdle()
+            composeRule.awaitNodeWithText(context.getString(R.string.app_addbutton_save)).performClick()
             composeRule
-                .onNodeWithText(context.getString(R.string.app_addbutton_name_is_required_error))
+                .awaitNodeWithText(context.getString(R.string.app_addbutton_name_is_required_error))
                 .assertIsDisplayed()
         }
     }

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonEditFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonEditFlowTest.kt
@@ -11,8 +11,6 @@ import android.content.Intent
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasSetTextAction
-import androidx.compose.ui.test.onAllNodesWithContentDescription
-import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
@@ -26,6 +24,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.barriosnahuel.vossosunboton.AbstractUiTest
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.TestData
+import com.github.barriosnahuel.vossosunboton.WAIT_TIMEOUT_MS
+import com.github.barriosnahuel.vossosunboton.awaitNode
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithContentDescription
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithText
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.ui.home.LandingActivity
 import org.junit.Test
@@ -41,17 +43,14 @@ internal class AddButtonEditFlowTest : AbstractUiTest() {
         val sound = TestData.seedCustomSounds(context, count = 1).single()
 
         ActivityScenario.launch<AddButtonActivity>(editIntent(sound)).use {
-            composeRule.waitForIdle()
             // Both the OutlinedTextField and the AudioPreview header render the sound name,
             // so a plain hasText() matcher returns 2 nodes. Scope to the editable input.
-            nameField().assertIsDisplayed()
+            composeRule.awaitNode(hasSetTextAction()).assertIsDisplayed()
             // AudioPreview gates its Card render on `isReady`, which is flipped from a
-            // LaunchedEffect after `withContext(Dispatchers.IO) { player.prepare() }` finishes.
-            // `waitForIdle()` returns when Compose is idle but does NOT await the IO dispatcher,
-            // so poll until the Preview audio button actually appears before asserting.
-            awaitPreviewButton()
+            // LaunchedEffect after `withContext(Dispatchers.IO) { player.prepare() }` finishes —
+            // an IO round-trip that `waitForIdle()` does not await.
             composeRule
-                .onNodeWithContentDescription(context.getString(R.string.app_addbutton_preview_audio))
+                .awaitNodeWithContentDescription(context.getString(R.string.app_addbutton_preview_audio))
                 .assertHasClickAction()
         }
     }
@@ -61,12 +60,10 @@ internal class AddButtonEditFlowTest : AbstractUiTest() {
         val sound = TestData.seedCustomSounds(context, count = 1).single()
 
         ActivityScenario.launch<AddButtonActivity>(editIntent(sound)).use {
-            composeRule.waitForIdle()
-            nameField().performTextClearance()
+            composeRule.awaitNode(hasSetTextAction()).performTextClearance()
             composeRule.onNodeWithText(context.getString(R.string.app_addbutton_save_changes)).performClick()
-            composeRule.waitForIdle()
             composeRule
-                .onNodeWithText(context.getString(R.string.app_addbutton_name_is_required_error))
+                .awaitNodeWithText(context.getString(R.string.app_addbutton_name_is_required_error))
                 .assertIsDisplayed()
         }
     }
@@ -81,8 +78,7 @@ internal class AddButtonEditFlowTest : AbstractUiTest() {
             .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, null))
 
         ActivityScenario.launch<AddButtonActivity>(editIntent(sound)).use {
-            composeRule.waitForIdle()
-            nameField().performTextClearance()
+            composeRule.awaitNode(hasSetTextAction()).performTextClearance()
             nameField().performTextInput(newName)
             composeRule.onNodeWithText(context.getString(R.string.app_addbutton_save_changes)).performClick()
             // Inspect Intents.getIntents() directly instead of Intents.intended(): when a resumed activity exists,
@@ -105,11 +101,8 @@ internal class AddButtonEditFlowTest : AbstractUiTest() {
         val sound = TestData.seedCustomSounds(context, count = 1).single()
 
         ActivityScenario.launch<AddButtonActivity>(editIntent(sound)).use {
-            composeRule.waitForIdle()
-            // See `editModeRendersPreviewCardAndExistingName` for the why behind this poll.
-            awaitPreviewButton()
             composeRule
-                .onNodeWithContentDescription(context.getString(R.string.app_addbutton_preview_audio))
+                .awaitNodeWithContentDescription(context.getString(R.string.app_addbutton_preview_audio))
                 .assertHasClickAction()
         }
     }
@@ -117,15 +110,4 @@ internal class AddButtonEditFlowTest : AbstractUiTest() {
     private fun editIntent(sound: Sound): Intent = LandingActivity.editIntent(context, sound)
 
     private fun nameField() = composeRule.onNode(hasSetTextAction())
-
-    private fun awaitPreviewButton() {
-        val previewLabel = context.getString(R.string.app_addbutton_preview_audio)
-        composeRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) {
-            composeRule.onAllNodesWithContentDescription(previewLabel).fetchSemanticsNodes().isNotEmpty()
-        }
-    }
-
-    companion object {
-        private const val WAIT_TIMEOUT_MS = 5_000L
-    }
 }

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenFlowTest.kt
@@ -26,6 +26,8 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasData
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.barriosnahuel.vossosunboton.AbstractUiTest
 import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithContentDescription
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithText
 import com.github.barriosnahuel.vossosunboton.ui.home.LandingActivity
 import org.hamcrest.Description
 import org.hamcrest.Matcher
@@ -41,8 +43,7 @@ internal class AboutScreenFlowTest : AbstractUiTest() {
     fun overflowMenuOpensAboutScreen() {
         ActivityScenario.launch(LandingActivity::class.java).use {
             openAbout()
-            composeRule.onNodeWithContentDescription(backLabel()).assertIsDisplayed()
-            composeRule.onNodeWithText(licenseLabel()).assertIsDisplayed()
+            composeRule.awaitNodeWithText(licenseLabel()).assertIsDisplayed()
         }
     }
 
@@ -51,9 +52,8 @@ internal class AboutScreenFlowTest : AbstractUiTest() {
         ActivityScenario.launch(LandingActivity::class.java).use {
             openAbout()
             composeRule.onNodeWithContentDescription(backLabel()).performClick()
-            composeRule.waitForIdle()
             // Search FAB on Landing is back in view.
-            composeRule.onNodeWithContentDescription(context.getString(R.string.app_search)).assertIsDisplayed()
+            composeRule.awaitNodeWithContentDescription(context.getString(R.string.app_search)).assertIsDisplayed()
         }
     }
 
@@ -62,8 +62,7 @@ internal class AboutScreenFlowTest : AbstractUiTest() {
         ActivityScenario.launch(LandingActivity::class.java).use {
             openAbout()
             Espresso.pressBack()
-            composeRule.waitForIdle()
-            composeRule.onNodeWithContentDescription(context.getString(R.string.app_search)).assertIsDisplayed()
+            composeRule.awaitNodeWithContentDescription(context.getString(R.string.app_search)).assertIsDisplayed()
         }
     }
 
@@ -72,10 +71,9 @@ internal class AboutScreenFlowTest : AbstractUiTest() {
         ActivityScenario.launch(LandingActivity::class.java).use {
             openAbout()
             composeRule
-                .onNodeWithContentDescription(playBrandingAudioLabel())
+                .awaitNodeWithContentDescription(playBrandingAudioLabel())
                 .assertHasClickAction()
                 .performClick()
-            composeRule.waitForIdle()
             // SoundPool playback is fire-and-forget; nothing to assert in the UI tree, but
             // performing the click verifies the handler does not throw.
         }
@@ -89,9 +87,8 @@ internal class AboutScreenFlowTest : AbstractUiTest() {
             composeRule.onAllNodes(hasText(geminiName())).fetchSemanticsNodes().let {
                 assert(it.isEmpty()) { "Gemini card visible before expanding Credits." }
             }
-            composeRule.onNodeWithText(creditsLabel()).performClick()
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText(geminiName()).assertIsDisplayed()
+            composeRule.awaitNodeWithText(creditsLabel()).performClick()
+            composeRule.awaitNodeWithText(geminiName()).assertIsDisplayed()
             composeRule.onNodeWithText(claudeName()).assertIsDisplayed()
         }
     }
@@ -100,9 +97,10 @@ internal class AboutScreenFlowTest : AbstractUiTest() {
     fun licenseButtonOpensModalBottomSheetWithAgplExcerpt() {
         ActivityScenario.launch(LandingActivity::class.java).use {
             openAbout()
-            composeRule.onNodeWithText(licenseLabel()).performClick()
+            composeRule.awaitNodeWithText(licenseLabel()).performClick()
+            // The license file (raw/app_license) starts with the AGPL header. Substring matching
+            // does not fit the awaitNodeWithText helper (which is exact-match), so this stays inline.
             composeRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) {
-                // The license file (raw/app_license) starts with the AGPL header.
                 composeRule
                     .onAllNodes(hasText("GNU AFFERO GENERAL PUBLIC LICENSE", substring = true))
                     .fetchSemanticsNodes()
@@ -118,7 +116,7 @@ internal class AboutScreenFlowTest : AbstractUiTest() {
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             openAbout()
-            composeRule.onNodeWithText(sourceLabel()).performScrollTo().performClick()
+            composeRule.awaitNodeWithText(sourceLabel()).performScrollTo().performClick()
             composeRule.waitForIdle()
             // The data URL is unique to this button's ACTION_VIEW; matching the URL alone
             // is sufficient and avoids the hamcrest 1.3 `allOf(2-arg)` API gap.
@@ -133,7 +131,7 @@ internal class AboutScreenFlowTest : AbstractUiTest() {
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             openAbout()
-            composeRule.onNodeWithText(privacyPolicyLabel()).performScrollTo().performClick()
+            composeRule.awaitNodeWithText(privacyPolicyLabel()).performScrollTo().performClick()
             composeRule.waitForIdle()
             intended(hasData(matchesSupportedHl(context.getString(R.string.app_about_privacy_policy_url))))
         }
@@ -146,7 +144,7 @@ internal class AboutScreenFlowTest : AbstractUiTest() {
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             openAbout()
-            composeRule.onNodeWithText(dataSafetyLabel()).performScrollTo().performClick()
+            composeRule.awaitNodeWithText(dataSafetyLabel()).performScrollTo().performClick()
             composeRule.waitForIdle()
             intended(hasData(matchesSupportedHl(context.getString(R.string.app_about_data_safety_url))))
         }
@@ -156,7 +154,7 @@ internal class AboutScreenFlowTest : AbstractUiTest() {
     fun externalLegalItemsExposeOpensInBrowserHint() {
         ActivityScenario.launch(LandingActivity::class.java).use {
             openAbout()
-            composeRule.onNodeWithText(privacyPolicyLabel()).performScrollTo()
+            composeRule.awaitNodeWithText(privacyPolicyLabel()).performScrollTo()
             composeRule
                 .onAllNodesWithContentDescription(context.getString(R.string.app_about_open_in_browser))
                 .fetchSemanticsNodes()
@@ -173,7 +171,7 @@ internal class AboutScreenFlowTest : AbstractUiTest() {
         ActivityScenario.launch(LandingActivity::class.java).use {
             openAbout()
             composeRule.onNodeWithContentDescription(backLabel()).assertHasClickAction()
-            composeRule.onNodeWithContentDescription(playBrandingAudioLabel()).assertHasClickAction()
+            composeRule.awaitNodeWithContentDescription(playBrandingAudioLabel()).assertHasClickAction()
         }
     }
 
@@ -184,7 +182,7 @@ internal class AboutScreenFlowTest : AbstractUiTest() {
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             openAbout()
-            composeRule.onNodeWithText(kofiLabel()).performScrollTo().performClick()
+            composeRule.awaitNodeWithText(kofiLabel()).performScrollTo().performClick()
             composeRule.waitForIdle()
             intended(hasData(context.getString(R.string.app_about_gratitude_kofi_url)))
         }
@@ -198,18 +196,16 @@ internal class AboutScreenFlowTest : AbstractUiTest() {
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             openAbout()
-            composeRule.onNodeWithText(cafecitoLabel()).performScrollTo().performClick()
+            composeRule.awaitNodeWithText(cafecitoLabel()).performScrollTo().performClick()
             composeRule.waitForIdle()
             intended(hasData(context.getString(R.string.app_about_gratitude_cafecito_url)))
         }
     }
 
     private fun openAbout() {
-        composeRule.waitForIdle()
-        composeRule.onNodeWithContentDescription(context.getString(R.string.app_overflow_menu)).performClick()
-        composeRule.waitForIdle()
-        composeRule.onNodeWithText(context.getString(R.string.app_about)).performClick()
-        composeRule.waitForIdle()
+        composeRule.awaitNodeWithContentDescription(context.getString(R.string.app_overflow_menu)).performClick()
+        composeRule.awaitNodeWithText(context.getString(R.string.app_about)).performClick()
+        composeRule.awaitNodeWithContentDescription(backLabel()).assertIsDisplayed()
     }
 
     private fun backLabel() = context.getString(R.string.app_about_back)

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/DeepLinkTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/DeepLinkTest.kt
@@ -10,12 +10,12 @@ import android.net.Uri
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onAllNodesWithContentDescription
-import androidx.compose.ui.test.onNodeWithText
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.barriosnahuel.vossosunboton.AbstractUiTest
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.TestData
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithText
 import com.github.barriosnahuel.vossosunboton.model.data.local.defaultaudios.PackagedAudios
 import org.junit.Assume.assumeFalse
 import org.junit.Assume.assumeTrue
@@ -34,9 +34,8 @@ internal class DeepLinkTest : AbstractUiTest() {
         TestData.seedCustomSounds(context, count = 1)
 
         ActivityScenario.launch<LandingActivity>(deeplink("/home")).use {
-            composeRule.waitForIdle()
             // Custom sound is on Home; bundled sound is on Explore.
-            composeRule.onNodeWithText("custom_1").assertIsDisplayed()
+            composeRule.awaitNodeWithText("custom_1").assertIsDisplayed()
             composeRule.onAllNodes(hasText(bundled.first().name)).fetchSemanticsNodes().let {
                 assert(it.isEmpty()) { "Bundled sound should not be visible on Home." }
             }
@@ -53,8 +52,7 @@ internal class DeepLinkTest : AbstractUiTest() {
         TestData.seedCustomSounds(context, count = 1)
 
         ActivityScenario.launch<LandingActivity>(deeplink("/explore")).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText(bundled.first().name).assertIsDisplayed()
+            composeRule.awaitNodeWithText(bundled.first().name).assertIsDisplayed()
             composeRule.onAllNodes(hasText("custom_1")).fetchSemanticsNodes().let {
                 assert(it.isEmpty()) { "Custom sound should not be visible on Explore." }
             }
@@ -70,9 +68,8 @@ internal class DeepLinkTest : AbstractUiTest() {
         TestData.seedCustomSounds(context, count = 1)
 
         ActivityScenario.launch<LandingActivity>(deeplink("/explore")).use {
-            composeRule.waitForIdle()
             // Custom sound (Home content) is visible.
-            composeRule.onNodeWithText("custom_1").assertIsDisplayed()
+            composeRule.awaitNodeWithText("custom_1").assertIsDisplayed()
             // BottomBar is hidden since hasBundledSounds == false.
             composeRule.onAllNodesWithContentDescription(exploreTabLabel()).fetchSemanticsNodes().let {
                 assert(it.isEmpty()) { "BottomBar should be hidden when there are no bundled sounds." }
@@ -90,10 +87,9 @@ internal class DeepLinkTest : AbstractUiTest() {
         TestData.seedCustomSounds(context, count = 1)
 
         ActivityScenario.launch<LandingActivity>(deeplink("/anything-unknown")).use {
-            composeRule.waitForIdle()
             // Per the closed deep-link allowlist in LandingActivity.handleDeeplink,
             // any unknown path must safely fall back to MY_SOUNDS — never silently route to Explore.
-            composeRule.onNodeWithText("custom_1").assertIsDisplayed()
+            composeRule.awaitNodeWithText("custom_1").assertIsDisplayed()
             composeRule.onAllNodes(hasText(bundled.first().name)).fetchSemanticsNodes().let {
                 assert(it.isEmpty()) { "Bundled sound should not be visible since unknown paths fall back to MY_SOUNDS." }
             }

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/ExploreTabFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/ExploreTabFlowTest.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onFirst
-import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
@@ -22,6 +21,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.barriosnahuel.vossosunboton.AbstractUiTest
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.TestData
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithContentDescription
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithText
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.model.data.local.defaultaudios.PackagedAudios
 import org.junit.Assume.assumeTrue
@@ -44,14 +45,9 @@ internal class ExploreTabFlowTest : AbstractUiTest() {
     @Test
     fun bottomBarIsVisibleWhenBundledSoundsExist() {
         ActivityScenario.launch(LandingActivity::class.java).use {
-            // The bottom bar renders only after the bundled-sounds StateFlow emits a non-empty list;
-            // waitForIdle() can return before that emission lands, so poll for the tab label first.
             // Find by label text — the icon's contentDescription only lives in the unmerged
             // tree, while the label (a Text composable) bubbles up through merge.
-            composeRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) {
-                composeRule.onAllNodes(hasText(homeTabLabel())).fetchSemanticsNodes().isNotEmpty()
-            }
-            composeRule.onNodeWithText(homeTabLabel()).assertIsDisplayed()
+            composeRule.awaitNodeWithText(homeTabLabel()).assertIsDisplayed()
             composeRule.onNodeWithText(exploreTabLabel()).assertIsDisplayed()
         }
     }
@@ -62,10 +58,8 @@ internal class ExploreTabFlowTest : AbstractUiTest() {
         val firstBundledName = bundled.first().name
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText(exploreTabLabel()).performClick()
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText(firstBundledName).assertIsDisplayed()
+            composeRule.awaitNodeWithText(exploreTabLabel()).performClick()
+            composeRule.awaitNodeWithText(firstBundledName).assertIsDisplayed()
             // The seeded "custom_1" lives only on Home; switching to Explore hides it.
             composeRule.onAllNodes(hasText("custom_1")).assertCountEquals(0)
         }
@@ -76,10 +70,8 @@ internal class ExploreTabFlowTest : AbstractUiTest() {
         val firstBundledName = bundled.first().name
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText(exploreTabLabel()).performClick()
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText(firstBundledName).performTouchInput { swipeLeft() }
+            composeRule.awaitNodeWithText(exploreTabLabel()).performClick()
+            composeRule.awaitNodeWithText(firstBundledName).performTouchInput { swipeLeft() }
             composeRule.waitForIdle()
             // Card stays at the same position with the pin icon (not unpin) — swipe-left
             // only fires a reject haptic for bundled sounds.
@@ -96,16 +88,9 @@ internal class ExploreTabFlowTest : AbstractUiTest() {
         val targetName = bundled.first().name
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText(exploreTabLabel()).performClick()
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText(targetName).performTouchInput { swipeRight() }
-            composeRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) {
-                composeRule
-                    .onAllNodesWithContentDescription(unpinLabel())
-                    .fetchSemanticsNodes()
-                    .isNotEmpty()
-            }
+            composeRule.awaitNodeWithText(exploreTabLabel()).performClick()
+            composeRule.awaitNodeWithText(targetName).performTouchInput { swipeRight() }
+            composeRule.awaitNodeWithContentDescription(unpinLabel()).assertIsDisplayed()
         }
     }
 
@@ -114,21 +99,25 @@ internal class ExploreTabFlowTest : AbstractUiTest() {
         val targetName = bundled.first().name
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText(exploreTabLabel()).performClick()
-            composeRule.waitForIdle()
+            composeRule.awaitNodeWithText(exploreTabLabel()).performClick()
+            // Wait for the bundled cards to seed before grabbing the first pin icon.
+            // `onAllNodes(...).onFirst()` is the "first of N" shape that the helper does not cover;
+            // the wait + lookup stays inline.
+            composeRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) {
+                composeRule.onAllNodesWithContentDescription(pinLabel()).fetchSemanticsNodes().isNotEmpty()
+            }
             composeRule.onAllNodesWithContentDescription(pinLabel()).onFirst().performClick()
-            composeRule.waitForIdle()
-            composeRule.onNodeWithContentDescription(unpinLabel()).assertIsDisplayed()
+            composeRule.awaitNodeWithContentDescription(unpinLabel()).assertIsDisplayed()
         }
     }
 
     @Test
     fun exploreTabExposesA11yContentDescriptions() {
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText(exploreTabLabel()).performClick()
-            composeRule.waitForIdle()
+            composeRule.awaitNodeWithText(exploreTabLabel()).performClick()
+            composeRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) {
+                composeRule.onAllNodesWithContentDescription(playLabel()).fetchSemanticsNodes().isNotEmpty()
+            }
             composeRule.onAllNodesWithContentDescription(playLabel()).onFirst().assertHasClickAction()
             composeRule.onAllNodesWithContentDescription(shareLabel()).onFirst().assertHasClickAction()
             composeRule.onAllNodesWithContentDescription(pinLabel()).onFirst().assertHasClickAction()

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/HomeTabFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/HomeTabFlowTest.kt
@@ -12,9 +12,6 @@ import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.longClick
-import androidx.compose.ui.test.onAllNodesWithContentDescription
-import androidx.compose.ui.test.onNodeWithContentDescription
-import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeLeft
@@ -29,6 +26,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.barriosnahuel.vossosunboton.AbstractUiTest
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.TestData
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithContentDescription
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithText
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -39,9 +38,8 @@ internal class HomeTabFlowTest : AbstractUiTest() {
         TestData.seedCustomSounds(context, count = 2)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText("custom_1").assertIsDisplayed()
-            composeRule.onNodeWithText("custom_2").assertIsDisplayed()
+            composeRule.awaitNodeWithText("custom_1").assertIsDisplayed()
+            composeRule.awaitNodeWithText("custom_2").assertIsDisplayed()
         }
     }
 
@@ -50,15 +48,8 @@ internal class HomeTabFlowTest : AbstractUiTest() {
         TestData.seedCustomSounds(context, count = 1)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithContentDescription(playLabel()).performClick()
-            composeRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) {
-                composeRule
-                    .onAllNodesWithContentDescription(pauseLabel())
-                    .fetchSemanticsNodes()
-                    .isNotEmpty()
-            }
-            composeRule.onNodeWithContentDescription(pauseLabel()).assertIsDisplayed()
+            composeRule.awaitNodeWithContentDescription(playLabel()).performClick()
+            composeRule.awaitNodeWithContentDescription(pauseLabel()).assertIsDisplayed()
         }
     }
 
@@ -69,8 +60,7 @@ internal class HomeTabFlowTest : AbstractUiTest() {
             .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, null))
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithContentDescription(shareLabel()).performClick()
+            composeRule.awaitNodeWithContentDescription(shareLabel()).performClick()
             composeRule.waitForIdle()
 
             intended(hasAction(Intent.ACTION_CHOOSER))
@@ -84,10 +74,8 @@ internal class HomeTabFlowTest : AbstractUiTest() {
             .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, null))
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText(sound.name).performTouchInput { longClick() }
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText(renameLabel()).performClick()
+            composeRule.awaitNodeWithText(sound.name).performTouchInput { longClick() }
+            composeRule.awaitNodeWithText(renameLabel()).performClick()
             composeRule.waitForIdle()
 
             // Hamcrest 1.3 (transitively pinned in the test APK) lacks the 2-arg `allOf`
@@ -102,15 +90,10 @@ internal class HomeTabFlowTest : AbstractUiTest() {
         val sound = TestData.seedCustomSounds(context, count = 1).single()
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText(sound.name).performTouchInput { swipeLeft() }
+            composeRule.awaitNodeWithText(sound.name).performTouchInput { swipeLeft() }
             val undoLabel = context.getString(R.string.app_undo)
-            composeRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) {
-                composeRule.onAllNodes(hasText(undoLabel)).fetchSemanticsNodes().isNotEmpty()
-            }
-            composeRule.onNodeWithText(undoLabel).performClick()
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText(sound.name).assertIsDisplayed()
+            composeRule.awaitNodeWithText(undoLabel).performClick()
+            composeRule.awaitNodeWithText(sound.name).assertIsDisplayed()
         }
     }
 
@@ -119,8 +102,7 @@ internal class HomeTabFlowTest : AbstractUiTest() {
         val sound = TestData.seedCustomSounds(context, count = 1).single()
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText(sound.name).performTouchInput { swipeLeft() }
+            composeRule.awaitNodeWithText(sound.name).performTouchInput { swipeLeft() }
             // Snackbar (long timeout) → confirmDelete → card vanishes from the list.
             composeRule.waitUntil(timeoutMillis = SNACKBAR_LONG_TIMEOUT_MS) {
                 composeRule.onAllNodes(hasText(sound.name)).fetchSemanticsNodes().isEmpty()
@@ -133,22 +115,8 @@ internal class HomeTabFlowTest : AbstractUiTest() {
         TestData.seedCustomSounds(context, count = 1)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            // waitForIdle() alone races against the DataStore-read → StateFlow-emit → LazyColumn-render chain;
-            // poll for the pin IconButton's semantics node before clicking, mirroring tapPlaySwapsPlayIconToPause.
-            composeRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) {
-                composeRule
-                    .onAllNodesWithContentDescription(pinLabel())
-                    .fetchSemanticsNodes()
-                    .isNotEmpty()
-            }
-            composeRule.onNodeWithContentDescription(pinLabel()).performClick()
-            composeRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) {
-                composeRule
-                    .onAllNodesWithContentDescription(unpinLabel())
-                    .fetchSemanticsNodes()
-                    .isNotEmpty()
-            }
-            composeRule.onNodeWithContentDescription(unpinLabel()).assertIsDisplayed()
+            composeRule.awaitNodeWithContentDescription(pinLabel()).performClick()
+            composeRule.awaitNodeWithContentDescription(unpinLabel()).assertIsDisplayed()
         }
     }
 
@@ -157,14 +125,8 @@ internal class HomeTabFlowTest : AbstractUiTest() {
         TestData.seedCustomSounds(context, count = 2)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText("custom_2").performTouchInput { swipeRight() }
-            composeRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) {
-                composeRule
-                    .onAllNodesWithContentDescription(unpinLabel())
-                    .fetchSemanticsNodes()
-                    .isNotEmpty()
-            }
+            composeRule.awaitNodeWithText("custom_2").performTouchInput { swipeRight() }
+            composeRule.awaitNodeWithContentDescription(unpinLabel()).assertIsDisplayed()
         }
     }
 
@@ -173,12 +135,11 @@ internal class HomeTabFlowTest : AbstractUiTest() {
         TestData.seedCustomSounds(context, count = 1)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithContentDescription(searchLabel()).assertHasClickAction()
-            composeRule.onNodeWithContentDescription(overflowLabel()).assertHasClickAction()
-            composeRule.onNodeWithContentDescription(playLabel()).assertHasClickAction()
-            composeRule.onNodeWithContentDescription(shareLabel()).assertHasClickAction()
-            composeRule.onNodeWithContentDescription(pinLabel()).assertHasClickAction()
+            composeRule.awaitNodeWithContentDescription(searchLabel()).assertHasClickAction()
+            composeRule.awaitNodeWithContentDescription(overflowLabel()).assertHasClickAction()
+            composeRule.awaitNodeWithContentDescription(playLabel()).assertHasClickAction()
+            composeRule.awaitNodeWithContentDescription(shareLabel()).assertHasClickAction()
+            composeRule.awaitNodeWithContentDescription(pinLabel()).assertHasClickAction()
         }
     }
 
@@ -199,7 +160,6 @@ internal class HomeTabFlowTest : AbstractUiTest() {
     private fun overflowLabel() = context.getString(R.string.app_overflow_menu)
 
     companion object {
-        private const val WAIT_TIMEOUT_MS = 5_000L
         private const val SNACKBAR_LONG_TIMEOUT_MS = 15_000L
         private const val ADD_BUTTON_ACTIVITY =
             "com.github.barriosnahuel.vossosunboton.feature.addbutton.AddButtonActivity"

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlayTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlayTest.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onNodeWithContentDescription
-import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.test.core.app.ActivityScenario
@@ -20,6 +19,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.barriosnahuel.vossosunboton.AbstractUiTest
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.TestData
+import com.github.barriosnahuel.vossosunboton.WAIT_TIMEOUT_MS
+import com.github.barriosnahuel.vossosunboton.awaitNode
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithContentDescription
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithText
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -30,11 +33,9 @@ internal class SearchOverlayTest : AbstractUiTest() {
         TestData.seedCustomSounds(context, count = 1)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithContentDescription(searchLabel()).performClick()
-            composeRule.waitForIdle()
+            composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
             // The overlay's TopAppBar back arrow uses "Close search" as content description.
-            composeRule.onNodeWithContentDescription(closeSearchLabel()).assertIsDisplayed()
+            composeRule.awaitNodeWithContentDescription(closeSearchLabel()).assertIsDisplayed()
         }
     }
 
@@ -43,15 +44,13 @@ internal class SearchOverlayTest : AbstractUiTest() {
         TestData.seedCustomSounds(context, count = 3)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithContentDescription(searchLabel()).performClick()
-            composeRule.waitForIdle()
-            composeRule.onNode(hasSetTextAction()).performTextInput("custom_2")
-            // The SearchOverlay surfaces "custom_2" once the 200ms debounce fires.
-            // Filter logic itself is covered by SoundsViewModelSearchTest — here we only
-            // verify the matching result becomes visible (the underlying LandingScreen
-            // remains in the semantic tree behind the overlay so we can't assert custom_1
-            // is *absent*).
+            composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
+            composeRule.awaitNode(hasSetTextAction()).performTextInput("custom_2")
+            // The SearchOverlay surfaces "custom_2" once the 200ms debounce fires. After typing,
+            // "custom_2" lives in three places at once: the editable input itself, the overlay
+            // result card, and the underlying LandingScreen card still in the semantics tree
+            // behind the overlay — so awaitNodeWithText (single-node + assertIsDisplayed) can't
+            // be used here. Wait for *presence* with onAllNodes instead.
             composeRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) {
                 composeRule.onAllNodes(hasText("custom_2")).fetchSemanticsNodes().isNotEmpty()
             }
@@ -63,16 +62,9 @@ internal class SearchOverlayTest : AbstractUiTest() {
         TestData.seedCustomSounds(context, count = 1)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithContentDescription(searchLabel()).performClick()
-            composeRule.waitForIdle()
-            composeRule.onNode(hasSetTextAction()).performTextInput("zzz_no_match")
-            composeRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) {
-                composeRule
-                    .onAllNodes(hasText(context.getString(R.string.app_search_empty_headline)))
-                    .fetchSemanticsNodes()
-                    .isNotEmpty()
-            }
+            composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
+            composeRule.awaitNode(hasSetTextAction()).performTextInput("zzz_no_match")
+            composeRule.awaitNodeWithText(context.getString(R.string.app_search_empty_headline)).assertIsDisplayed()
         }
     }
 
@@ -81,16 +73,12 @@ internal class SearchOverlayTest : AbstractUiTest() {
         TestData.seedCustomSounds(context, count = 1)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithContentDescription(searchLabel()).performClick()
-            composeRule.waitForIdle()
-            composeRule.onNode(hasSetTextAction()).performTextInput("custom")
-            composeRule.waitForIdle()
-            composeRule.onNodeWithContentDescription(clearSearchLabel()).performClick()
-            composeRule.waitForIdle()
+            composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
+            composeRule.awaitNode(hasSetTextAction()).performTextInput("custom")
+            composeRule.awaitNodeWithContentDescription(clearSearchLabel()).performClick()
             // Initial hint is back (overlay still open) and the back arrow remains visible.
             composeRule
-                .onNodeWithText(context.getString(R.string.app_search_initial_hint))
+                .awaitNodeWithText(context.getString(R.string.app_search_initial_hint))
                 .assertIsDisplayed()
             composeRule.onNodeWithContentDescription(closeSearchLabel()).assertIsDisplayed()
         }
@@ -101,10 +89,8 @@ internal class SearchOverlayTest : AbstractUiTest() {
         TestData.seedCustomSounds(context, count = 1)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithContentDescription(searchLabel()).performClick()
-            composeRule.waitForIdle()
-            composeRule.onNodeWithContentDescription(closeSearchLabel()).performClick()
+            composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
+            composeRule.awaitNodeWithContentDescription(closeSearchLabel()).performClick()
             composeRule.waitForIdle()
             composeRule.onNodeWithContentDescription(closeSearchLabel()).assertIsNotDisplayed()
             // FAB returns to view → we are back on Landing.
@@ -117,12 +103,11 @@ internal class SearchOverlayTest : AbstractUiTest() {
         TestData.seedCustomSounds(context, count = 1)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithContentDescription(searchLabel()).performClick()
-            composeRule.waitForIdle()
+            composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
+            // Wait for overlay to be on screen before pressing back, otherwise pressBack closes the Activity instead.
+            composeRule.awaitNodeWithContentDescription(closeSearchLabel()).assertIsDisplayed()
             Espresso.pressBack()
-            composeRule.waitForIdle()
-            composeRule.onNodeWithContentDescription(searchLabel()).assertIsDisplayed()
+            composeRule.awaitNodeWithContentDescription(searchLabel()).assertIsDisplayed()
         }
     }
 
@@ -131,13 +116,10 @@ internal class SearchOverlayTest : AbstractUiTest() {
         TestData.seedCustomSounds(context, count = 1)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithContentDescription(searchLabel()).performClick()
-            composeRule.waitForIdle()
-            composeRule.onNodeWithContentDescription(closeSearchLabel()).assertHasClickAction()
-            composeRule.onNode(hasSetTextAction()).performTextInput("c")
-            composeRule.waitForIdle()
-            composeRule.onNodeWithContentDescription(clearSearchLabel()).assertHasClickAction()
+            composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
+            composeRule.awaitNodeWithContentDescription(closeSearchLabel()).assertHasClickAction()
+            composeRule.awaitNode(hasSetTextAction()).performTextInput("c")
+            composeRule.awaitNodeWithContentDescription(clearSearchLabel()).assertHasClickAction()
         }
     }
 
@@ -146,8 +128,4 @@ internal class SearchOverlayTest : AbstractUiTest() {
     private fun closeSearchLabel() = context.getString(R.string.app_search_close)
 
     private fun clearSearchLabel() = context.getString(R.string.app_search_clear)
-
-    companion object {
-        private const val WAIT_TIMEOUT_MS = 5_000L
-    }
 }

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/WelcomeStickerFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/WelcomeStickerFlowTest.kt
@@ -6,7 +6,6 @@
 package com.github.barriosnahuel.vossosunboton.ui.home
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
@@ -18,6 +17,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.barriosnahuel.vossosunboton.AbstractUiTest
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.TestData
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithText
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -44,8 +44,7 @@ internal class WelcomeStickerFlowTest : AbstractUiTest() {
         val origin = context.getString(R.string.app_welcome_sticker_origin)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText(title).assertIsDisplayed()
+            composeRule.awaitNodeWithText(title).assertIsDisplayed()
             composeRule.onNodeWithText(origin).assertIsDisplayed()
         }
     }
@@ -59,15 +58,10 @@ internal class WelcomeStickerFlowTest : AbstractUiTest() {
         val dismissedMessage = context.getString(R.string.app_welcome_sticker_feedback_dismissed)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText(title).performTouchInput { swipeLeft() }
-            composeRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) {
-                composeRule.onAllNodes(hasText(dismissedMessage)).fetchSemanticsNodes().isNotEmpty()
-            }
+            composeRule.awaitNodeWithText(title).performTouchInput { swipeLeft() }
+            composeRule.awaitNodeWithText(dismissedMessage).assertIsDisplayed()
             composeRule.onNodeWithText(undoLabel).performClick()
-            composeRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) {
-                composeRule.onAllNodesWithText(title).fetchSemanticsNodes().isNotEmpty()
-            }
+            composeRule.awaitNodeWithText(title).assertIsDisplayed()
 
             // The welcome must reappear BELOW the user's custom sound — row 0 belongs to the
             // user once they've shown they want this sticker back rather than letting it consume.
@@ -94,25 +88,13 @@ internal class WelcomeStickerFlowTest : AbstractUiTest() {
         val dismissedMessage = context.getString(R.string.app_welcome_sticker_feedback_dismissed)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
-            composeRule.waitForIdle()
-            composeRule.onNodeWithText(title).performTouchInput { longClick() }
-            composeRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) {
-                composeRule.onAllNodesWithText(deleteLabel).fetchSemanticsNodes().isNotEmpty()
-            }
-
-            composeRule.onNodeWithText(deleteLabel).assertIsDisplayed()
+            composeRule.awaitNodeWithText(title).performTouchInput { longClick() }
+            composeRule.awaitNodeWithText(deleteLabel).assertIsDisplayed()
             // Edit must NOT appear — the welcome is a system anchor, not an editable user sound.
             assertThat(composeRule.onAllNodesWithText(editLabel).fetchSemanticsNodes()).isEmpty()
 
             composeRule.onNodeWithText(deleteLabel).performClick()
-            composeRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) {
-                composeRule.onAllNodes(hasText(dismissedMessage)).fetchSemanticsNodes().isNotEmpty()
-            }
-            composeRule.onNodeWithText(dismissedMessage).assertIsDisplayed()
+            composeRule.awaitNodeWithText(dismissedMessage).assertIsDisplayed()
         }
-    }
-
-    companion object {
-        private const val WAIT_TIMEOUT_MS = 5_000L
     }
 }

--- a/scripts/setup-test-emulator.sh
+++ b/scripts/setup-test-emulator.sh
@@ -8,7 +8,7 @@
 #
 set -euo pipefail
 
-AVD_NAME="push_me_test"
+AVD_NAME="Android_14_API_34"
 API_LEVEL="34"
 
 ARCH="$(uname -m)"


### PR DESCRIPTION
### Summary
- Adds three `awaitNode*` extensions on `ComposeTestRule` (`app/src/androidTest/.../ComposeTestExtensions.kt`) that fuse a `waitUntil`-presence poll with the node lookup. The safe call is shorter than the unsafe one (`composeRule.awaitNodeWithText(x).performClick()` vs. `composeRule.waitForIdle(); composeRule.onNodeWithText(x).performClick()`), so the right thing becomes the easy thing — no rule to remember.
- Sweeps the instrumented suite (8 files, 49 tests) onto the helpers wherever a bare `waitForIdle()` + immediate single-node action targeted a state-dependent node. Negative assertions, `onAllNodes(...).onFirst()` chains, multi-match presence checks, and flush-after-deterministic-action calls deliberately stay on the existing forms.
- Documents the rule in `CLAUDE.md` § *Local UI test suite* — single new "Synchronization" subsection naming the four cases where `waitForIdle()` (or an inline `waitUntil { onAllNodes(...).isNotEmpty() }`) is still correct.
- Renames the test AVD from `push_me_test` to `Android_14_API_34` (matches Android Studio's canonical ID convention `Pixel_7_API_34`, self-documents the platform). Touches `scripts/setup-test-emulator.sh` and `CLAUDE.md` only — no behaviour change.
- Net **−34 lines** across the suite vs. develop (helper file is +69, tests collapse by ~103).

### Code review tips
- Helper contract: wait for presence (≥1 node), then return the single-node `SemanticsNodeInteraction`. The terminal `onNodeWith*` throws on >1 match — by design, documented as case (d) in the CLAUDE.md note. `SearchOverlayTest.typingQueryFiltersResultsToMatchingSound` is the in-tree example where the helper does NOT apply (the typed query lives in 3 places at once: input + overlay result + underlying screen).
- `WAIT_TIMEOUT_MS` moves from per-test-class companion constants to a top-level `internal const` in the helper file. Test files that still need it import from the helper namespace.
- AVD rename: contributors with the legacy `push_me_test` AVD on disk will get the new `Android_14_API_34` alongside (the script is idempotent and only creates if missing). The old AVD is harmless; remove via `avdmanager delete avd -n push_me_test` if disk space matters.
- I deliberately did NOT add a custom Detekt/Android Lint rule. The project has no precedent for project-specific static-analysis rules, and the helper + CLAUDE.md note + clean baseline cover the same need with much lower maintenance cost.

### Already tested
- [x] `./gradlew check -x test` — green
- [x] `./gradlew app:compileDebugAndroidTestKotlin` — green (catches androidTest issues that `check -x test` skips, since CI does not compile androidTest)
- [x] `./gradlew app:connectedDebugAndroidTest` on `push_me_test` AVD, **3 consecutive full runs after the helper sweep**: 49 tests, 47 pass, 2 skip, 0 fail in each run
- [x] `./gradlew app:connectedDebugAndroidTest` on the renamed `Android_14_API_34` AVD: 49/47/2/0 — confirms the script + CLAUDE.md + UTP plumbing all resolve the new name. Report XML emitted as `TEST-Android_14_API_34(AVD) - 14-_app-.xml`, no spaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)