### PR TITLE
refactor(share): route flow through SoundsViewModel + Channel events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 #### Changed
 - Migrated Firebase to per-build-type projects (bomp-prod for release, bomp-debug for debug); added BigQuery export documentation
 - About screen's external Legal & Privacy links now open extensionless URLs (`/privacy-policy`, `/data-safety`, `/terms-of-service`) — GitHub Pages serves the same content under both forms, so this is a cosmetic cleanup with no destination or behavior change
+- Routed the audio share flow through `SoundsViewModel` with Channel-based one-shot events, aligning ADR 0002 (constructor injection) and ADR 0003 (Channel for one-shot events); `ShareFeature` is split into `prepareShareIntent` (VM-side I/O) and `launchChooser` (UI-side)
 
 #### Fixed
 - Debug builds now show a gray launcher icon background again, restoring the visual distinction from release builds that was lost when the icon was modernized to an adaptive icon

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
@@ -27,16 +27,53 @@ import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
 
-internal interface ShareFeature {
+/**
+ * Outcome of [ShareFeature.prepareShareIntent]. [Success] carries a ready-to-launch chooser intent
+ * and the originating surface so [ShareFeature.launchChooser] can log the analytics event with the
+ * matching `screen_name`. [Failure] carries an `@StringRes` feedback id for the caller to surface,
+ * paired with a non-fatal already tracked via `Tracker.track`.
+ */
+sealed class ShareIntentOutcome {
+    data class Success(
+        val intent: Intent,
+        val surface: String,
+    ) : ShareIntentOutcome()
+
+    data class Failure(
+        @get:StringRes
+        @param:StringRes
+        val feedback: Int,
+    ) : ShareIntentOutcome()
+}
+
+interface ShareFeature {
     /**
+     * Resolves the audio file for [sound] on the IO dispatcher, wraps it in a FileProvider URI, and
+     * builds the `ACTION_SEND` intent. Returns either a ready-to-launch [ShareIntentOutcome.Success]
+     * or a [ShareIntentOutcome.Failure] with an `@StringRes` feedback id (each failure is also recorded
+     * as non-fatal).
+     *
+     * Receives [applicationContext] — file resolution and FileProvider don't need an Activity context.
      * @param surface canonical screen_name from `CanonicalScreenName` describing where the share originated.
-     * @return `null` when the chooser launched, otherwise an `@StringRes` id with a user-facing
-     *         feedback message that the caller is expected to surface (Snackbar/Toast). Every
-     *         non-null return is paired with a non-fatal recorded via `Tracker.track`.
      */
-    suspend fun share(
-        context: Context,
+    suspend fun prepareShareIntent(
+        applicationContext: Context,
         sound: Sound,
+        surface: String,
+    ): ShareIntentOutcome
+
+    /**
+     * Wraps [intent] in a chooser and dispatches via `startActivity`, then logs the analytics event
+     * for [surface] only if the chooser launched. Returns `null` on success or
+     * `R.string.app_share_feedback_no_app_for_audio` if no activity can handle the intent (also tracked
+     * as non-fatal).
+     *
+     * Must be invoked from a UI-thread caller with an [activityContext] — Android's chooser expects
+     * the launching call on the Activity's Looper.
+     */
+    fun launchChooser(
+        activityContext: Context,
+        intent: Intent,
         surface: String,
     ): Int?
 
@@ -52,59 +89,61 @@ private class ShareFeatureImpl : ShareFeature {
      * For more info check
      * [developer.android.com/training/secure-file-sharing/setup-sharing](https://developer.android.com/training/secure-file-sharing/setup-sharing)
      */
-    override suspend fun share(
-        context: Context,
+    override suspend fun prepareShareIntent(
+        applicationContext: Context,
         sound: Sound,
         surface: String,
-    ): Int? {
-        Timber.d("Trying to share button: %s", sound.name)
+    ): ShareIntentOutcome {
+        Timber.d("Preparing share intent for button: %s", sound.name)
 
-        // Resolving the file path and (for bundled sounds, first share only) copying raw resources to disk
-        // both touch the file system. Run that part on IO; startActivity + analytics stay on the caller's
-        // Main dispatcher because Android's chooser expects the launching call on the UI thread.
-        val resolution = withContext(Dispatchers.IO) { resolveContentUri(context, sound) }
+        val resolution = withContext(Dispatchers.IO) { resolveContentUri(applicationContext, sound) }
         return when (resolution) {
-            is ShareOutcome.Failure -> resolution.feedback
-            is ShareOutcome.Success -> launchChooserAndTrack(context, sound, resolution.value, surface)
+            is ShareOutcome.Failure -> ShareIntentOutcome.Failure(resolution.feedback)
+            is ShareOutcome.Success -> {
+                Timber.d(
+                    "Share intent ready for: %s; contentUri=%s; URI=%s; rawResId=%s; surface=%s",
+                    sound.name,
+                    resolution.value,
+                    sound.file,
+                    sound.rawRes,
+                    surface,
+                )
+                ShareIntentOutcome.Success(buildShareIntent(resolution.value), surface)
+            }
         }
     }
 
-    private fun launchChooserAndTrack(
-        context: Context,
-        sound: Sound,
-        contentUri: Uri,
+    override fun launchChooser(
+        activityContext: Context,
+        intent: Intent,
         surface: String,
     ): Int? {
-        val shareIntent = Intent()
-        shareIntent.action = Intent.ACTION_SEND
-        shareIntent.type = "audio/*"
-        shareIntent.putExtra(Intent.EXTRA_STREAM, contentUri)
-        shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-
-        Timber.d(
-            "Starting disambiguation window for: %s: contentUri=%s; URI=%s; rawResId=%s;",
-            sound.name,
-            contentUri,
-            sound.file,
-            sound.rawRes,
-        )
-
         // Track AFTER the chooser actually launches: if `startActivity` throws (ActivityNotFoundException, OS reject)
         // we want `lifetime_shares` to stay accurate. If the chooser shows but the user cancels there is no reliable
         // callback, so "chooser displayed" remains the canonical share signal — matches Firebase's recommended event.
         try {
-            context.startActivity(Intent.createChooser(shareIntent, context.getString(R.string.app_share_chooser_title)))
+            activityContext.startActivity(
+                Intent.createChooser(intent, activityContext.getString(R.string.app_share_chooser_title)),
+            )
         } catch (e: ActivityNotFoundException) {
             Tracker.track(RuntimeException("No activity available to handle audio share intent", e))
             return R.string.app_share_feedback_no_app_for_audio
         }
 
-        val tracker = AnalyticsTrackerProvider.get(context.applicationContext)
+        val tracker = AnalyticsTrackerProvider.get(activityContext.applicationContext)
         tracker.log(AnalyticsEvent.Share(surface = surface))
         val newCount = tracker.incrementCounter(AnalyticsUserProperty.LIFETIME_SHARES)
         tracker.setUserProperty(AnalyticsUserProperty.LIFETIME_SHARES, newCount.toString())
         return null
     }
+
+    private fun buildShareIntent(contentUri: Uri): Intent =
+        Intent().apply {
+            action = Intent.ACTION_SEND
+            type = "audio/*"
+            putExtra(Intent.EXTRA_STREAM, contentUri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
 
     private fun resolveContentUri(
         context: Context,
@@ -170,7 +209,8 @@ private class ShareFeatureImpl : ShareFeature {
     /**
      * Two-step resolution result: either a value of [T] (file path, then content URI) or an
      * `@StringRes` feedback id paired with a non-fatal already tracked. `Failure : ShareOutcome<Nothing>`
-     * so it can flow through `ShareOutcome<File> → ShareOutcome<Uri>` without re-wrapping.
+     * so it can flow through `ShareOutcome<File> → ShareOutcome<Uri>` without re-wrapping. Private to
+     * the impl — the public boundary is [ShareIntentOutcome].
      */
     private sealed class ShareOutcome<out T> {
         data class Success<out T>(

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -162,15 +162,7 @@ fun LandingScreen(viewModel: SoundsViewModel) {
                 modifier = Modifier.padding(innerPadding),
                 onPlayClick = { sound -> viewModel.playOrStop(sound) },
                 onSeek = { positionMs -> viewModel.seekTo(positionMs) },
-                onShareClick = { sound ->
-                    val surface =
-                        if (selectedTab == AppTab.MY_SOUNDS) {
-                            CanonicalScreenName.MY_SOUNDS
-                        } else {
-                            CanonicalScreenName.EXPLORE_SOUNDS
-                        }
-                    coroutineScope.launch { shareWithFeedback(context, sound, surface, snackbarHostState) }
-                },
+                onShareClick = { sound -> viewModel.share(sound) },
                 onDelete = { sound -> viewModel.deleteSound(sound) },
                 onPinClick = { sound -> viewModel.togglePin(sound) },
                 onEdit = { sound ->
@@ -191,11 +183,7 @@ fun LandingScreen(viewModel: SoundsViewModel) {
             onClose = viewModel::hideSearch,
             onPlayClick = viewModel::playOrStop,
             onSeek = viewModel::seekTo,
-            onShareClick = { sound ->
-                coroutineScope.launch {
-                    shareWithFeedback(context, sound, CanonicalScreenName.SEARCH_SOUND, snackbarHostState)
-                }
-            },
+            onShareClick = { sound -> viewModel.share(sound) },
             onPinClick = viewModel::togglePin,
             onDelete = { sound ->
                 viewModel.hideSearch()
@@ -205,24 +193,21 @@ fun LandingScreen(viewModel: SoundsViewModel) {
     }
 }
 
-private suspend fun shareWithFeedback(
-    context: Context,
-    sound: Sound,
-    surface: String,
+// Indefinite + dismiss action so the snackbar stays until the user dismisses it. WCAG 2.2 AA
+// ground: TalkBack reads ~10–12 chars/sec so es-AR copy of 100+ chars (e.g. copy_failed) would
+// not finish reading before SnackbarDuration.Long (10 s) auto-dismissed. Letting the user
+// close it on their own pace is the only way to guarantee they receive the full message.
+private suspend fun showShareErrorSnackbar(
     snackbarHostState: SnackbarHostState,
+    context: Context,
+    errorRes: Int,
+    actionLabel: String,
 ) {
-    val errorRes = ShareFeature.instance.share(context, sound, surface)
-    if (errorRes != null) {
-        // Indefinite + dismiss action so the snackbar stays until the user dismisses it. WCAG 2.2 AA
-        // ground: TalkBack reads ~10–12 chars/sec so es-AR copy of 100+ chars (e.g. copy_failed) would
-        // not finish reading before SnackbarDuration.Long (10 s) auto-dismissed. Letting the user
-        // close it on their own pace is the only way to guarantee they receive the full message.
-        snackbarHostState.showSnackbar(
-            message = context.getString(errorRes),
-            actionLabel = context.getString(R.string.app_snackbar_action_dismiss),
-            duration = SnackbarDuration.Indefinite,
-        )
-    }
+    snackbarHostState.showSnackbar(
+        message = context.getString(errorRes),
+        actionLabel = actionLabel,
+        duration = SnackbarDuration.Indefinite,
+    )
 }
 
 @Composable
@@ -237,6 +222,8 @@ private fun SnackbarEffects(
     val playbackErrorMessage = stringResource(R.string.app_error_playback_failed)
     val buttonSavedTemplate = stringResource(R.string.app_feedback_button_saved)
     val buttonRenamedTemplate = stringResource(R.string.app_feedback_button_renamed)
+    val shareDismissLabel = stringResource(R.string.app_snackbar_action_dismiss)
+    val activityContext = LocalContext.current
 
     LaunchedEffect(Unit) {
         viewModel.playbackErrorEvent.collect {
@@ -244,6 +231,24 @@ private fun SnackbarEffects(
                 message = playbackErrorMessage,
                 duration = SnackbarDuration.Short,
             )
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        // Activity-side half of the share split: the VM produced an Intent on IO; here we wrap it in a
+        // chooser and call startActivity from the UI thread. If startActivity throws, launchChooser
+        // returns the same @StringRes contract used by shareErrorEvent — surface it the same way.
+        viewModel.shareIntentEvent.collect { event ->
+            val errorRes = ShareFeature.instance.launchChooser(activityContext, event.intent, event.surface)
+            if (errorRes != null) {
+                showShareErrorSnackbar(snackbarHostState, activityContext, errorRes, shareDismissLabel)
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.shareErrorEvent.collect { errorRes ->
+            showShareErrorSnackbar(snackbarHostState, activityContext, errorRes, shareDismissLabel)
         }
     }
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -19,6 +19,8 @@ import com.github.barriosnahuel.vossosunboton.commons.android.analytics.Canonica
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerListener
+import com.github.barriosnahuel.vossosunboton.feature.share.ShareFeature
+import com.github.barriosnahuel.vossosunboton.feature.share.ShareIntentOutcome
 import com.github.barriosnahuel.vossosunboton.feature.welcome.WelcomeStickerStore
 import com.github.barriosnahuel.vossosunboton.feature.welcome.isWelcomeSticker
 import com.github.barriosnahuel.vossosunboton.feature.welcome.welcomeSticker
@@ -59,6 +61,7 @@ class SoundsViewModel(
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val searchDebounceMs: Long = 200L,
     private val welcomeStore: WelcomeStickerStore = WelcomeStickerStore(application),
+    private val shareFeature: ShareFeature = ShareFeature.instance,
 ) : AndroidViewModel(application),
     PlayerControllerListener {
     private val repo = SoundsRepository(application, onError = Tracker::track)
@@ -134,6 +137,14 @@ class SoundsViewModel(
 
     private val _playbackErrorEvent = Channel<Unit>(Channel.BUFFERED)
     val playbackErrorEvent: Flow<Unit> = _playbackErrorEvent.receiveAsFlow()
+
+    // CONFLATED (vs the BUFFERED siblings above): a tap-spamming user does not need every share-error
+    // queued — only the latest matters, and stacking duplicate snackbars would just hide the message.
+    private val _shareIntentEvent = Channel<ShareIntentOutcome.Success>(Channel.CONFLATED)
+    val shareIntentEvent: Flow<ShareIntentOutcome.Success> = _shareIntentEvent.receiveAsFlow()
+
+    private val _shareErrorEvent = Channel<Int>(Channel.CONFLATED)
+    val shareErrorEvent: Flow<Int> = _shareErrorEvent.receiveAsFlow()
 
     init {
         PlayerControllerFactory.instance.setOnStartStopListener(this)
@@ -274,6 +285,17 @@ class SoundsViewModel(
     fun seekTo(positionMs: Int) {
         PlayerControllerFactory.instance.seekTo(positionMs)
         _playbackProgress.update { it?.copy(positionMs = positionMs) }
+    }
+
+    fun share(sound: Sound) {
+        viewModelScope.launch {
+            // applicationContext (via getApplication()) is enough: file resolution + FileProvider
+            // are activity-agnostic. Activity context only re-enters at launchChooser, on the UI side.
+            when (val outcome = shareFeature.prepareShareIntent(getApplication(), sound, currentSurface)) {
+                is ShareIntentOutcome.Success -> _shareIntentEvent.send(outcome)
+                is ShareIntentOutcome.Failure -> _shareErrorEvent.send(outcome.feedback)
+            }
+        }
     }
 
     fun deleteSound(sound: Sound) {

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
@@ -52,49 +52,48 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
         unmockkAll()
     }
 
+    // ─── prepareShareIntent: file resolution + intent build ───
+
     @Test
-    fun `share emits Share with the surface passed in by the caller`() {
-        val sound = givenASoundWithUri()
+    fun `prepareShareIntent returns Success carrying the surface passed in by the caller`() {
+        val outcome = whenPreparing(givenASoundWithUri(), CanonicalScreenName.EXPLORE_SOUNDS)
 
-        whenSharingThe(sound)
-
-        val event = fake.assertEmitted("share")
-        assertThat(event.params["surface"]).isEqualTo(CanonicalScreenName.MY_SOUNDS)
+        assertThat((outcome as ShareIntentOutcome.Success).surface).isEqualTo(CanonicalScreenName.EXPLORE_SOUNDS)
     }
 
     @Test
-    fun `share increments lifetime_shares user property monotonically across calls`() {
-        whenSharingThe(givenASoundWithUri())
-        whenSharingThe(givenASoundWithUri())
+    fun `prepareShareIntent returns Success with ACTION_SEND audio intent for sound with uri`() {
+        val outcome = whenPreparing(givenASoundWithUri())
 
-        assertThat(fake.userProperties[AnalyticsUserProperty.LIFETIME_SHARES]).isEqualTo("2")
+        val intent = (outcome as ShareIntentOutcome.Success).intent
+        assertThat(intent.action).isEqualTo(Intent.ACTION_SEND)
+        assertThat(intent.type).isEqualTo("audio/*")
+        assertThat(intent.extras?.containsKey(Intent.EXTRA_STREAM)).isTrue()
     }
 
     @Test
-    fun `share when chooser cannot start returns no-app feedback and tracks non-fatal`() {
-        val sound = givenASoundWithUri()
-        val mockedContext = spyk<Context>(ApplicationProvider.getApplicationContext<Context>())
-        mockkStatic(FileProvider::class)
-        every { FileProvider.getUriForFile(mockedContext, any(), any()) } returns Uri.EMPTY
-        every { mockedContext.startActivity(any()) } throws ActivityNotFoundException("no app handles audio share")
+    fun `prepareShareIntent returns Success for sound with rawRes resource`() {
+        val outcome = whenPreparing(givenASoundWithResourceId())
 
-        mockkObject(Tracker)
-        val tracked = slot<Throwable>()
-        every { Tracker.track(capture(tracked)) } answers { nothing }
-
-        val feedback =
-            runBlocking { ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
-
-        assertThat(feedback).isEqualTo(R.string.app_share_feedback_no_app_for_audio)
-        verify(exactly = 1) { Tracker.track(any()) }
-        assertThat(tracked.captured).isInstanceOf(RuntimeException::class.java)
-        assertThat(tracked.captured.cause).isInstanceOf(ActivityNotFoundException::class.java)
-        fake.assertNotEmitted("share")
-        assertThat(fake.userProperties[AnalyticsUserProperty.LIFETIME_SHARES]).isNull()
+        assertThat(outcome).isInstanceOf(ShareIntentOutcome.Success::class.java)
     }
 
     @Test
-    fun `share when FileProvider rejects the file returns unshareable feedback and tracks a non-fatal`() {
+    fun `prepareShareIntent generates content Uri under Music directory`() {
+        val capturedFile = whenPreparingCapturingTheFilePath(givenASoundWithUri())
+
+        assertThat(capturedFile.absolutePath.split("/").contains(Environment.DIRECTORY_MUSIC)).isTrue()
+    }
+
+    @Test
+    fun `prepareShareIntent uses soundName dot mp3 as the bundled temp filename`() {
+        val capturedFile = whenPreparingCapturingTheFilePath(givenASoundWithResourceId())
+
+        assertThat(capturedFile.name).isEqualTo("$dummyButtonName.mp3")
+    }
+
+    @Test
+    fun `prepareShareIntent returns Failure unshareable when FileProvider rejects the file`() {
         val sound = givenASoundWithUri()
         val mockedContext = spyk<Context>(ApplicationProvider.getApplicationContext<Context>())
 
@@ -107,21 +106,18 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
         every { Tracker.track(capture(tracked)) } answers { nothing }
         every { mockedContext.startActivity(any()) } answers { nothing }
 
-        val feedback =
-            runBlocking { ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
+        val outcome =
+            runBlocking { ShareFeature.instance.prepareShareIntent(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
 
-        assertThat(feedback).isEqualTo(R.string.app_share_feedback_unshareable)
+        assertThat((outcome as ShareIntentOutcome.Failure).feedback).isEqualTo(R.string.app_share_feedback_unshareable)
         verify(exactly = 1) { Tracker.track(any()) }
         assertThat(tracked.captured).isInstanceOf(RuntimeException::class.java)
         assertThat(tracked.captured.cause).isInstanceOf(IllegalArgumentException::class.java)
-
-        fake.assertNotEmitted("share")
-        assertThat(fake.userProperties[AnalyticsUserProperty.LIFETIME_SHARES]).isNull()
         verify(exactly = 0) { mockedContext.startActivity(any()) }
     }
 
     @Test
-    fun `share when sound has neither file nor rawRes returns broken-data feedback and tracks non-fatal`() {
+    fun `prepareShareIntent returns Failure broken_data when sound has neither file nor rawRes`() {
         val sound = givenASoundWithNullUri()
         val mockedContext = spyk<Context>(ApplicationProvider.getApplicationContext<Context>())
 
@@ -130,19 +126,17 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
         every { Tracker.track(capture(tracked)) } answers { nothing }
         every { mockedContext.startActivity(any()) } answers { nothing }
 
-        val feedback =
-            runBlocking { ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
+        val outcome =
+            runBlocking { ShareFeature.instance.prepareShareIntent(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
 
-        assertThat(feedback).isEqualTo(R.string.app_share_feedback_broken_data)
+        assertThat((outcome as ShareIntentOutcome.Failure).feedback).isEqualTo(R.string.app_share_feedback_broken_data)
         verify(exactly = 1) { Tracker.track(any()) }
         assertThat(tracked.captured).isInstanceOf(RuntimeException::class.java)
-        fake.assertNotEmitted("share")
-        assertThat(fake.userProperties[AnalyticsUserProperty.LIFETIME_SHARES]).isNull()
         verify(exactly = 0) { mockedContext.startActivity(any()) }
     }
 
     @Test
-    fun `share when bundled copy throws IOException returns copy-failed feedback and tracks non-fatal`() {
+    fun `prepareShareIntent returns Failure copy_failed when bundled copy throws IOException`() {
         val sound = givenASoundWithResourceId()
         val realContext = ApplicationProvider.getApplicationContext<Context>()
         val mockedContext = spyk<Context>(realContext)
@@ -166,80 +160,87 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
         every { Tracker.track(capture(tracked)) } answers { nothing }
         every { mockedContext.startActivity(any()) } answers { nothing }
 
-        val feedback =
-            runBlocking { ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
+        val outcome =
+            runBlocking { ShareFeature.instance.prepareShareIntent(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
 
-        assertThat(feedback).isEqualTo(R.string.app_share_feedback_copy_failed)
+        assertThat((outcome as ShareIntentOutcome.Failure).feedback).isEqualTo(R.string.app_share_feedback_copy_failed)
         verify(exactly = 1) { Tracker.track(any()) }
         assertThat(tracked.captured).isInstanceOf(RuntimeException::class.java)
         assertThat(tracked.captured.cause).isInstanceOf(IOException::class.java)
-        fake.assertNotEmitted("share")
-        assertThat(fake.userProperties[AnalyticsUserProperty.LIFETIME_SHARES]).isNull()
         verify(exactly = 0) { mockedContext.startActivity(any()) }
     }
 
-    @Test
-    fun `share when chooser launches successfully returns null`() {
-        val sound = givenASoundWithUri()
-        val mockedContext = spyk<Context>(ApplicationProvider.getApplicationContext<Context>())
-        mockkStatic(FileProvider::class)
-        every { FileProvider.getUriForFile(mockedContext, any(), any()) } returns Uri.EMPTY
-        every { mockedContext.startActivity(any()) } answers { nothing }
+    // ─── launchChooser: startActivity + analytics ───
 
-        val feedback =
-            runBlocking { ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
+    @Test
+    fun `launchChooser emits Share with the surface passed in by the caller`() {
+        val (context, intent) = givenAReadyToLaunchPair()
+
+        ShareFeature.instance.launchChooser(context, intent, CanonicalScreenName.MY_SOUNDS)
+
+        val event = fake.assertEmitted("share")
+        assertThat(event.params["surface"]).isEqualTo(CanonicalScreenName.MY_SOUNDS)
+    }
+
+    @Test
+    fun `launchChooser increments lifetime_shares user property monotonically across calls`() {
+        val (context, intent) = givenAReadyToLaunchPair()
+
+        ShareFeature.instance.launchChooser(context, intent, CanonicalScreenName.MY_SOUNDS)
+        ShareFeature.instance.launchChooser(context, intent, CanonicalScreenName.MY_SOUNDS)
+
+        assertThat(fake.userProperties[AnalyticsUserProperty.LIFETIME_SHARES]).isEqualTo("2")
+    }
+
+    @Test
+    fun `launchChooser returns null when chooser launches successfully`() {
+        val (context, intent) = givenAReadyToLaunchPair()
+
+        val feedback = ShareFeature.instance.launchChooser(context, intent, CanonicalScreenName.MY_SOUNDS)
 
         assertThat(feedback).isNull()
     }
 
     @Test
-    fun `share when sound URI is valid show disambiguation window`() {
-        val sound = givenASoundWithUri()
+    fun `launchChooser wraps the share intent in ACTION_CHOOSER before startActivity`() {
+        val mockedContext = spyk<Context>(ApplicationProvider.getApplicationContext<Context>())
+        val baseIntent =
+            Intent().apply {
+                action = Intent.ACTION_SEND
+                type = "audio/*"
+                putExtra(Intent.EXTRA_STREAM, Uri.EMPTY)
+            }
+        val captured = slot<Intent>()
+        every { mockedContext.startActivity(capture(captured)) } answers { nothing }
 
-        val generatedIntent = whenSharingThe(sound)
+        ShareFeature.instance.launchChooser(mockedContext, baseIntent, CanonicalScreenName.MY_SOUNDS)
 
-        thenOSShowDisambiguationWindow(generatedIntent)
+        assertThat(captured.captured.action).isEqualTo(Intent.ACTION_CHOOSER)
+        assertThat(captured.captured.extras?.containsKey(Intent.EXTRA_INTENT)).isTrue()
+        thenWeSendAnAudio(captured.captured)
     }
 
     @Test
-    fun `share when sound raw resource ID is valid show disambiguation window`() {
-        val sound = givenASoundWithResourceId()
+    fun `launchChooser returns no_app_for_audio when activity not found and tracks non-fatal without analytics`() {
+        val mockedContext = spyk<Context>(ApplicationProvider.getApplicationContext<Context>())
+        val baseIntent = Intent().apply { action = Intent.ACTION_SEND }
+        every { mockedContext.startActivity(any()) } throws ActivityNotFoundException("no app handles audio share")
 
-        val generatedIntent = whenSharingThe(sound)
+        mockkObject(Tracker)
+        val tracked = slot<Throwable>()
+        every { Tracker.track(capture(tracked)) } answers { nothing }
 
-        thenOSShowDisambiguationWindow(generatedIntent)
+        val feedback = ShareFeature.instance.launchChooser(mockedContext, baseIntent, CanonicalScreenName.MY_SOUNDS)
+
+        assertThat(feedback).isEqualTo(R.string.app_share_feedback_no_app_for_audio)
+        verify(exactly = 1) { Tracker.track(any()) }
+        assertThat(tracked.captured).isInstanceOf(RuntimeException::class.java)
+        assertThat(tracked.captured.cause).isInstanceOf(ActivityNotFoundException::class.java)
+        fake.assertNotEmitted("share")
+        assertThat(fake.userProperties[AnalyticsUserProperty.LIFETIME_SHARES]).isNull()
     }
 
-    @Test
-    fun `share when sound URI is valid sends the audio file`() {
-        val sound = givenASoundWithUri()
-
-        val generatedIntent = whenSharingThe(sound)
-
-        thenWeSendAnAudio(generatedIntent)
-    }
-
-    @Test
-    fun `share should generate a content Uri under Music directory as described in app_file_provider_paths resource`() {
-        val sound = givenASoundWithUri()
-
-        val capturedFile = whenSharingTheSoundCapturingThePath(sound)
-
-        thenWeCheckSoundPathIsAtMusicDirectory(capturedFile)
-    }
-
-    @Test
-    fun `share packaged sound temp filename is soundName dot mp3 without any prefix`() {
-        val sound = givenASoundWithResourceId()
-
-        val capturedFile = whenSharingTheSoundCapturingThePath(sound)
-
-        assertThat(capturedFile.name).isEqualTo("$dummyButtonName.mp3")
-    }
-
-    private fun thenWeCheckSoundPathIsAtMusicDirectory(capturedFile: File) {
-        assertThat(capturedFile.absolutePath.split("/").contains(Environment.DIRECTORY_MUSIC)).isTrue()
-    }
+    // ─── helpers ───
 
     private fun givenASoundWithUri() = Sound(dummyButtonName, "a/dummy/sound/uri")
 
@@ -247,38 +248,37 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
 
     private fun givenASoundWithNullUri() = Sound(dummyButtonName)
 
-    private fun whenSharingTheSoundCapturingThePath(sound: Sound): File {
+    private fun whenPreparing(
+        sound: Sound,
+        surface: String = CanonicalScreenName.MY_SOUNDS,
+    ): ShareIntentOutcome {
         val mockedContext = spyk<Context>(ApplicationProvider.getApplicationContext<Context>())
+        mockkStatic(FileProvider::class)
+        every { FileProvider.getUriForFile(mockedContext, any(), any()) } returns Uri.EMPTY
+        return runBlocking { ShareFeature.instance.prepareShareIntent(mockedContext, sound, surface) }
+    }
 
+    private fun whenPreparingCapturingTheFilePath(sound: Sound): File {
+        val mockedContext = spyk<Context>(ApplicationProvider.getApplicationContext<Context>())
         val slotFile = slot<File>()
         mockkStatic(FileProvider::class)
         every { FileProvider.getUriForFile(mockedContext, any(), capture(slotFile)) } returns Uri.EMPTY
-
-        val slot = slot<Intent>()
-        every { mockedContext.startActivity(capture(slot)) } answers { nothing }
-
-        runBlocking { ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
-
+        runBlocking {
+            ShareFeature.instance.prepareShareIntent(mockedContext, sound, CanonicalScreenName.MY_SOUNDS)
+        }
         return slotFile.captured
     }
 
-    private fun whenSharingThe(sound: Sound): Intent {
+    private fun givenAReadyToLaunchPair(): Pair<Context, Intent> {
         val mockedContext = spyk<Context>(ApplicationProvider.getApplicationContext<Context>())
-
-        mockkStatic(FileProvider::class)
-        every { FileProvider.getUriForFile(mockedContext, any(), any()) } returns Uri.EMPTY
-
-        val slot = slot<Intent>()
-        every { mockedContext.startActivity(capture(slot)) } answers { nothing }
-
-        runBlocking { ShareFeature.instance.share(mockedContext, sound, CanonicalScreenName.MY_SOUNDS) }
-
-        return slot.captured
-    }
-
-    private fun thenOSShowDisambiguationWindow(intent: Intent) {
-        assertThat(intent.action).isEqualTo(Intent.ACTION_CHOOSER)
-        assertThat(intent.extras?.containsKey(Intent.EXTRA_INTENT)).isTrue()
+        every { mockedContext.startActivity(any()) } answers { nothing }
+        val intent =
+            Intent().apply {
+                action = Intent.ACTION_SEND
+                type = "audio/*"
+                putExtra(Intent.EXTRA_STREAM, Uri.EMPTY)
+            }
+        return mockedContext to intent
     }
 
     private fun thenWeSendAnAudio(intent: Intent) {

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
@@ -5,10 +5,14 @@
  */
 package com.github.barriosnahuel.vossosunboton.ui.home
 
+import android.content.Intent
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
+import com.github.barriosnahuel.vossosunboton.feature.share.ShareFeature
+import com.github.barriosnahuel.vossosunboton.feature.share.ShareIntentOutcome
 import com.github.barriosnahuel.vossosunboton.feature.welcome.WelcomeStickerStore
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.model.data.manager.SoundsRepository
@@ -475,13 +479,17 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    private fun givenAViewModel(welcomeStore: WelcomeStickerStore? = null): SoundsViewModel {
+    private fun givenAViewModel(
+        welcomeStore: WelcomeStickerStore? = null,
+        shareFeature: ShareFeature? = null,
+    ): SoundsViewModel {
         val context = ApplicationProvider.getApplicationContext<android.app.Application>()
         val vm =
             SoundsViewModel(
                 context,
                 ioDispatcher = UnconfinedTestDispatcher(),
                 welcomeStore = welcomeStore ?: WelcomeStickerStore(context),
+                shareFeature = shareFeature ?: ShareFeature.instance,
             )
         runBlocking { vm.isInitialLoadComplete.first { it } }
         return vm
@@ -700,4 +708,86 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
                 .name,
         ).isNotEqualTo(welcomeTitle)
     }
+
+    @Test
+    fun `share emits to shareIntentEvent on Success outcome`() =
+        runTest {
+            val intent = mockk<Intent>(relaxed = true)
+            val shareFeature =
+                mockk<ShareFeature> {
+                    coEvery { prepareShareIntent(any(), any(), any()) } returns
+                        ShareIntentOutcome.Success(intent, CanonicalScreenName.MY_SOUNDS)
+                }
+            val viewModel = givenAViewModel(shareFeature = shareFeature)
+
+            viewModel.share(Sound("s", file = "s.mp3"))
+
+            val event = withTimeoutOrNull(1000) { viewModel.shareIntentEvent.first() }
+            assertThat(event?.intent).isEqualTo(intent)
+            assertThat(event?.surface).isEqualTo(CanonicalScreenName.MY_SOUNDS)
+        }
+
+    @Test
+    fun `share emits to shareErrorEvent with feedback res on Failure outcome`() =
+        runTest {
+            val shareFeature =
+                mockk<ShareFeature> {
+                    coEvery { prepareShareIntent(any(), any(), any()) } returns
+                        ShareIntentOutcome.Failure(R.string.app_share_feedback_unshareable)
+                }
+            val viewModel = givenAViewModel(shareFeature = shareFeature)
+
+            viewModel.share(Sound("s", file = "s.mp3"))
+
+            val emitted = withTimeoutOrNull(1000) { viewModel.shareErrorEvent.first() }
+            assertThat(emitted).isEqualTo(R.string.app_share_feedback_unshareable)
+        }
+
+    @Test
+    fun `share passes MY_SOUNDS surface when MY_SOUNDS tab selected and search hidden`() =
+        runTest {
+            val shareFeature = mockShareFeatureReturning(CanonicalScreenName.MY_SOUNDS)
+            val viewModel = givenAViewModel(shareFeature = shareFeature)
+            val sound = Sound("s", file = "s.mp3")
+            viewModel.selectTab(AppTab.MY_SOUNDS)
+
+            viewModel.share(sound)
+            withTimeoutOrNull(1000) { viewModel.shareIntentEvent.first() }
+
+            coVerify { shareFeature.prepareShareIntent(any(), sound, CanonicalScreenName.MY_SOUNDS) }
+        }
+
+    @Test
+    fun `share passes EXPLORE_SOUNDS surface when EXPLORE_SOUNDS tab selected`() =
+        runTest {
+            val shareFeature = mockShareFeatureReturning(CanonicalScreenName.EXPLORE_SOUNDS)
+            val viewModel = givenAViewModel(shareFeature = shareFeature)
+            val sound = Sound("s", file = "s.mp3")
+            viewModel.selectTab(AppTab.EXPLORE_SOUNDS)
+
+            viewModel.share(sound)
+            withTimeoutOrNull(1000) { viewModel.shareIntentEvent.first() }
+
+            coVerify { shareFeature.prepareShareIntent(any(), sound, CanonicalScreenName.EXPLORE_SOUNDS) }
+        }
+
+    @Test
+    fun `share passes SEARCH_SOUND surface when search overlay is visible`() =
+        runTest {
+            val shareFeature = mockShareFeatureReturning(CanonicalScreenName.SEARCH_SOUND)
+            val viewModel = givenAViewModel(shareFeature = shareFeature)
+            val sound = Sound("s", file = "s.mp3")
+            viewModel.showSearch()
+
+            viewModel.share(sound)
+            withTimeoutOrNull(1000) { viewModel.shareIntentEvent.first() }
+
+            coVerify { shareFeature.prepareShareIntent(any(), sound, CanonicalScreenName.SEARCH_SOUND) }
+        }
+
+    private fun mockShareFeatureReturning(surface: String): ShareFeature =
+        mockk {
+            coEvery { prepareShareIntent(any(), any(), any()) } returns
+                ShareIntentOutcome.Success(mockk(relaxed = true), surface)
+        }
 }


### PR DESCRIPTION
## Summary
- Splits `ShareFeature` into `prepareShareIntent` (suspend, VM-side I/O + intent build) and `launchChooser` (UI-side, `startActivity` + analytics).
- Routes share through `SoundsViewModel.share(sound)` with two `Channel.CONFLATED` events (`shareIntentEvent`, `shareErrorEvent`); deletes the file-level `shareWithFeedback` helper.
- Surface (`MY_SOUNDS` / `EXPLORE_SOUNDS` / `SEARCH_SOUND`) flows from the existing `currentSurface` getter, removing the per-callsite ternary in `LandingScreen`.
- Restores ADR 0002 + ADR 0003 compliance for the share flow — the last one-shot event in this screen that wasn't on the canonical pattern.

## Code review tips
- `ShareFeature` and `ShareIntentOutcome` are no longer `internal` so the VM constructor can expose them — mirrors `WelcomeStickerStore`.
- Compose still calls `ShareFeature.instance.launchChooser(...)` from a `LaunchedEffect`; intentional and scoped — `startActivity` needs Activity context. The I/O path is fully VM-mediated.
- `Channel.CONFLATED` (vs sibling `BUFFERED` channels) so tap-spam doesn't stack duplicate snackbars or intents.
- `ShareFeatureTest.kt` was reorganized under `prepareShareIntent` / `launchChooser` groups; every previous failure mode (FileProvider IllegalArgument, broken_data, copy IOException, ActivityNotFound, intent shape) is still covered.

## Already tested
- [x] `./gradlew check -x test` — green
- [x] `./gradlew test` — green; 5 new VM share tests + 12 reorganized ShareFeature tests
- [x] `scripts/check-adr-invariants.sh` — green
- [x] Emulator (Android 14): `HomeTabFlowTest.shareButtonEmitsActionSendChooserIntent` + `ExploreTabFlowTest.exploreTabExposesA11yContentDescriptions` — green
- [x] Manual smoke on Pixel 8: share works from Home, Explore, and search overlay