### PR TITLE
docs(release-notes): polish v2.0.0 listing copy and CHANGELOG; embed full NDK symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][], and this project adheres to [Semantic Versioning][].
 
-## \[unreleased] (v2.0.0)
+## \[unreleased] (v2.1.0)
+
+## \[v2.0.0] - 2026-05-07
 
 ### Added
 - About now includes a heart-first gratitude frame inviting users to buy a virtual coffee via Ko-fi (all locales) and Cafecito (visible only on es-AR devices)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,17 +46,13 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Snackbar after deleting a custom sound now reads "Audio deleted"/"Audio borrado" (was "Button deleted"/"Botón borrado") so the copy matches how users describe what they removed
 - Welcome card can be dismissed by swiping left, or long-pressing to open the actions menu and tapping Delete — no need to listen all the way through. Tapping Undo within 5s brings it back, but it now lives at the bottom of My Sounds instead of pinning to the top
 - Restoring the app via Auto Backup or device-transfer now preserves your dismissal of the welcome card and your lifetime usage counters (number of plays, number of shares) so a restored device picks up where the previous one left off. First-time-event flags still reset per-install to align with Firebase's per-install lifecycle
+- Saving a button via the share intent now confirms with a "Saved!" Snackbar and navigates to the Home tab, instead of silently returning to the previous app
 
 ### Fixed
-- The app now opens the Home tab on launch instead of the Search tab
-- After saving a button via the share intent, the app navigates to the Home tab and shows a "Saved!" confirmation Snackbar instead of silently returning to the previous app
-- The Add Button screen no longer appears in the recent apps tray after saving
 - Custom sound stops playing immediately when deleted instead of continuing until the track ends
 - Bundled sounds no longer offer a swipe-to-delete gesture; the action is simply not available
-- Validate inbound audio URIs by scheme, MIME type, and size before importing
-- Restrict deep link routing to a known path allowlist with a safe fallback to My Sounds
-- Crash when switching tabs mid-playback fixed by ViewModel-owned player state
-- Scrolling-induced ghost playing state fixed by migrating to Compose state-driven rendering
+- Crash when switching tabs while a sound is playing
+- Ghost-playing state when scrolling the list
 
 ### Removed
 - About screen pronunciation block (`/sohs oon boh-TOHN/`) removed alongside the rename to Bomp
@@ -95,13 +91,10 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - KTLint migrated to JLLeitschuh plugin with KTLint 1.5.0
 - Resolved all Kotlin compiler and Gradle DSL deprecation warnings for a clean build log
 - Bundled audio files removed from version control; bottom navigation bar hidden in release builds (Explore tab only appears in debug when audio files are manually placed)
+- Inbound audio URIs from share intents are now validated by scheme, MIME type, and size before importing
 
 #### Fixed
 - `ShareFeature.share` now runs file-system access (`getFile` + first-time `copy` of bundled raw resources) on `Dispatchers.IO`, eliminating a long-standing main-thread disk write that could cause jank the first time a bundled sound was shared
-- `AddButtonEditFlowTest.saveWithValidNameNavigatesBackToLandingWithRenamedExtra` no longer flakes (~25–50% rate). `Intents.intended()` routes through `Espresso.onView(isRoot()).check(...)` when a resumed activity exists, which trips the class-wide ATF run from `AbstractUiTest` against a mid-transition view tree. Switched to inspecting `Intents.getIntents()` directly and matching with plain Kotlin — keeps the recorded-intent assertion without touching the view hierarchy
-- `DataStoreCounterStoreTest` and `DataStoreFirstFlagStoreTest` no longer rely on a fixed 250 ms `Thread.sleep` to wait for fire-and-forget DataStore writes. The wait started losing the race after the androidx.datastore-preferences 1.1.7 → 1.2.1 bump (Counter test failed on Robolectric SDK 23/33). Inject the writeback scope and join its child jobs deterministically before asserting disk state
-- `HomeTabFlowTest.tapPlaySwapsPlayIconToPause` no longer flakes after a fresh install. The test asset was a ~200 ms silent MP3, which let the `isPlaying = true → false` window close before Compose committed the playing-state frame on a starved main thread (post-install codec spin-up + jank). Regenerated as a 5 s silent MP3 (same encoding) so the playing window comfortably outlasts any realistic `prepare()`/recompose latency
-- `HomeTabFlowTest.pinIconButtonMarksSoundAsPinned` and `ExploreTabFlowTest.bottomBarIsVisibleWhenBundledSoundsExist` no longer flake (~1-in-3 across consecutive full suite runs). `waitForIdle()` alone returns before the DataStore-read → `StateFlow`-emit → Compose-render chain finishes seeding the LazyColumn row / bottom-nav bar, so the immediate `performClick`/`assertIsDisplayed` could resolve against a still-empty semantics tree. Replaced with a `waitUntil { onAllNodes(...).fetchSemanticsNodes().isNotEmpty() }` gate before the action, matching the pattern already used by neighbouring tests (`tapPlaySwapsPlayIconToPause`, `swipeRightPinsACustomSound`)
 
 #### Removed
 - Removed `techstack.md` and its companion `techstack.yml` (StackShare.io config that broke after the repo rename to `bomp` and was no longer maintained — last meaningful update predated the v2.0 Compose rewrite)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,6 +79,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig = signingConfigs.release
             buildConfigField "String", "DEBUG_ROOT_DIR_NAME", "\"\""
+            ndk {
+                debugSymbolLevel 'FULL'
+            }
         }
     }
 

--- a/store-listing/en-US/changelog-5.txt
+++ b/store-listing/en-US/changelog-5.txt
@@ -1,11 +1,13 @@
 Welcome to Bomp.
 
-Your personal collection of voices. The ones that matter, always close: your mom's laugh, the boss's catchphrase, the voice note from a friend that always makes you smile.
+Your personal collection of voices — the ones that matter, always close: your mom's laugh, that inside joke you all share, the voice note from a friend that never fails to crack you up.
 
-▸ Save the voice note (from WhatsApp, Telegram, or wherever).
-▸ Name it your way — the name only you'd get.
-▸ Bomp it when you need it: you first, share later if you want.
+▸ Save the voice note (WhatsApp, Telegram, anywhere).
+▸ Give it the name only you'd get.
+▸ Bomp it whenever: you first, share later if you want.
 
-Truly private: your voice notes live on your phone. No servers, no analysis.
+Search, favorites, and backup to your Google Drive.
 
-Free, open source, AGPL-3.0.
+No signup, no email, no phone number. Your collection, yours.
+
+Free and open source, AGPL-3.0.

--- a/store-listing/es-AR/changelog-5.txt
+++ b/store-listing/es-AR/changelog-5.txt
@@ -1,11 +1,13 @@
 Bienvenido a Bomp.
 
-Tu colección personal de voces. Las que te importan, siempre con vos: la risa de tu vieja, la frase del jefe, el audio del amigo que te hace reír sin falta.
+Tu colección personal de voces — las que te importan, siempre contigo: la risa de mamá, ese chiste interno de siempre, el audio del amigo que te hace reír sin falta.
 
-▸ Guardá el audio (de WhatsApp, Telegram o donde sea).
-▸ Apodalo a tu manera — el apodo que solo vos entendés.
-▸ Bompealo cuando lo necesites: primero para vos, después para mandar si querés.
+▸ Guarda el audio (WhatsApp, Telegram, donde sea).
+▸ Ponle el nombre que solo tú entiendes.
+▸ Bompéalo cuando quieras: primero para ti, después para mandar.
 
-Privado de verdad: tus audios viven en tu teléfono. Cero servidor, cero análisis.
+Búsqueda, favoritos y respaldo en tu Google Drive.
 
-Software libre, código abierto, AGPL-3.0.
+Sin registro, sin email, sin número de teléfono. Tu colección, tuya.
+
+Libre y abierto, AGPL-3.0.


### PR DESCRIPTION
### Summary
- Rewrite v2.0.0 *What's New* in both locales (en-US + es-AR). Drops the "no servers / cero servidor" overclaim — Auto Backup + Firebase ship in v2 and that line contradicts `data-safety.html`. ES moves to LatAm-neutral (tú, sin voseo) so the same copy works across the region. Both locales fit under Play's 500-char cap (498 / 493).
- Purge intra-v2 entries from `## [unreleased] (v2.0.0)` — bugs introduced and resolved inside v2 don't get a public Fixed line per the CHANGELOG rule. Moves URI validation + share-intent Snackbar into Changed where they belong.
- Enable `ndk.debugSymbolLevel FULL` on the release build type. No-op today (transitive `.so`s come stripped) but future-proofs the AAB so any native lib shipping debug info gets symbols embedded for Play Console.

### Code review tips
- `app/build.gradle`: `ndk { debugSymbolLevel 'FULL' }` only affects release. AAB should still build clean — verify next bundle output.
- Store-listing copy: cross-check vs `../push-me-backlog/docs/brand-dna.md` and `../push-me-ghpages/{privacy-policy,data-safety}.html` — manifesto-style cierre invariant; "respaldo en tu Google Drive" doesn't overclaim ("imborrable" still avoided).
- `CHANGELOG.md` Fixed-block trimming relies on the "no entry for intra-cycle regressions" rule. Two surviving Fixed entries (tab-switch crash, scroll ghost-state) describe bugs that existed before v2 even if the fix landed in v2.

### Already tested
- [x] Read-aloud check on both locales (native register, no calques, brand-DNA-aligned)
- [x] Char count vs Play 500-char cap (498 en-US, 493 es-AR)
- [x] `./gradlew check -x test` clean locally
- [ ] AAB upload to Play Console to confirm symbol parsing — deferred until v2.0.0 release cut (no-op today)