### PR TITLE
fix: catch share/playback/URI errors with accessible user feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 ## \[unreleased] (v2.0.1)
 
 ### Fixed
-- Sharing a Bomp whose audio path can't be resolved by the FileProvider no longer crashes the app; the failure is reported to the user with a Toast and tracked as a non-fatal so it can be investigated
+- Sharing a Bomp whose audio path can't be resolved by the FileProvider no longer crashes the app; the failure is reported to the user with a Snackbar and tracked as a non-fatal so it can be investigated
+- Sharing a Bomp no longer crashes the app when no installed app handles audio sharing, when external storage can't be written, or when the Sound has corrupt data — each case shows a tailored Snackbar and is tracked as a non-fatal
+- Tapping play on a Bomp no longer crashes the app if MediaPlayer rejects the start call; the playback error Snackbar is shown instead and a non-fatal is tracked
+- Saving a new Bomp from a revoked or unreadable inbound URI now shows a tailored "couldn't read the audio" Snackbar instead of failing silently; the underlying ContentResolver failure is tracked as a non-fatal
 - Optimized app size by filtering AAB locales to `en` and `es` only via AGP 9 `androidResources.localeFilters`; transitive dependencies (Material, AndroidX, Firebase, Play Services) no longer ship ~80 unused translations in the bundle
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 ## \[unreleased] (v2.0.1)
 
 ### Fixed
+- Sharing a Bomp whose audio path can't be resolved by the FileProvider no longer crashes the app; the failure is reported to the user with a Toast and tracked as a non-fatal so it can be investigated
 - Optimized app size by filtering AAB locales to `en` and `es` only via AGP 9 `androidResources.localeFilters`; transitive dependencies (Material, AndroidX, Firebase, Play Services) no longer ship ~80 unused translations in the bundle
 
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
@@ -11,6 +11,7 @@ import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.provider.OpenableColumns
 import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.commons.file.copy
 import com.github.barriosnahuel.vossosunboton.commons.file.getFile
 import com.github.barriosnahuel.vossosunboton.model.Sound
@@ -57,8 +58,10 @@ private class AddButtonFeatureImpl : AddButtonFeature {
         return GlobalScope.async(Dispatchers.IO) {
             var feedbackMessage = R.string.app_feedback_generic_error_contact_support
             val parsed = Uri.parse(uri)
-            if (validateAudioUri(context, parsed) != ValidationResult.Ok) {
-                return@async feedbackMessage
+            when (validateAudioUri(context, parsed)) {
+                ValidationResult.Ok -> Unit
+                ValidationResult.Rejected -> return@async feedbackMessage
+                ValidationResult.Unreadable -> return@async R.string.app_addbutton_feedback_uri_unreadable
             }
             // getFile() resolves context.getExternalFilesDir(...), which performs disk I/O —
             // keep it inside the IO dispatcher so StrictMode does not flag it on the main thread.
@@ -116,7 +119,14 @@ private class AddButtonFeatureImpl : AddButtonFeature {
         uri: Uri,
     ): ValidationResult {
         val resolver = context.contentResolver
-        val mime = resolver.getType(uri)
+        val mimeResult = runCatching { resolver.getType(uri) }
+        if (mimeResult.isFailure) {
+            Tracker.track(
+                RuntimeException("ContentResolver.getType failed for inbound URI", mimeResult.exceptionOrNull()),
+            )
+            return ValidationResult.Unreadable
+        }
+        val mime = mimeResult.getOrNull()
         val size = resolveSize(resolver, uri)
         val rejection =
             when {
@@ -154,6 +164,8 @@ private class AddButtonFeatureImpl : AddButtonFeature {
         data object Ok : ValidationResult()
 
         data object Rejected : ValidationResult()
+
+        data object Unreadable : ValidationResult()
     }
 
     private companion object {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
@@ -118,6 +118,19 @@ private class AddButtonFeatureImpl : AddButtonFeature {
         context: Context,
         uri: Uri,
     ): ValidationResult {
+        // Scheme check first: a rejected scheme (e.g. http://) shouldn't trigger ContentResolver work
+        // that may itself blow up on the unsupported URI and confuse the Unreadable vs Rejected metric.
+        if (uri.scheme !in ALLOWED_SCHEMES) {
+            Timber.w("Rejected inbound URI: scheme=%s", uri.scheme)
+            return ValidationResult.Rejected
+        }
+        return validateContentUri(context, uri)
+    }
+
+    private fun validateContentUri(
+        context: Context,
+        uri: Uri,
+    ): ValidationResult {
         val resolver = context.contentResolver
         val mimeResult = runCatching { resolver.getType(uri) }
         if (mimeResult.isFailure) {
@@ -130,7 +143,6 @@ private class AddButtonFeatureImpl : AddButtonFeature {
         val size = resolveSize(resolver, uri)
         val rejection =
             when {
-                uri.scheme !in ALLOWED_SCHEMES -> "scheme=${uri.scheme}"
                 mime == null || !mime.startsWith(AUDIO_MIME_PREFIX) -> "mime=$mime"
                 size == null || size > MAX_AUDIO_BYTES -> "size=$size"
                 else -> null

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerImpl.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerImpl.kt
@@ -60,7 +60,13 @@ internal class PlayerControllerImpl(
 
             listener?.onPlayerStart(sound, durationMs)
             currentSound = sound
-            mediaPlayer.start()
+            try {
+                mediaPlayer.start()
+            } catch (e: IllegalStateException) {
+                Tracker.track(RuntimeException("Media player can't be started for playback.", e))
+                listener?.onPlayerError(sound)
+                return
+            }
             handler.post(progressRunnable)
         }
     }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerImpl.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerImpl.kt
@@ -58,7 +58,6 @@ internal class PlayerControllerImpl(
                 listener?.onPlayerStop(sound, completed = true)
             }
 
-            listener?.onPlayerStart(sound, durationMs)
             currentSound = sound
             try {
                 mediaPlayer.start()
@@ -67,6 +66,10 @@ internal class PlayerControllerImpl(
                 listener?.onPlayerError(sound)
                 return
             }
+            // onPlayerStart fires AFTER start() succeeds so the UI never flips to "playing" when start
+            // is going to throw. Both happen on Main, so the listener still updates before the first
+            // progressRunnable post lands.
+            listener?.onPlayerStart(sound, durationMs)
             handler.post(progressRunnable)
         }
     }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
@@ -62,7 +62,7 @@ private class ShareFeatureImpl : ShareFeature {
         // Resolving the file path and (for bundled sounds, first share only) copying raw resources to disk
         // both touch the file system. Run that part on IO; startActivity + analytics stay on the caller's
         // Main dispatcher because Android's chooser expects the launching call on the UI thread.
-        val resolution = withContext(Dispatchers.IO) { resolveContentUri(sound, context) }
+        val resolution = withContext(Dispatchers.IO) { resolveContentUri(context, sound) }
         return when (resolution) {
             is ShareOutcome.Failure -> resolution.feedback
             is ShareOutcome.Success -> launchChooserAndTrack(context, sound, resolution.value, surface)
@@ -107,18 +107,18 @@ private class ShareFeatureImpl : ShareFeature {
     }
 
     private fun resolveContentUri(
-        sound: Sound,
         context: Context,
+        sound: Sound,
     ): ShareOutcome<Uri> =
-        when (val fileResolution = resolveFileForSharing(sound, context)) {
+        when (val fileResolution = resolveFileForSharing(context, sound)) {
             is ShareOutcome.Failure -> fileResolution
-            is ShareOutcome.Success -> wrapInFileProviderUri(context, fileResolution.value, sound)
+            is ShareOutcome.Success -> wrapInFileProviderUri(context, sound, fileResolution.value)
         }
 
     private fun wrapInFileProviderUri(
         context: Context,
-        file: File,
         sound: Sound,
+        file: File,
     ): ShareOutcome<Uri> =
         try {
             ShareOutcome.Success(FileProvider.getUriForFile(context, authority, file))
@@ -128,8 +128,8 @@ private class ShareFeatureImpl : ShareFeature {
         }
 
     private fun resolveFileForSharing(
-        sound: Sound,
         context: Context,
+        sound: Sound,
     ): ShareOutcome<File> =
         when {
             sound.file != null -> ShareOutcome.Success(getFile(context, sound.file!!))
@@ -137,12 +137,12 @@ private class ShareFeatureImpl : ShareFeature {
                 Tracker.track(RuntimeException("Sound has neither file URI nor raw resource ID: ${sound.name}"))
                 ShareOutcome.Failure(R.string.app_share_feedback_broken_data)
             }
-            else -> resolveBundledFileForSharing(sound, context)
+            else -> resolveBundledFileForSharing(context, sound)
         }
 
     private fun resolveBundledFileForSharing(
-        sound: Sound,
         context: Context,
+        sound: Sound,
     ): ShareOutcome<File> {
         val fileForSharing = getFile(context, sound.name + ".mp3")
         return if (fileForSharing.exists()) {
@@ -150,13 +150,13 @@ private class ShareFeatureImpl : ShareFeature {
             ShareOutcome.Success(fileForSharing)
         } else {
             Timber.d("Packaged audio is gonna be copied to share directory: %s", fileForSharing)
-            copyBundledAudioForSharing(sound, context, fileForSharing)
+            copyBundledAudioForSharing(context, sound, fileForSharing)
         }
     }
 
     private fun copyBundledAudioForSharing(
-        sound: Sound,
         context: Context,
+        sound: Sound,
         fileForSharing: File,
     ): ShareOutcome<File> =
         try {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
@@ -5,10 +5,11 @@
  */
 package com.github.barriosnahuel.vossosunboton.feature.share
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.widget.Toast
+import androidx.annotation.StringRes
 import androidx.core.content.FileProvider
 import com.github.barriosnahuel.vossosunboton.BuildConfig
 import com.github.barriosnahuel.vossosunboton.R
@@ -22,18 +23,22 @@ import com.github.barriosnahuel.vossosunboton.model.Sound
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
+import java.io.File
 import java.io.FileOutputStream
+import java.io.IOException
 
 internal interface ShareFeature {
     /**
      * @param surface canonical screen_name from `CanonicalScreenName` describing where the share originated.
-     * @throws IllegalStateException when any required parameter is `null`
+     * @return `null` when the chooser launched, otherwise an `@StringRes` id with a user-facing
+     *         feedback message that the caller is expected to surface (Snackbar/Toast). Every
+     *         non-null return is paired with a non-fatal recorded via `Tracker.track`.
      */
     suspend fun share(
         context: Context,
         sound: Sound,
         surface: String,
-    )
+    ): Int?
 
     companion object {
         val instance: ShareFeature by lazy { ShareFeatureImpl() }
@@ -51,29 +56,36 @@ private class ShareFeatureImpl : ShareFeature {
         context: Context,
         sound: Sound,
         surface: String,
-    ) {
+    ): Int? {
         Timber.d("Trying to share button: %s", sound.name)
 
         // Resolving the file path and (for bundled sounds, first share only) copying raw resources to disk
         // both touch the file system. Run that part on IO; startActivity + analytics stay on the caller's
         // Main dispatcher because Android's chooser expects the launching call on the UI thread.
-        val buttonFileContentUri = withContext(Dispatchers.IO) { getContentUriForSound(sound, context) }
-        if (buttonFileContentUri == null) {
-            // FileProvider rejected the Sound's path (e.g. legacy persisted absolute path outside the configured root).
-            // Surface a non-blocking message to the user; the failure is already tracked as a non-fatal in getContentUriForSound.
-            Toast.makeText(context, R.string.app_share_feedback_unshareable, Toast.LENGTH_LONG).show()
-            return
+        val resolution = withContext(Dispatchers.IO) { resolveContentUri(sound, context) }
+        return when (resolution) {
+            is UriResolution.Failure -> resolution.feedback
+            is UriResolution.Success -> launchChooserAndTrack(context, sound, resolution.uri, surface)
         }
+    }
+
+    @StringRes
+    private fun launchChooserAndTrack(
+        context: Context,
+        sound: Sound,
+        contentUri: Uri,
+        surface: String,
+    ): Int? {
         val shareIntent = Intent()
         shareIntent.action = Intent.ACTION_SEND
         shareIntent.type = "audio/*"
-        shareIntent.putExtra(Intent.EXTRA_STREAM, buttonFileContentUri)
+        shareIntent.putExtra(Intent.EXTRA_STREAM, contentUri)
         shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
 
         Timber.d(
             "Starting disambiguation window for: %s: contentUri=%s; URI=%s; rawResId=%s;",
             sound.name,
-            buttonFileContentUri,
+            contentUri,
             sound.file,
             sound.rawRes,
         )
@@ -81,43 +93,94 @@ private class ShareFeatureImpl : ShareFeature {
         // Track AFTER the chooser actually launches: if `startActivity` throws (ActivityNotFoundException, OS reject)
         // we want `lifetime_shares` to stay accurate. If the chooser shows but the user cancels there is no reliable
         // callback, so "chooser displayed" remains the canonical share signal — matches Firebase's recommended event.
-        context.startActivity(Intent.createChooser(shareIntent, context.getString(R.string.app_share_chooser_title)))
+        try {
+            context.startActivity(Intent.createChooser(shareIntent, context.getString(R.string.app_share_chooser_title)))
+        } catch (e: ActivityNotFoundException) {
+            Tracker.track(RuntimeException("No activity available to handle audio share intent", e))
+            return R.string.app_share_feedback_no_app_for_audio
+        }
 
         val tracker = AnalyticsTrackerProvider.get(context.applicationContext)
         tracker.log(AnalyticsEvent.Share(surface = surface))
         val newCount = tracker.incrementCounter(AnalyticsUserProperty.LIFETIME_SHARES)
         tracker.setUserProperty(AnalyticsUserProperty.LIFETIME_SHARES, newCount.toString())
+        return null
     }
 
-    private fun getContentUriForSound(
+    private fun resolveContentUri(
         sound: Sound,
         context: Context,
-    ): Uri? {
-        val fileForSharing =
-            when (sound.file) {
-                null -> {
-                    check(sound.rawRes != 0) { "Either file URI or raw resource ID must exist on a given sound" }
-
-                    val rawResourceInputStream = context.resources.openRawResource(sound.rawRes)
-
-                    val fileForSharing = getFile(context, sound.name + ".mp3")
-                    if (fileForSharing.exists()) {
-                        Timber.d("Packaged audio already copied to share directory: %s", fileForSharing)
-                    } else {
-                        Timber.d("Packaged audio is gonna be copied to share directory: %s", fileForSharing)
-                        copy(rawResourceInputStream, FileOutputStream(fileForSharing))
-                    }
-
-                    fileForSharing
-                }
-                else -> getFile(context, sound.file!!)
-            }
-
+    ): UriResolution {
+        val fileResolution = resolveFileForSharing(sound, context)
+        if (fileResolution is FileResolution.Failure) {
+            return UriResolution.Failure(fileResolution.feedback)
+        }
+        val file = (fileResolution as FileResolution.Success).file
         return try {
-            FileProvider.getUriForFile(context, authority, fileForSharing)
+            UriResolution.Success(FileProvider.getUriForFile(context, authority, file))
         } catch (e: IllegalArgumentException) {
             Tracker.track(RuntimeException("Couldn't create FileProvider URI for sound: ${sound.file}", e))
-            null
+            UriResolution.Failure(R.string.app_share_feedback_unshareable)
         }
+    }
+
+    private fun resolveFileForSharing(
+        sound: Sound,
+        context: Context,
+    ): FileResolution =
+        when {
+            sound.file != null -> FileResolution.Success(getFile(context, sound.file!!))
+            sound.rawRes == 0 -> {
+                Tracker.track(RuntimeException("Sound has neither file URI nor raw resource ID: ${sound.name}"))
+                FileResolution.Failure(R.string.app_share_feedback_broken_data)
+            }
+            else -> resolveBundledFileForSharing(sound, context)
+        }
+
+    private fun resolveBundledFileForSharing(
+        sound: Sound,
+        context: Context,
+    ): FileResolution {
+        val fileForSharing = getFile(context, sound.name + ".mp3")
+        return if (fileForSharing.exists()) {
+            Timber.d("Packaged audio already copied to share directory: %s", fileForSharing)
+            FileResolution.Success(fileForSharing)
+        } else {
+            Timber.d("Packaged audio is gonna be copied to share directory: %s", fileForSharing)
+            copyBundledAudioForSharing(sound, context, fileForSharing)
+        }
+    }
+
+    private fun copyBundledAudioForSharing(
+        sound: Sound,
+        context: Context,
+        fileForSharing: File,
+    ): FileResolution =
+        try {
+            copy(context.resources.openRawResource(sound.rawRes), FileOutputStream(fileForSharing))
+            FileResolution.Success(fileForSharing)
+        } catch (e: IOException) {
+            Tracker.track(RuntimeException("Couldn't copy bundled audio to shareable directory: ${sound.name}", e))
+            FileResolution.Failure(R.string.app_share_feedback_copy_failed)
+        }
+
+    private sealed class FileResolution {
+        data class Success(
+            val file: File,
+        ) : FileResolution()
+
+        data class Failure(
+            @param:StringRes val feedback: Int,
+        ) : FileResolution()
+    }
+
+    private sealed class UriResolution {
+        data class Success(
+            val uri: Uri,
+        ) : UriResolution()
+
+        data class Failure(
+            @param:StringRes val feedback: Int,
+        ) : UriResolution()
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
@@ -69,7 +69,6 @@ private class ShareFeatureImpl : ShareFeature {
         }
     }
 
-    @StringRes
     private fun launchChooserAndTrack(
         context: Context,
         sound: Sound,

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
@@ -178,7 +178,9 @@ private class ShareFeatureImpl : ShareFeature {
         ) : ShareOutcome<T>()
 
         data class Failure(
-            @param:StringRes val feedback: Int,
+            @get:StringRes
+            @param:StringRes
+            val feedback: Int,
         ) : ShareOutcome<Nothing>()
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
@@ -64,8 +64,8 @@ private class ShareFeatureImpl : ShareFeature {
         // Main dispatcher because Android's chooser expects the launching call on the UI thread.
         val resolution = withContext(Dispatchers.IO) { resolveContentUri(sound, context) }
         return when (resolution) {
-            is UriResolution.Failure -> resolution.feedback
-            is UriResolution.Success -> launchChooserAndTrack(context, sound, resolution.uri, surface)
+            is ShareOutcome.Failure -> resolution.feedback
+            is ShareOutcome.Success -> launchChooserAndTrack(context, sound, resolution.value, surface)
         }
     }
 
@@ -110,29 +110,33 @@ private class ShareFeatureImpl : ShareFeature {
     private fun resolveContentUri(
         sound: Sound,
         context: Context,
-    ): UriResolution {
-        val fileResolution = resolveFileForSharing(sound, context)
-        if (fileResolution is FileResolution.Failure) {
-            return UriResolution.Failure(fileResolution.feedback)
+    ): ShareOutcome<Uri> =
+        when (val fileResolution = resolveFileForSharing(sound, context)) {
+            is ShareOutcome.Failure -> fileResolution
+            is ShareOutcome.Success -> wrapInFileProviderUri(context, fileResolution.value, sound)
         }
-        val file = (fileResolution as FileResolution.Success).file
-        return try {
-            UriResolution.Success(FileProvider.getUriForFile(context, authority, file))
+
+    private fun wrapInFileProviderUri(
+        context: Context,
+        file: File,
+        sound: Sound,
+    ): ShareOutcome<Uri> =
+        try {
+            ShareOutcome.Success(FileProvider.getUriForFile(context, authority, file))
         } catch (e: IllegalArgumentException) {
             Tracker.track(RuntimeException("Couldn't create FileProvider URI for sound: ${sound.file}", e))
-            UriResolution.Failure(R.string.app_share_feedback_unshareable)
+            ShareOutcome.Failure(R.string.app_share_feedback_unshareable)
         }
-    }
 
     private fun resolveFileForSharing(
         sound: Sound,
         context: Context,
-    ): FileResolution =
+    ): ShareOutcome<File> =
         when {
-            sound.file != null -> FileResolution.Success(getFile(context, sound.file!!))
+            sound.file != null -> ShareOutcome.Success(getFile(context, sound.file!!))
             sound.rawRes == 0 -> {
                 Tracker.track(RuntimeException("Sound has neither file URI nor raw resource ID: ${sound.name}"))
-                FileResolution.Failure(R.string.app_share_feedback_broken_data)
+                ShareOutcome.Failure(R.string.app_share_feedback_broken_data)
             }
             else -> resolveBundledFileForSharing(sound, context)
         }
@@ -140,11 +144,11 @@ private class ShareFeatureImpl : ShareFeature {
     private fun resolveBundledFileForSharing(
         sound: Sound,
         context: Context,
-    ): FileResolution {
+    ): ShareOutcome<File> {
         val fileForSharing = getFile(context, sound.name + ".mp3")
         return if (fileForSharing.exists()) {
             Timber.d("Packaged audio already copied to share directory: %s", fileForSharing)
-            FileResolution.Success(fileForSharing)
+            ShareOutcome.Success(fileForSharing)
         } else {
             Timber.d("Packaged audio is gonna be copied to share directory: %s", fileForSharing)
             copyBundledAudioForSharing(sound, context, fileForSharing)
@@ -155,32 +159,27 @@ private class ShareFeatureImpl : ShareFeature {
         sound: Sound,
         context: Context,
         fileForSharing: File,
-    ): FileResolution =
+    ): ShareOutcome<File> =
         try {
             copy(context.resources.openRawResource(sound.rawRes), FileOutputStream(fileForSharing))
-            FileResolution.Success(fileForSharing)
+            ShareOutcome.Success(fileForSharing)
         } catch (e: IOException) {
             Tracker.track(RuntimeException("Couldn't copy bundled audio to shareable directory: ${sound.name}", e))
-            FileResolution.Failure(R.string.app_share_feedback_copy_failed)
+            ShareOutcome.Failure(R.string.app_share_feedback_copy_failed)
         }
 
-    private sealed class FileResolution {
-        data class Success(
-            val file: File,
-        ) : FileResolution()
+    /**
+     * Two-step resolution result: either a value of [T] (file path, then content URI) or an
+     * `@StringRes` feedback id paired with a non-fatal already tracked. `Failure : ShareOutcome<Nothing>`
+     * so it can flow through `ShareOutcome<File> → ShareOutcome<Uri>` without re-wrapping.
+     */
+    private sealed class ShareOutcome<out T> {
+        data class Success<out T>(
+            val value: T,
+        ) : ShareOutcome<T>()
 
         data class Failure(
             @param:StringRes val feedback: Int,
-        ) : FileResolution()
-    }
-
-    private sealed class UriResolution {
-        data class Success(
-            val uri: Uri,
-        ) : UriResolution()
-
-        data class Failure(
-            @param:StringRes val feedback: Int,
-        ) : UriResolution()
+        ) : ShareOutcome<Nothing>()
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
@@ -8,12 +8,14 @@ package com.github.barriosnahuel.vossosunboton.feature.share
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.widget.Toast
 import androidx.core.content.FileProvider
 import com.github.barriosnahuel.vossosunboton.BuildConfig
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsEvent
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsUserProperty
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.commons.file.copy
 import com.github.barriosnahuel.vossosunboton.commons.file.getFile
 import com.github.barriosnahuel.vossosunboton.model.Sound
@@ -56,6 +58,12 @@ private class ShareFeatureImpl : ShareFeature {
         // both touch the file system. Run that part on IO; startActivity + analytics stay on the caller's
         // Main dispatcher because Android's chooser expects the launching call on the UI thread.
         val buttonFileContentUri = withContext(Dispatchers.IO) { getContentUriForSound(sound, context) }
+        if (buttonFileContentUri == null) {
+            // FileProvider rejected the Sound's path (e.g. legacy persisted absolute path outside the configured root).
+            // Surface a non-blocking message to the user; the failure is already tracked as a non-fatal in getContentUriForSound.
+            Toast.makeText(context, R.string.app_share_feedback_unshareable, Toast.LENGTH_LONG).show()
+            return
+        }
         val shareIntent = Intent()
         shareIntent.action = Intent.ACTION_SEND
         shareIntent.type = "audio/*"
@@ -108,7 +116,8 @@ private class ShareFeatureImpl : ShareFeature {
         return try {
             FileProvider.getUriForFile(context, authority, fileForSharing)
         } catch (e: IllegalArgumentException) {
-            throw IllegalStateException("Button content uri couldn't be created.", e)
+            Tracker.track(RuntimeException("Couldn't create FileProvider URI for sound: ${sound.file}", e))
+            null
         }
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -213,11 +213,14 @@ private suspend fun shareWithFeedback(
 ) {
     val errorRes = ShareFeature.instance.share(context, sound, surface)
     if (errorRes != null) {
-        // Long (~7s) instead of Short (~4s): error copy includes a call-to-action ("Free up some space",
-        // "Try installing one") that needs reading time, and our error strings are 70+ chars in es-AR.
+        // Indefinite + dismiss action so the snackbar stays until the user dismisses it. WCAG 2.2 AA
+        // ground: TalkBack reads ~10–12 chars/sec so es-AR copy of 100+ chars (e.g. copy_failed) would
+        // not finish reading before SnackbarDuration.Long (10 s) auto-dismissed. Letting the user
+        // close it on their own pace is the only way to guarantee they receive the full message.
         snackbarHostState.showSnackbar(
             message = context.getString(errorRes),
-            duration = SnackbarDuration.Long,
+            actionLabel = context.getString(R.string.app_snackbar_action_dismiss),
+            duration = SnackbarDuration.Indefinite,
         )
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -213,9 +213,11 @@ private suspend fun shareWithFeedback(
 ) {
     val errorRes = ShareFeature.instance.share(context, sound, surface)
     if (errorRes != null) {
+        // Long (~7s) instead of Short (~4s): error copy includes a call-to-action ("Free up some space",
+        // "Try installing one") that needs reading time, and our error strings are 70+ chars in es-AR.
         snackbarHostState.showSnackbar(
             message = context.getString(errorRes),
-            duration = SnackbarDuration.Short,
+            duration = SnackbarDuration.Long,
         )
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -5,6 +5,7 @@
  */
 package com.github.barriosnahuel.vossosunboton.ui.home
 
+import android.content.Context
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
@@ -168,7 +169,7 @@ fun LandingScreen(viewModel: SoundsViewModel) {
                         } else {
                             CanonicalScreenName.EXPLORE_SOUNDS
                         }
-                    coroutineScope.launch { ShareFeature.instance.share(context, sound, surface) }
+                    coroutineScope.launch { shareWithFeedback(context, sound, surface, snackbarHostState) }
                 },
                 onDelete = { sound -> viewModel.deleteSound(sound) },
                 onPinClick = { sound -> viewModel.togglePin(sound) },
@@ -192,7 +193,7 @@ fun LandingScreen(viewModel: SoundsViewModel) {
             onSeek = viewModel::seekTo,
             onShareClick = { sound ->
                 coroutineScope.launch {
-                    ShareFeature.instance.share(context, sound, CanonicalScreenName.SEARCH_SOUND)
+                    shareWithFeedback(context, sound, CanonicalScreenName.SEARCH_SOUND, snackbarHostState)
                 }
             },
             onPinClick = viewModel::togglePin,
@@ -200,6 +201,21 @@ fun LandingScreen(viewModel: SoundsViewModel) {
                 viewModel.hideSearch()
                 viewModel.deleteSound(sound)
             },
+        )
+    }
+}
+
+private suspend fun shareWithFeedback(
+    context: Context,
+    sound: Sound,
+    surface: String,
+    snackbarHostState: SnackbarHostState,
+) {
+    val errorRes = ShareFeature.instance.share(context, sound, surface)
+    if (errorRes != null) {
+        snackbarHostState.showSnackbar(
+            message = context.getString(errorRes),
+            duration = SnackbarDuration.Short,
         )
     }
 }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -7,6 +7,7 @@
     <string name="app_share_feedback_copy_failed">No pude preparar este Bomp para compartir. Liberá espacio y probá de nuevo — Nahu ya se enteró y lo va a investigar.</string>
     <string name="app_share_feedback_broken_data">Los datos de este Bomp están rotos. Borralo y volvé a agregarlo — Nahu ya se enteró y lo va a investigar.</string>
     <string name="app_undo">Deshacer!</string>
+    <string name="app_snackbar_action_dismiss">Listo</string>
     <string name="app_feedback_audio_deleted">Audio borrado</string>
     <string name="app_feedback_button_saved">¡%1$s es tuyo!</string>
     <string name="app_feedback_generic_error_contact_support">Uh! Por favor contactá con soporte</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">Bomp</string>
 
     <string name="app_share_chooser_title">Compartir vía</string>
+    <string name="app_share_feedback_unshareable">No se pudo compartir este Bomp. Nahu ya se enteró y lo va a investigar.</string>
     <string name="app_undo">Deshacer!</string>
     <string name="app_feedback_audio_deleted">Audio borrado</string>
     <string name="app_feedback_button_saved">¡%1$s es tuyo!</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -5,7 +5,7 @@
     <string name="app_share_feedback_unshareable">No se pudo compartir este Bomp. Nahu ya se enteró y lo va a investigar.</string>
     <string name="app_share_feedback_no_app_for_audio">No tenés una app para compartir audios. Probá instalando una.</string>
     <string name="app_share_feedback_copy_failed">No pude preparar este Bomp para compartir. Liberá espacio y probá de nuevo — Nahu ya se enteró y lo va a investigar.</string>
-    <string name="app_share_feedback_broken_data">Los datos de este Bomp están rotos. Nahu ya se enteró y lo va a investigar.</string>
+    <string name="app_share_feedback_broken_data">Los datos de este Bomp están rotos. Borralo y volvé a agregarlo — Nahu ya se enteró y lo va a investigar.</string>
     <string name="app_undo">Deshacer!</string>
     <string name="app_feedback_audio_deleted">Audio borrado</string>
     <string name="app_feedback_button_saved">¡%1$s es tuyo!</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -3,6 +3,9 @@
 
     <string name="app_share_chooser_title">Compartir vía</string>
     <string name="app_share_feedback_unshareable">No se pudo compartir este Bomp. Nahu ya se enteró y lo va a investigar.</string>
+    <string name="app_share_feedback_no_app_for_audio">No tenés una app para compartir audios. Probá instalando una.</string>
+    <string name="app_share_feedback_copy_failed">No pude preparar este Bomp para compartir. Liberá espacio y probá de nuevo — Nahu ya se enteró y lo va a investigar.</string>
+    <string name="app_share_feedback_broken_data">Los datos de este Bomp están rotos. Nahu ya se enteró y lo va a investigar.</string>
     <string name="app_undo">Deshacer!</string>
     <string name="app_feedback_audio_deleted">Audio borrado</string>
     <string name="app_feedback_button_saved">¡%1$s es tuyo!</string>
@@ -66,6 +69,7 @@
     <string name="app_addbutton_name_is_required_error">El nombre es obligatorio</string>
     <string name="app_addbutton_missing_parameter_error">Falta indicar el audio</string>
     <string name="app_addbutton_feedback_saved_ok">Guardado</string>
+    <string name="app_addbutton_feedback_uri_unreadable">No pude leer el audio que elegiste. Nahu ya se enteró y lo va a investigar.</string>
 
     <!-- Mis audios — empty state (welcome consumido, sin Bomps propios todavía) -->
     <string name="app_my_sounds_empty_headline">Acá viven las voces que te importan.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,9 @@
 
     <string name="app_share_chooser_title">Share vía</string>
     <string name="app_share_feedback_unshareable">Couldn\'t share this Bomp. Nahu\'s already on it.</string>
+    <string name="app_share_feedback_no_app_for_audio">No app on your device can share audio. Try installing one.</string>
+    <string name="app_share_feedback_copy_failed">Couldn\'t prepare this Bomp for sharing. Free up some space and try again — Nahu\'s already looking into it.</string>
+    <string name="app_share_feedback_broken_data">This Bomp\'s data is broken. Nahu\'s already on it.</string>
     <string name="app_undo">Undo!</string>
     <string name="app_feedback_audio_deleted">Audio deleted</string>
     <string name="app_feedback_button_saved">%1$s is now yours!</string>
@@ -71,6 +74,7 @@
     <string name="app_addbutton_name_is_required_error">Name is required</string>
     <string name="app_addbutton_missing_parameter_error">Missing audio file</string>
     <string name="app_addbutton_feedback_saved_ok">Saved!</string>
+    <string name="app_addbutton_feedback_uri_unreadable">Couldn\'t read the audio you picked. Nahu\'s already on it.</string>
 
     <!-- My Sounds empty state (welcome consumed, no custom sounds yet) -->
     <string name="app_my_sounds_empty_headline">This is where the voices live.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">Bomp</string>
 
     <string name="app_share_chooser_title">Share vía</string>
+    <string name="app_share_feedback_unshareable">Couldn\'t share this Bomp. Nahu\'s already on it.</string>
     <string name="app_undo">Undo!</string>
     <string name="app_feedback_audio_deleted">Audio deleted</string>
     <string name="app_feedback_button_saved">%1$s is now yours!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="app_share_feedback_copy_failed">Couldn\'t prepare this Bomp for sharing. Free up some space and try again — Nahu\'s already looking into it.</string>
     <string name="app_share_feedback_broken_data">This Bomp\'s data is broken. Remove it and add it again — Nahu\'s already on it.</string>
     <string name="app_undo">Undo!</string>
+    <string name="app_snackbar_action_dismiss">Got it</string>
     <string name="app_feedback_audio_deleted">Audio deleted</string>
     <string name="app_feedback_button_saved">%1$s is now yours!</string>
 <string name="app_feedback_generic_error_contact_support">Oops! I did it again, please contact support</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
     <string name="app_share_feedback_unshareable">Couldn\'t share this Bomp. Nahu\'s already on it.</string>
     <string name="app_share_feedback_no_app_for_audio">No app on your device can share audio. Try installing one.</string>
     <string name="app_share_feedback_copy_failed">Couldn\'t prepare this Bomp for sharing. Free up some space and try again — Nahu\'s already looking into it.</string>
-    <string name="app_share_feedback_broken_data">This Bomp\'s data is broken. Nahu\'s already on it.</string>
+    <string name="app_share_feedback_broken_data">This Bomp\'s data is broken. Remove it and add it again — Nahu\'s already on it.</string>
     <string name="app_undo">Undo!</string>
     <string name="app_feedback_audio_deleted">Audio deleted</string>
     <string name="app_feedback_button_saved">%1$s is now yours!</string>

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeatureTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeatureTest.kt
@@ -87,6 +87,22 @@ internal class AddButtonFeatureTest : AbstractRobolectricTest() {
     }
 
     @Test
+    fun `saveNewButtonAsync does not call ContentResolver getType when scheme is rejected`() {
+        // Locks in the scheme-first ordering: a future refactor that re-runs getType before checking
+        // the scheme would mis-route the failure into the Unreadable bucket and waste a resolver call.
+        val uri = Uri.parse("http://example.com/foo.mp3")
+        val resolver = spyk(realContext.contentResolver)
+        val context = spyk(realContext)
+        every { context.contentResolver } returns resolver
+
+        runBlocking {
+            AddButtonFeature.instance.saveNewButtonAsync(context, "http", uri.toString()).await()
+        }
+
+        verify(exactly = 0) { resolver.getType(uri) }
+    }
+
+    @Test
     fun `saveNewButtonAsync rejects URIs whose MIME type is unknown`() {
         val uri = Uri.parse("content://test/no-mime")
         val context = contextWith(uri, mime = null, sizeBytes = 1024L)

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeatureTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeatureTest.kt
@@ -118,7 +118,7 @@ internal class AddButtonFeatureTest : AbstractRobolectricTest() {
             }
 
         assertThat(result).isEqualTo(R.string.app_addbutton_feedback_uri_unreadable)
-        verify(atLeast = 1) { Tracker.track(any()) }
+        verify(exactly = 1) { Tracker.track(any()) }
     }
 
     /**

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeatureTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeatureTest.kt
@@ -12,17 +12,27 @@ import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.spyk
+import io.mockk.unmockkAll
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
+import org.junit.After
 import org.junit.Test
 import org.robolectric.Shadows.shadowOf
 import java.io.ByteArrayInputStream
 
 internal class AddButtonFeatureTest : AbstractRobolectricTest() {
     private val realContext: Context = ApplicationProvider.getApplicationContext()
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
 
     @Test
     fun `saveNewButtonAsync saves a valid audio URI and returns saved_ok`() {
@@ -87,6 +97,28 @@ internal class AddButtonFeatureTest : AbstractRobolectricTest() {
             }
 
         assertThat(result).isEqualTo(R.string.app_feedback_generic_error_contact_support)
+    }
+
+    @Test
+    fun `saveNewButtonAsync returns uri-unreadable feedback when ContentResolver getType throws SecurityException`() {
+        val uri = Uri.parse("content://test/revoked-grant")
+        val baseResolver = realContext.contentResolver
+        shadowOf(baseResolver).registerInputStream(uri, ByteArrayInputStream(ByteArray(0)))
+        val resolver = spyk(baseResolver)
+        every { resolver.getType(uri) } throws SecurityException("URI permission revoked")
+        val context = spyk(realContext)
+        every { context.contentResolver } returns resolver
+
+        mockkObject(Tracker)
+        every { Tracker.track(any()) } answers { nothing }
+
+        val result =
+            runBlocking {
+                AddButtonFeature.instance.saveNewButtonAsync(context, "revoked", uri.toString()).await()
+            }
+
+        assertThat(result).isEqualTo(R.string.app_addbutton_feedback_uri_unreadable)
+        verify(atLeast = 1) { Tracker.track(any()) }
     }
 
     /**

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerTest.kt
@@ -127,6 +127,8 @@ internal class PlayerControllerTest : AbstractRobolectricTest() {
 
         verify { listener.onPlayerError(sound) }
         verify(exactly = 1) { Tracker.track(any()) }
+        // Guards the "no flicker" invariant: when start() fails, the UI must never see "playing".
+        verify(exactly = 0) { listener.onPlayerStart(any(), any()) }
     }
 
     @Test

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerTest.kt
@@ -109,6 +109,27 @@ internal class PlayerControllerTest : AbstractRobolectricTest() {
     }
 
     @Test
+    fun `on startPlayingSound when start throws IllegalStateException should call onPlayerError and track non-fatal`() {
+        val context = mockk<Context>(relaxed = true)
+        val sound = Sound("test", rawRes = 1)
+        val mp = givenAnIdleMediaPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        every { mp.start() } throws IllegalStateException("MediaPlayer in invalid state")
+
+        mockkObject(Tracker)
+        every { Tracker.track(any()) } answers { nothing }
+        mockkStatic(MediaPlayerHelper::class)
+        every { MediaPlayerHelper.setupSoundSource(any(), any(), any<Int>()) } returns true
+
+        val controller = PlayerControllerImpl(mp)
+        controller.setOnStartStopListener(listener)
+        controller.startPlayingSound(context, sound)
+
+        verify { listener.onPlayerError(sound) }
+        verify(exactly = 1) { Tracker.track(any()) }
+    }
+
+    @Test
     fun `on natural completion the listener receives onPlayerStop with completed = true`() {
         val context = mockk<Context>(relaxed = true)
         val sound = Sound("test", rawRes = 1)

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerTest.kt
@@ -109,6 +109,29 @@ internal class PlayerControllerTest : AbstractRobolectricTest() {
     }
 
     @Test
+    fun `on startPlayingSound when start succeeds emits onPlayerStart only after start`() {
+        // Locks in the no-flicker invariant from the inverse case: the listener must NOT be told
+        // "playing" until start() has actually returned, so a future revert that fires onPlayerStart
+        // before start() (the historical order) doesn't sneak past the failure-path test.
+        val context = mockk<Context>(relaxed = true)
+        val sound = Sound("test", rawRes = 1)
+        val mp = givenAnIdleMediaPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+
+        mockkStatic(MediaPlayerHelper::class)
+        every { MediaPlayerHelper.setupSoundSource(any(), any(), any<Int>()) } returns true
+
+        val controller = PlayerControllerImpl(mp)
+        controller.setOnStartStopListener(listener)
+        controller.startPlayingSound(context, sound)
+
+        verifyOrder {
+            mp.start()
+            listener.onPlayerStart(sound, any())
+        }
+    }
+
+    @Test
     fun `on startPlayingSound when start throws IllegalStateException should call onPlayerError and track non-fatal`() {
         val context = mockk<Context>(relaxed = true)
         val sound = Sound("test", rawRes = 1)

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
@@ -144,9 +144,17 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
     @Test
     fun `share when bundled copy throws IOException returns copy-failed feedback and tracks non-fatal`() {
         val sound = givenASoundWithResourceId()
-        val mockedContext = spyk<Context>(ApplicationProvider.getApplicationContext<Context>())
+        val realContext = ApplicationProvider.getApplicationContext<Context>()
+        val mockedContext = spyk<Context>(realContext)
 
-        // Force the bundled-resource branch to take the copy path even if the file already exists on disk.
+        // Robolectric's external dir survives across tests in the same JVM run; if a sibling test (e.g. the one
+        // that captures the path) already copied "$dummyButtonName.mp3" to it, the bundled branch short-circuits
+        // on `fileForSharing.exists()` and never reaches our `copy(...)` mock. Delete the leftover so the copy
+        // path is exercised deterministically regardless of test execution order.
+        com.github.barriosnahuel.vossosunboton.commons.file
+            .getFile(realContext, "$dummyButtonName.mp3")
+            .delete()
+
         mockkStatic("com.github.barriosnahuel.vossosunboton.commons.file.FileUtils")
         every {
             com.github.barriosnahuel.vossosunboton.commons.file

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
@@ -19,12 +19,16 @@ import com.github.barriosnahuel.vossosunboton.commons.android.analytics.Analytic
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsUserProperty
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.FakeAnalyticsTracker
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.spyk
+import io.mockk.unmockkAll
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
@@ -44,6 +48,7 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
     @After
     fun tearDownAnalytics() {
         AnalyticsTrackerProvider.setForTest(null)
+        unmockkAll()
     }
 
     @Test
@@ -80,6 +85,31 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
 
         fake.assertNotEmitted("share")
         assertThat(fake.userProperties[AnalyticsUserProperty.LIFETIME_SHARES]).isNull()
+    }
+
+    @Test
+    fun `share when FileProvider rejects the file does not crash and tracks a non-fatal`() {
+        val sound = givenASoundWithUri()
+        val mockedContext = spyk<Context>(ApplicationProvider.getApplicationContext<Context>())
+
+        mockkStatic(FileProvider::class)
+        every { FileProvider.getUriForFile(mockedContext, any(), any()) } throws
+            IllegalArgumentException("Failed to find configured root that contains /data/local/tmp/external/x.mp3")
+
+        mockkObject(Tracker)
+        val tracked = slot<Throwable>()
+        every { Tracker.track(capture(tracked)) } answers { nothing }
+        every { mockedContext.startActivity(any()) } answers { nothing }
+
+        runBlocking { ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
+
+        verify(exactly = 1) { Tracker.track(any()) }
+        assertThat(tracked.captured).isInstanceOf(RuntimeException::class.java)
+        assertThat(tracked.captured.cause).isInstanceOf(IllegalArgumentException::class.java)
+
+        fake.assertNotEmitted("share")
+        assertThat(fake.userProperties[AnalyticsUserProperty.LIFETIME_SHARES]).isNull()
+        verify(exactly = 0) { mockedContext.startActivity(any()) }
     }
 
     @Test

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
@@ -34,6 +34,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import java.io.File
+import java.io.IOException
 
 internal class ShareFeatureTest : AbstractRobolectricTest() {
     private val dummyButtonName = "my button name"
@@ -70,25 +71,30 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `share does not increment lifetime_shares when the chooser activity cannot be started`() {
+    fun `share when chooser cannot start returns no-app feedback and tracks non-fatal`() {
         val sound = givenASoundWithUri()
         val mockedContext = spyk<Context>(ApplicationProvider.getApplicationContext<Context>())
         mockkStatic(FileProvider::class)
         every { FileProvider.getUriForFile(mockedContext, any(), any()) } returns Uri.EMPTY
         every { mockedContext.startActivity(any()) } throws ActivityNotFoundException("no app handles audio share")
 
-        try {
-            runBlocking { ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
-        } catch (_: ActivityNotFoundException) {
-            // expected — propagates so the caller can show an error UI
-        }
+        mockkObject(Tracker)
+        val tracked = slot<Throwable>()
+        every { Tracker.track(capture(tracked)) } answers { nothing }
 
+        val feedback =
+            runBlocking { ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
+
+        assertThat(feedback).isEqualTo(R.string.app_share_feedback_no_app_for_audio)
+        verify(exactly = 1) { Tracker.track(any()) }
+        assertThat(tracked.captured).isInstanceOf(RuntimeException::class.java)
+        assertThat(tracked.captured.cause).isInstanceOf(ActivityNotFoundException::class.java)
         fake.assertNotEmitted("share")
         assertThat(fake.userProperties[AnalyticsUserProperty.LIFETIME_SHARES]).isNull()
     }
 
     @Test
-    fun `share when FileProvider rejects the file does not crash and tracks a non-fatal`() {
+    fun `share when FileProvider rejects the file returns unshareable feedback and tracks a non-fatal`() {
         val sound = givenASoundWithUri()
         val mockedContext = spyk<Context>(ApplicationProvider.getApplicationContext<Context>())
 
@@ -101,8 +107,10 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
         every { Tracker.track(capture(tracked)) } answers { nothing }
         every { mockedContext.startActivity(any()) } answers { nothing }
 
-        runBlocking { ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
+        val feedback =
+            runBlocking { ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
 
+        assertThat(feedback).isEqualTo(R.string.app_share_feedback_unshareable)
         verify(exactly = 1) { Tracker.track(any()) }
         assertThat(tracked.captured).isInstanceOf(RuntimeException::class.java)
         assertThat(tracked.captured.cause).isInstanceOf(IllegalArgumentException::class.java)
@@ -113,14 +121,67 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `share when sound Uri and resource are null must throw an exception`() {
+    fun `share when sound has neither file nor rawRes returns broken-data feedback and tracks non-fatal`() {
         val sound = givenASoundWithNullUri()
+        val mockedContext = spyk<Context>(ApplicationProvider.getApplicationContext<Context>())
 
-        try {
-            whenSharingThe(sound)
-        } catch (e: IllegalStateException) {
-            thenWeThrowAnIllegalStateException(e)
-        }
+        mockkObject(Tracker)
+        val tracked = slot<Throwable>()
+        every { Tracker.track(capture(tracked)) } answers { nothing }
+        every { mockedContext.startActivity(any()) } answers { nothing }
+
+        val feedback =
+            runBlocking { ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
+
+        assertThat(feedback).isEqualTo(R.string.app_share_feedback_broken_data)
+        verify(exactly = 1) { Tracker.track(any()) }
+        assertThat(tracked.captured).isInstanceOf(RuntimeException::class.java)
+        fake.assertNotEmitted("share")
+        assertThat(fake.userProperties[AnalyticsUserProperty.LIFETIME_SHARES]).isNull()
+        verify(exactly = 0) { mockedContext.startActivity(any()) }
+    }
+
+    @Test
+    fun `share when bundled copy throws IOException returns copy-failed feedback and tracks non-fatal`() {
+        val sound = givenASoundWithResourceId()
+        val mockedContext = spyk<Context>(ApplicationProvider.getApplicationContext<Context>())
+
+        // Force the bundled-resource branch to take the copy path even if the file already exists on disk.
+        mockkStatic("com.github.barriosnahuel.vossosunboton.commons.file.FileUtils")
+        every {
+            com.github.barriosnahuel.vossosunboton.commons.file
+                .copy(any(), any())
+        } throws IOException("simulated disk full while copying raw resource")
+
+        mockkObject(Tracker)
+        val tracked = slot<Throwable>()
+        every { Tracker.track(capture(tracked)) } answers { nothing }
+        every { mockedContext.startActivity(any()) } answers { nothing }
+
+        val feedback =
+            runBlocking { ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
+
+        assertThat(feedback).isEqualTo(R.string.app_share_feedback_copy_failed)
+        verify(exactly = 1) { Tracker.track(any()) }
+        assertThat(tracked.captured).isInstanceOf(RuntimeException::class.java)
+        assertThat(tracked.captured.cause).isInstanceOf(IOException::class.java)
+        fake.assertNotEmitted("share")
+        assertThat(fake.userProperties[AnalyticsUserProperty.LIFETIME_SHARES]).isNull()
+        verify(exactly = 0) { mockedContext.startActivity(any()) }
+    }
+
+    @Test
+    fun `share when chooser launches successfully returns null`() {
+        val sound = givenASoundWithUri()
+        val mockedContext = spyk<Context>(ApplicationProvider.getApplicationContext<Context>())
+        mockkStatic(FileProvider::class)
+        every { FileProvider.getUriForFile(mockedContext, any(), any()) } returns Uri.EMPTY
+        every { mockedContext.startActivity(any()) } answers { nothing }
+
+        val feedback =
+            runBlocking { ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
+
+        assertThat(feedback).isNull()
     }
 
     @Test
@@ -205,10 +266,6 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
         runBlocking { ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
 
         return slot.captured
-    }
-
-    private fun thenWeThrowAnIllegalStateException(e: IllegalStateException) {
-        assertThat(e.message).isEqualTo("Either file URI or raw resource ID must exist on a given sound")
     }
 
     private fun thenOSShowDisambiguationWindow(intent: Intent) {

--- a/commons_file/build.gradle
+++ b/commons_file/build.gradle
@@ -29,4 +29,7 @@ android {
 dependencies {
     implementation libs.androidx.annotation
     implementation libs.timber
+
+    testImplementation libs.junit
+    testImplementation libs.truth
 }

--- a/commons_file/src/main/java/com/github/barriosnahuel/vossosunboton/commons/file/FileUtils.kt
+++ b/commons_file/src/main/java/com/github/barriosnahuel/vossosunboton/commons/file/FileUtils.kt
@@ -31,8 +31,8 @@ fun getFile(
 ): File = File(context.getExternalFilesDir(Environment.DIRECTORY_MUSIC), fileName)
 
 /**
- * @param inputStream The input stream to copy.
- * @param fileOutputStream The output stream to use.
+ * @param inputStream The input stream to copy. Closed before this function returns, regardless of success.
+ * @param fileOutputStream The output stream to use. Closed before this function returns, regardless of success.
  * @throws IOException either calling [InputStream.read] or [FileOutputStream.write], or even when closing those streams.
  */
 @Throws(IOException::class)
@@ -40,10 +40,13 @@ fun copy(
     @NonNull inputStream: InputStream,
     @NonNull fileOutputStream: FileOutputStream,
 ) {
-    inputStream.copyTo(fileOutputStream, INPUT_STREAM_READ_BUFFER_SIZE)
-
-    inputStream.close()
-    fileOutputStream.close()
+    // .use { } guarantees both streams close even if copyTo throws — without it, IOException propagates with
+    // the descriptors leaked (caller can't reach a finally because the streams were created by the caller).
+    inputStream.use { input ->
+        fileOutputStream.use { output ->
+            input.copyTo(output, INPUT_STREAM_READ_BUFFER_SIZE)
+        }
+    }
 }
 
 /**

--- a/commons_file/src/test/java/com/github/barriosnahuel/vossosunboton/commons/file/FileUtilsTest.kt
+++ b/commons_file/src/test/java/com/github/barriosnahuel/vossosunboton/commons/file/FileUtilsTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.commons.file
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.io.InputStream
+
+class FileUtilsTest {
+    private lateinit var targetFile: File
+
+    @Before
+    fun setUp() {
+        targetFile = File.createTempFile("file-utils-test", ".tmp")
+    }
+
+    @After
+    fun tearDown() {
+        targetFile.delete()
+    }
+
+    @Test
+    fun `copy closes both streams on success and writes the input to the file`() {
+        val input = TrackingInputStream(ByteArrayInputStream("hello".toByteArray()))
+        val output = TrackingFileOutputStream(targetFile)
+
+        copy(input, output)
+
+        assertThat(input.closed).isTrue()
+        assertThat(output.closed).isTrue()
+        assertThat(targetFile.readText()).isEqualTo("hello")
+    }
+
+    @Test
+    fun `copy closes both streams when input read throws IOException and rethrows`() {
+        val input = TrackingInputStream(ThrowingOnReadInputStream())
+        val output = TrackingFileOutputStream(targetFile)
+
+        // The .use { } wrappers in copy() must close both streams before the exception escapes —
+        // assertThrows confirms it propagates, and the closed assertions confirm cleanup happened.
+        assertThrows(IOException::class.java) { copy(input, output) }
+
+        assertThat(input.closed).isTrue()
+        assertThat(output.closed).isTrue()
+    }
+
+    private class TrackingInputStream(
+        private val delegate: InputStream,
+    ) : InputStream() {
+        var closed = false
+            private set
+
+        override fun read(): Int = delegate.read()
+
+        override fun read(
+            b: ByteArray,
+            off: Int,
+            len: Int,
+        ): Int = delegate.read(b, off, len)
+
+        override fun close() {
+            closed = true
+            delegate.close()
+        }
+    }
+
+    private class TrackingFileOutputStream(
+        file: File,
+    ) : FileOutputStream(file) {
+        var closed = false
+            private set
+
+        override fun close() {
+            closed = true
+            super.close()
+        }
+    }
+
+    private class ThrowingOnReadInputStream : InputStream() {
+        override fun read(): Int = throw IOException("simulated read failure")
+
+        override fun read(
+            b: ByteArray,
+            off: Int,
+            len: Int,
+        ): Int = throw IOException("simulated read failure")
+    }
+}


### PR DESCRIPTION
## Summary

- Audit-driven sweep of failure modes that crashed the app or failed silently: `ShareFeature` (3 uncaught exceptions), `PlayerControllerImpl.start()`, and `AddButtonFeature` URI validation. Each path now records a non-fatal in Crashlytics and surfaces a tailored Snackbar to the user.
- Snackbars use `SnackbarDuration.Indefinite` with a "Got it"/"Listo" dismiss action — error copy is 100+ chars in es-AR and at default TalkBack rate the auto-timeouts cut TTS off mid-sentence (WCAG 2.2 AA target per project guidelines).
- `FileUtils.copy` now wraps streams in `.use { }` so a mid-copy `IOException` no longer leaks file descriptors — pre-existing bug that became reachable now that we keep the process alive instead of crashing.
- Includes follow-up review fixes: PlayerController no-flicker invariant, AddButton scheme-first ordering, generic `ShareOutcome<T>` deduplicating result types, broken-data copy with a recovery path.

## Code review tips

- `ShareFeature.kt` is the deepest delta — note the public `share(): Int?` contract change (was `Unit`); both call sites in `LandingScreen.kt` were updated.
- The **welcome sticker first-share path** is the only branch that exercises raw-resource → external-files copy. Worth a manual smoke if you haven't.
- `app_share_feedback_*` strings — read aloud per CLAUDE.md § Copy & localization. The 4 errors map to distinct causes; reusing the existing `unshareable` for all of them was rejected explicitly.
- 2 ADRs are *not* updated by this PR: ADR 0002/0003 — see `handoff/2026-05-09-share-via-viewmodel.md` for why and the migration plan.

## Already tested

- [x] `./gradlew check` (KtLint + Detekt + Spotless + Android Lint)
- [x] `./gradlew test` — full unit test suite, 13 new tests + 3 updated, including 2 fresh tests in `commons_file` (was untested before)
- [x] `./gradlew app:connectedDebugAndroidTest` on `Android_14_API_34` AVD — 49/49 passed (2 skipped)
- [ ] Manual smoke of the welcome-sticker share-on-virtualized-Android path (covered indirectly by the FileProvider regression test from PR #1117)

🤖 Generated with [Claude Code](https://claude.com/claude-code)