### PR TITLE
feat(about): add Terms of Service link to Legal & Privacy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ model/src/debug/res/raw/*.ogg
 
 ### Gradle files
 .gradle/
+.kotlin/
 build/
 gradle/gradle-daemon-jvm.properties
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 ## \[unreleased] (v2.0.1)
 
+### Added
+- Terms of Service link in the About screen's "Legal & Privacy" section, opening the published page with `?hl=` matched to the device locale (es-AR, es-419, es-ES, en, pt-BR)
+
 ### Fixed
 - Optimized app size by filtering AAB locales to `en` and `es` only via AGP 9 `androidResources.localeFilters`; transitive dependencies (Material, AndroidX, Firebase, Play Services) no longer ship ~80 unused translations in the bundle
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 ### For nerds 🤓
 
+#### Changed
+- About screen's external Legal & Privacy links now open extensionless URLs (`/privacy-policy`, `/data-safety`, `/terms-of-service`) — GitHub Pages serves the same content under both forms, so this is a cosmetic cleanup with no destination or behavior change
+
 #### Fixed
 - Debug builds now show a gray launcher icon background again, restoring the visual distinction from release builds that was lost when the icon was modernized to an adaptive icon
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/AppIcons.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/AppIcons.kt
@@ -192,6 +192,59 @@ public object AppIcons {
             }.build()
     }
 
+    val Handshake: ImageVector by lazy {
+        ImageVector
+            .Builder(
+                name = "Handshake",
+                defaultWidth = 24.dp,
+                defaultHeight = 24.dp,
+                viewportWidth = 24f,
+                viewportHeight = 24f,
+            ).apply {
+                path(fill = SolidColor(Color.Black)) {
+                    moveTo(16.48f, 10.41f)
+                    curveToRelative(-0.39f, 0.39f, -1.04f, 0.39f, -1.43f, 0f)
+                    lineToRelative(-4.47f, -4.46f)
+                    lineToRelative(-7.05f, 7.04f)
+                    lineToRelative(-0.66f, -0.63f)
+                    curveToRelative(-1.17f, -1.17f, -1.17f, -3.07f, 0f, -4.24f)
+                    lineToRelative(4.24f, -4.24f)
+                    curveToRelative(1.17f, -1.17f, 3.07f, -1.17f, 4.24f, 0f)
+                    lineTo(16.48f, 9f)
+                    curveTo(16.87f, 9.39f, 16.87f, 10.02f, 16.48f, 10.41f)
+                    close()
+                    moveTo(17.18f, 8.29f)
+                    curveToRelative(0.78f, 0.78f, 0.78f, 2.05f, 0f, 2.83f)
+                    curveToRelative(-1.27f, 1.27f, -2.61f, 0.22f, -2.83f, 0f)
+                    lineToRelative(-3.76f, -3.76f)
+                    lineToRelative(-5.57f, 5.57f)
+                    curveToRelative(-0.39f, 0.39f, -0.39f, 1.02f, 0f, 1.41f)
+                    curveToRelative(0.39f, 0.39f, 1.02f, 0.39f, 1.42f, 0f)
+                    lineToRelative(4.62f, -4.62f)
+                    lineToRelative(0.71f, 0.71f)
+                    lineToRelative(-4.62f, 4.62f)
+                    curveToRelative(-0.39f, 0.39f, -0.39f, 1.02f, 0f, 1.41f)
+                    curveToRelative(0.39f, 0.39f, 1.02f, 0.39f, 1.42f, 0f)
+                    lineToRelative(4.62f, -4.62f)
+                    lineToRelative(0.71f, 0.71f)
+                    lineToRelative(-4.62f, 4.62f)
+                    curveToRelative(-0.39f, 0.39f, -0.39f, 1.02f, 0f, 1.41f)
+                    curveToRelative(0.39f, 0.39f, 1.02f, 0.39f, 1.41f, 0f)
+                    lineToRelative(4.62f, -4.62f)
+                    lineToRelative(0.71f, 0.71f)
+                    lineToRelative(-4.62f, 4.62f)
+                    curveToRelative(-0.39f, 0.39f, -0.39f, 1.02f, 0f, 1.41f)
+                    curveToRelative(0.39f, 0.39f, 1.02f, 0.39f, 1.41f, 0f)
+                    lineToRelative(8.32f, -8.34f)
+                    curveToRelative(1.17f, -1.17f, 1.17f, -3.07f, 0f, -4.24f)
+                    lineToRelative(-4.24f, -4.24f)
+                    curveToRelative(-1.15f, -1.15f, -3.01f, -1.17f, -4.18f, -0.06f)
+                    lineTo(17.18f, 8.29f)
+                    close()
+                }
+            }.build()
+    }
+
     val PrivacyTip: ImageVector by lazy {
         ImageVector
             .Builder(

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreen.kt
@@ -93,6 +93,7 @@ fun AboutScreen(onBack: () -> Unit) {
     val sourceUrl = stringResource(R.string.app_about_source_url)
     val privacyPolicyUrl = stringResource(R.string.app_about_privacy_policy_url)
     val dataSafetyUrl = stringResource(R.string.app_about_data_safety_url)
+    val termsOfServiceUrl = stringResource(R.string.app_about_terms_of_service_url)
     val cafecitoUrl = stringResource(R.string.app_about_gratitude_cafecito_url)
     val kofiUrl = stringResource(R.string.app_about_gratitude_kofi_url)
     val noBrowserMessage = stringResource(R.string.app_about_error_no_browser)
@@ -197,6 +198,13 @@ fun AboutScreen(onBack: () -> Unit) {
                 onDataSafetyClick = {
                     if (openUrl(context, dataSafetyUrl.withDeviceHl())) {
                         AnalyticsTrackerProvider.get(context.applicationContext).log(AnalyticsEvent.AboutDataSafetyOpen)
+                    } else {
+                        scope.launch { snackbarHostState.showSnackbar(noBrowserMessage) }
+                    }
+                },
+                onTermsOfServiceClick = {
+                    if (openUrl(context, termsOfServiceUrl.withDeviceHl())) {
+                        AnalyticsTrackerProvider.get(context.applicationContext).log(AnalyticsEvent.AboutTermsOfServiceOpen)
                     } else {
                         scope.launch { snackbarHostState.showSnackbar(noBrowserMessage) }
                     }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/LegalAndPrivacySection.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/LegalAndPrivacySection.kt
@@ -31,6 +31,7 @@ internal fun LegalAndPrivacySection(
     onLicenseClick: () -> Unit,
     onPrivacyPolicyClick: () -> Unit,
     onDataSafetyClick: () -> Unit,
+    onTermsOfServiceClick: () -> Unit,
     onSourceClick: () -> Unit,
 ) {
     Column(
@@ -67,6 +68,12 @@ internal fun LegalAndPrivacySection(
                     label = stringResource(R.string.app_about_data_safety),
                     isExternal = true,
                     onClick = onDataSafetyClick,
+                )
+                LegalListItem(
+                    icon = AppIcons.Handshake,
+                    label = stringResource(R.string.app_about_terms_of_service),
+                    isExternal = true,
+                    onClick = onTermsOfServiceClick,
                 )
                 LegalListItem(
                     icon = AppIcons.Code,

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -45,6 +45,7 @@
     <string name="app_about_legal_section_title">Legal y privacidad</string>
     <string name="app_about_privacy_policy">Política de privacidad</string>
     <string name="app_about_data_safety">Seguridad de datos</string>
+    <string name="app_about_terms_of_service">Términos del servicio</string>
     <string name="app_about_open_in_browser">Se abre en el navegador</string>
     <string name="app_about_error_no_browser">No se pudo abrir el navegador</string>
     <string name="app_about_gratitude_eyebrow">¿Te alegró el día?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,9 +49,9 @@
     <string name="app_about_terms_of_service">Terms of Service</string>
     <string name="app_about_open_in_browser">Opens in browser</string>
     <string name="app_about_error_no_browser">Couldn\'t open in a browser</string>
-    <string name="app_about_privacy_policy_url" translatable="false">https://barriosnahuel.github.io/bomp/privacy-policy.html</string>
-    <string name="app_about_data_safety_url" translatable="false">https://barriosnahuel.github.io/bomp/data-safety.html</string>
-    <string name="app_about_terms_of_service_url" translatable="false">https://barriosnahuel.github.io/bomp/terms-of-service.html</string>
+    <string name="app_about_privacy_policy_url" translatable="false">https://barriosnahuel.github.io/bomp/privacy-policy</string>
+    <string name="app_about_data_safety_url" translatable="false">https://barriosnahuel.github.io/bomp/data-safety</string>
+    <string name="app_about_terms_of_service_url" translatable="false">https://barriosnahuel.github.io/bomp/terms-of-service</string>
     <string name="app_about_gratitude_eyebrow">Brightened your day?</string>
     <string name="app_about_gratitude_title">Buy me a virtual coffee.</string>
     <string name="app_about_gratitude_body">Bomp is free and ad-free.\nIf you enjoyed it and want to say thanks, you can do it with a virtual coffee. Either way, using it and sharing it already counts — thank you!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,10 +46,12 @@
     <string name="app_about_legal_section_title">Legal &amp; Privacy</string>
     <string name="app_about_privacy_policy">Privacy Policy</string>
     <string name="app_about_data_safety">Data Safety</string>
+    <string name="app_about_terms_of_service">Terms of Service</string>
     <string name="app_about_open_in_browser">Opens in browser</string>
     <string name="app_about_error_no_browser">Couldn\'t open in a browser</string>
     <string name="app_about_privacy_policy_url" translatable="false">https://barriosnahuel.github.io/bomp/privacy-policy.html</string>
     <string name="app_about_data_safety_url" translatable="false">https://barriosnahuel.github.io/bomp/data-safety.html</string>
+    <string name="app_about_terms_of_service_url" translatable="false">https://barriosnahuel.github.io/bomp/terms-of-service.html</string>
     <string name="app_about_gratitude_eyebrow">Brightened your day?</string>
     <string name="app_about_gratitude_title">Buy me a virtual coffee.</string>
     <string name="app_about_gratitude_body">Bomp is free and ad-free.\nIf you enjoyed it and want to say thanks, you can do it with a virtual coffee. Either way, using it and sharing it already counts — thank you!</string>

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenAnalyticsTest.kt
@@ -115,6 +115,19 @@ internal class AboutScreenAnalyticsTest : AbstractRobolectricTest() {
     }
 
     @Test
+    fun `tap on terms of service item emits about_terms_of_service_open`() {
+        composeTestRule.setContent { AppTheme { AboutScreen(onBack = {}) } }
+
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.app_about_terms_of_service))
+            .performScrollTo()
+            .performClick()
+        composeTestRule.waitForIdle()
+
+        fake.assertEmitted("about_terms_of_service_open")
+    }
+
+    @Test
     fun `tap on branding audio button does not emit before the SoundPool finishes loading`() {
         composeTestRule.setContent { AppTheme { AboutScreen(onBack = {}) } }
 

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenTest.kt
@@ -321,6 +321,6 @@ internal class AboutScreenTest : AbstractRobolectricTest() {
     }
 
     private companion object {
-        const val EXTERNAL_LEGAL_ITEMS = 3
+        const val EXTERNAL_LEGAL_ITEMS = 4
     }
 }

--- a/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsEvent.kt
+++ b/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsEvent.kt
@@ -110,6 +110,9 @@ sealed class AnalyticsEvent(
     /** External Data Safety link followed from About. The user leaves the app. */
     object AboutDataSafetyOpen : AnalyticsEvent(name = "about_data_safety_open", hasFirstVariant = true)
 
+    /** External Terms of Service link followed from About. The user leaves the app. */
+    object AboutTermsOfServiceOpen : AnalyticsEvent(name = "about_terms_of_service_open", hasFirstVariant = true)
+
     /**
      * Brand audio played from the About hero section. NOTE: separate surface from the home-grid
      * Sticker Cero introduced in v2.0.0 — that one emits its own [WelcomeStickerPlay] event.

--- a/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsCoverageMatrixTest.kt
+++ b/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsCoverageMatrixTest.kt
@@ -67,6 +67,7 @@ internal class AnalyticsCoverageMatrixTest {
                 "AboutSourceOpen",
                 "AboutPrivacyPolicyOpen",
                 "AboutDataSafetyOpen",
+                "AboutTermsOfServiceOpen",
                 "AboutBrandingAudioPlay",
                 "AboutGratitudeCafecitoOpen",
                 "AboutGratitudeKofiOpen",


### PR DESCRIPTION
### Summary
- New "Terms of Service" row in About → Legal & Privacy, mirroring Privacy Policy / Data Safety: external link with locale-matched `?hl=` query param.
- New `AppIcons.Handshake` (hand-rolled inline `ImageVector` from the canonical Material Icons `social/handshake` path) — keeps the dep graph on `material-icons-core` only, no `material-icons-extended` bloat.
- New analytics event `about_terms_of_service_open` (`hasFirstVariant = true`) wired through `AnalyticsTrackerProvider`, registered in the regression matrix.
- Drops the `.html` suffix from all three Legal & Privacy URLs (`/privacy-policy`, `/data-safety`, `/terms-of-service`); GH Pages serves the same content under both forms.

### Code review tips
- `LegalAndPrivacySection.kt` adds a parameter to its public-internal signature (`onTermsOfServiceClick`); blast radius is the single call-site in `AboutScreen.kt` — confirmed via grep, no other consumers.
- `AboutScreenTest.EXTERNAL_LEGAL_ITEMS` bumped 3 → 4. The assertion counts `contentDescription = app_about_open_in_browser` so it's icon-agnostic.
- Strings: `app_about_terms_of_service_url` is `translatable="false"`; the runtime appends `?hl=` via `withDeviceHl()` (5 locales: es-AR, es-419, es-ES, en, pt-BR). Verified `?hl=es-AR` works on the extensionless URL.
- The destination page on GH Pages is **not in this PR** — it ships from `push-me-ghpages` separately. Until that page is live, taps to ToS will 404 in production. PP and DS already exist and respond 200 on both URL forms.

### Already tested
- [x] `./gradlew check -x test` (KtLint, Detekt, Spotless, Android Lint)
- [x] `./gradlew test` (453 tests, including the new `tap on terms of service item emits about_terms_of_service_open`)
- [x] `curl -L` against the live extensionless URLs for PP and DS — both 200, with and without `?hl=`
- [ ] Instrumented suite on emulator (`app:connectedDebugAndroidTest`)
- [ ] Manual emulator render in light + dark mode