### PR TITLE
fix(share): no fatal crash when FileProvider rejects audio path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 ## \[unreleased] (v2.0.1)
 
 ### Fixed
+- Sharing a Bomp whose audio path can't be resolved by the FileProvider no longer crashes the app; the failure is reported to the user with a Toast and tracked as a non-fatal so it can be investigated
 - Optimized app size by filtering AAB locales to `en` and `es` only via AGP 9 `androidResources.localeFilters`; transitive dependencies (Material, AndroidX, Firebase, Play Services) no longer ship ~80 unused translations in the bundle
 
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
@@ -8,12 +8,14 @@ package com.github.barriosnahuel.vossosunboton.feature.share
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.widget.Toast
 import androidx.core.content.FileProvider
 import com.github.barriosnahuel.vossosunboton.BuildConfig
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsEvent
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsUserProperty
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.commons.file.copy
 import com.github.barriosnahuel.vossosunboton.commons.file.getFile
 import com.github.barriosnahuel.vossosunboton.model.Sound
@@ -56,6 +58,12 @@ private class ShareFeatureImpl : ShareFeature {
         // both touch the file system. Run that part on IO; startActivity + analytics stay on the caller's
         // Main dispatcher because Android's chooser expects the launching call on the UI thread.
         val buttonFileContentUri = withContext(Dispatchers.IO) { getContentUriForSound(sound, context) }
+        if (buttonFileContentUri == null) {
+            // FileProvider rejected the Sound's path (e.g. legacy persisted absolute path outside the configured root).
+            // Surface a non-blocking message to the user; the failure is already tracked as a non-fatal in getContentUriForSound.
+            Toast.makeText(context, R.string.app_share_feedback_unshareable, Toast.LENGTH_LONG).show()
+            return
+        }
         val shareIntent = Intent()
         shareIntent.action = Intent.ACTION_SEND
         shareIntent.type = "audio/*"
@@ -108,7 +116,8 @@ private class ShareFeatureImpl : ShareFeature {
         return try {
             FileProvider.getUriForFile(context, authority, fileForSharing)
         } catch (e: IllegalArgumentException) {
-            throw IllegalStateException("Button content uri couldn't be created.", e)
+            Tracker.track(RuntimeException("Couldn't create FileProvider URI for sound: ${sound.file}", e))
+            null
         }
     }
 }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">Bomp</string>
 
     <string name="app_share_chooser_title">Compartir vía</string>
+    <string name="app_share_feedback_unshareable">No se pudo compartir este Bomp. Nahu ya se enteró y lo va a investigar.</string>
     <string name="app_undo">Deshacer!</string>
     <string name="app_feedback_audio_deleted">Audio borrado</string>
     <string name="app_feedback_button_saved">¡%1$s es tuyo!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">Bomp</string>
 
     <string name="app_share_chooser_title">Share vía</string>
+    <string name="app_share_feedback_unshareable">Couldn\'t share this Bomp. Nahu\'s already on it.</string>
     <string name="app_undo">Undo!</string>
     <string name="app_feedback_audio_deleted">Audio deleted</string>
     <string name="app_feedback_button_saved">%1$s is now yours!</string>

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
@@ -19,12 +19,16 @@ import com.github.barriosnahuel.vossosunboton.commons.android.analytics.Analytic
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsUserProperty
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.FakeAnalyticsTracker
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.spyk
+import io.mockk.unmockkAll
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
@@ -44,6 +48,7 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
     @After
     fun tearDownAnalytics() {
         AnalyticsTrackerProvider.setForTest(null)
+        unmockkAll()
     }
 
     @Test
@@ -80,6 +85,31 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
 
         fake.assertNotEmitted("share")
         assertThat(fake.userProperties[AnalyticsUserProperty.LIFETIME_SHARES]).isNull()
+    }
+
+    @Test
+    fun `share when FileProvider rejects the file does not crash and tracks a non-fatal`() {
+        val sound = givenASoundWithUri()
+        val mockedContext = spyk<Context>(ApplicationProvider.getApplicationContext<Context>())
+
+        mockkStatic(FileProvider::class)
+        every { FileProvider.getUriForFile(mockedContext, any(), any()) } throws
+            IllegalArgumentException("Failed to find configured root that contains /data/local/tmp/external/x.mp3")
+
+        mockkObject(Tracker)
+        val tracked = slot<Throwable>()
+        every { Tracker.track(capture(tracked)) } answers { nothing }
+        every { mockedContext.startActivity(any()) } answers { nothing }
+
+        runBlocking { ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
+
+        verify(exactly = 1) { Tracker.track(any()) }
+        assertThat(tracked.captured).isInstanceOf(RuntimeException::class.java)
+        assertThat(tracked.captured.cause).isInstanceOf(IllegalArgumentException::class.java)
+
+        fake.assertNotEmitted("share")
+        assertThat(fake.userProperties[AnalyticsUserProperty.LIFETIME_SHARES]).isNull()
+        verify(exactly = 0) { mockedContext.startActivity(any()) }
     }
 
     @Test


### PR DESCRIPTION
### Summary
- `ShareFeatureImpl.getContentUriForSound` no longer rethrows `IllegalArgumentException` from `FileProvider.getUriForFile` as a fatal `IllegalStateException`; it now reports a non-fatal via `Tracker.track` and returns `null`.
- `ShareFeature.share` early-returns with a Toast (`app_share_feedback_unshareable`) when the URI is `null` — no chooser launches, no `share` analytics event fires, no `LIFETIME_SHARES` increment.
- Crashlytics shows this hitting in production for the bundled welcome sticker; diagnosis points to environmental causes (virtualized Android emulators or custom-storage ROMs) where `getExternalFilesDir(Music)` returns `null` and the process cwd is non-`/`. Not data corruption.
- New en + es-AR strings keep the heart-first voice ("Nahu's already on it." / "Nahu ya se enteró y lo va a investigar.") instead of pushing the user toward a fix that doesn't apply for bundled sounds.

### Code review tips
- The Toast is shown directly from `ShareFeature.share` after the `withContext(Dispatchers.IO)` boundary — same pattern as the existing `startActivity(chooser)` call in that function, so no architectural break, but worth a glance to confirm the dispatcher/context interaction.
- Test asserts: no fatal, `Tracker.track` invoked once with `RuntimeException` wrapping `IllegalArgumentException`, no `share` event, no `LIFETIME_SHARES`, no `startActivity`. It does not assert the Toast text — Robolectric shadows Toast as a no-op.
- Added `unmockkAll()` to `ShareFeatureTest.tearDownAnalytics` to cover the new `mockkObject(Tracker)` — re-verified all 12 tests in the class pass after the change.
- Out of scope (tracked separately): `ActivityNotFoundException` and `IOException` paths still leak past `LandingScreen.kt:171` because the caller has no `try/catch` — that's the next iteration.

### Already tested
- [x] `./gradlew test` — full unit suite green (458 tests)
- [x] `./gradlew check -x test` — detekt + ktlint + Spotless + Android Lint all green
- [x] New TDD test reproduces the production crash signature (`IllegalArgumentException at FileProvider...`) and now passes after the fix
- [ ] Local UI test suite (`app:connectedDebugAndroidTest`) NOT run — change touches intent creation but no Composable. Recommended before merge if you want UI regression coverage.