### PR TITLE
feat(home): use Short snackbar duration when dismissing the welcome sticker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 ## \[unreleased] (v2.1.0)
 
+### Changed
+- Shortened the welcome-dismissal snackbar from 10 s to 4 s so the feedback no longer lingers; user-deleted sounds keep the longer Undo window
+
 ## \[v2.0.0] - 2026-05-07
 
 ### Added

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -256,7 +256,7 @@ private fun SnackbarEffects(
             snackbarHostState.showSnackbar(
                 message = message,
                 actionLabel = undoLabel,
-                duration = SnackbarDuration.Long,
+                duration = deletionSnackbarDuration(event.sound),
             )
         when (result) {
             SnackbarResult.ActionPerformed -> viewModel.restoreSound()
@@ -427,3 +427,8 @@ private fun SoundsList(
         }
     }
 }
+
+// Welcome dismissal is a low-stakes "got it, move on" interaction — Short keeps it from lingering.
+// User-deleted sounds are destructive and need Long so Undo stays reachable.
+internal fun deletionSnackbarDuration(sound: Sound): SnackbarDuration =
+    if (isWelcomeSticker(sound)) SnackbarDuration.Short else SnackbarDuration.Long

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/DeletionSnackbarDurationTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/DeletionSnackbarDurationTest.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home
+
+import androidx.compose.material3.SnackbarDuration
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+internal class DeletionSnackbarDurationTest {
+    @Test
+    fun `returns Short for the welcome sticker so dismissal feedback is not lingering`() {
+        val welcome = Sound(name = "Welcome", rawRes = R.raw.app_welcome_sticker)
+
+        val duration = deletionSnackbarDuration(welcome)
+
+        assertThat(duration).isEqualTo(SnackbarDuration.Short)
+    }
+
+    @Test
+    fun `returns Long for a user-created sound so Undo is reachable after destructive delete`() {
+        val userSound = Sound(name = "Abrazo", file = "/audio/abrazo.mp3")
+
+        val duration = deletionSnackbarDuration(userSound)
+
+        assertThat(duration).isEqualTo(SnackbarDuration.Long)
+    }
+}


### PR DESCRIPTION
### Summary
- Shortens the welcome-sticker dismissal snackbar from `SnackbarDuration.Long` (10 s) to `SnackbarDuration.Short` (4 s) so the "Welcome dismissed" feedback stops lingering on screen
- User-deleted sounds keep `Long` because the snackbar carries the only Undo affordance for a destructive action — 4 s is too short to read + reach Undo
- Decision is encapsulated in a new `internal fun deletionSnackbarDuration(sound: Sound): SnackbarDuration` helper at the bottom of `LandingScreen.kt`, wired into `SnackbarEffects`

### Code review tips
- The duration branch reuses the existing `isWelcomeSticker(event.sound)` check that already drives the message branch — same predicate, same call-site, no new state to read
- Behavior change is gated by a single helper; check that the test asserts both sides (welcome → Short, user-created → Long) so a future flip in either direction breaks the test deliberately

### Already tested
- [x] `./gradlew check -x test` (KtLint + Detekt + Spotless + Android Lint)
- [x] `./gradlew test` (full JVM/Robolectric suite)
- [x] New `DeletionSnackbarDurationTest` (TDD: RED then GREEN)
- [x] `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=...WelcomeStickerFlowTest` on `Android_14_API_34` AVD — all 3 tests pass, including `swipeLeftOnWelcomeShowsUndoSnackbarAndDemotesToBottomOnUndo` which exercises the exact snackbar