### PR TITLE
fix(app): restore distinct gray launcher icon on debug builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 ## \[unreleased] (v2.1.0)
 
+### For nerds 🤓
+
+#### Fixed
+- Debug builds now show a gray launcher icon background again, restoring the visual distinction from release builds that was lost when the icon was modernized to an adaptive icon
+
 ## \[v2.0.0] - 2026-05-07
 
 ### Added

--- a/app/src/debug/res/values/app_ic_launcher_background.xml
+++ b/app/src/debug/res/values/app_ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="app_ic_launcher_background">#9E9E9E</color>
+</resources>


### PR DESCRIPTION
### Summary

- Restores the pre-v2.0.0 visual distinction between debug and release launcher icons (gray vs. acid) so a developer can tell at a glance which variant is installed.
- v2.0.0 modernized the main icon to an adaptive icon (`mipmap-anydpi-v26/app_ic_launcher.xml`) but never added a parallel override under `app/src/debug/res/`, so on API 26+ debug builds were inheriting the colored release icon.
- Single-file fix: a debug-only `values/app_ic_launcher_background.xml` overrides the icon background color to Material gray 500 (`#9E9E9E`); Android's resource merger applies it through the existing adaptive-icon XML — `main` stays untouched.

### Code review tips

- The fix relies on Android's resource merge: same-name resource in `app/src/debug/res/` overrides `app/src/main/res/` only for the debug build type. Adaptive icon foreground/monochrome are intentionally not overridden — only the background color flips.
- Foreground stays `#0B0B0C` (near-black) → contrast against `#9E9E9E` ≈ 5.4:1, above WCAG 2.2 AA non-text threshold (3:1). Triangle stays legible on the gray background.
- Stale pre-Bomp PNGs in `app/src/debug/res/mipmap-*/app_ic_launcher.png` are intentionally **not touched**: they only fire on API 23–25 (<1% today), are already visually distinct from release, and regenerating them would be churn for negligible coverage.
- CHANGELOG entry sits under `### For nerds 🤓 → #### Fixed` since the regression was contributor-only (debug builds), not user-visible.

### Already tested

- [x] `./gradlew check -x test` (detekt + ktlint + spotless + Android lint) — green
- [x] `./gradlew test` (unit tests) — green
- [x] `./gradlew app:assembleDebug` + `adb install -r` on a connected device → debug shows gray icon, release (already installed, untouched, coexists via `applicationIdSuffix ".debug"`) still shows acid yellow-green
- [ ] Themed icon mode (Pixel Launcher Android 13+) — expected to look identical for both variants because monochrome is the same; debug/release distinction in themed mode relies on the package name, not the icon