### PR TITLE
refactor: stable Crashlytics messages with breadcrumb context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 #### Changed
 - Error-tracking non-fatals now use stable wrapper messages with per-event context attached as Crashlytics breadcrumbs (`Tracker.log("module.field=value")`) instead of interpolating dynamic data into the wrapper message; improves Crashlytics issue titles and BigQuery searchability
+- Retired "button" from internal error and log messages in favor of "audio" — user-facing copy already uses the brand name "Bomp"; internal messages stay neutral so the brand doesn't leak into operations
 - Migrated Firebase to per-build-type projects (bomp-prod for release, bomp-debug for debug); added BigQuery export documentation
 - About screen's external Legal & Privacy links now open extensionless URLs (`/privacy-policy`, `/data-safety`, `/terms-of-service`) — GitHub Pages serves the same content under both forms, so this is a cosmetic cleanup with no destination or behavior change
 - Routed the audio share flow through `SoundsViewModel` with Channel-based one-shot events, aligning ADR 0002 (constructor injection) and ADR 0003 (Channel for one-shot events); `ShareFeature` is split into `prepareShareIntent` (VM-side I/O) and `launchChooser` (UI-side)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 ### For nerds 🤓
 
 #### Changed
+- Error-tracking non-fatals now use stable wrapper messages with per-event context attached as Crashlytics breadcrumbs (`Tracker.log("module.field=value")`) instead of interpolating dynamic data into the wrapper message; improves Crashlytics issue titles and BigQuery searchability
 - Migrated Firebase to per-build-type projects (bomp-prod for release, bomp-debug for debug); added BigQuery export documentation
 - About screen's external Legal & Privacy links now open extensionless URLs (`/privacy-policy`, `/data-safety`, `/terms-of-service`) — GitHub Pages serves the same content under both forms, so this is a cosmetic cleanup with no destination or behavior change
 - Routed the audio share flow through `SoundsViewModel` with Channel-based one-shot events, aligning ADR 0002 (constructor injection) and ADR 0003 (Channel for one-shot events); `ShareFeature` is split into `prepareShareIntent` (VM-side I/O) and `launchChooser` (UI-side)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,15 +339,18 @@ Non-fatal exceptions go to Firebase Crashlytics through the `Tracker` wrapper at
 Hard rules:
 
 - **Do NOT rely on `Timber.e(throwable, message)` to surface a non-fatal.** The `ErrorTrackerTree` (planted in debug and release) forwards only the formatted message via `Tracker.log(...)` — the throwable parameter is silently dropped. `Timber.e` / `Timber.w` are fine for logcat-only diagnostics during dev.
-- For caught exceptions, follow the established pattern (see `PlayerControllerImpl.kt`): wrap the cause in a `RuntimeException` whose message describes the operation, then hand it to `Tracker.track`. The wrapper message becomes the Crashlytics title; the original throwable is preserved as `cause`.
+- **Wrapper message MUST be static.** Crashlytics shows the latest event's message as the issue title in the dashboard, so dynamic interpolation (`"... for $name"`) makes titles flicker between events and breaks BigQuery searches by message. Attach per-event context as a Crashlytics breadcrumb via `Tracker.log("module.field=value")` emitted **immediately before** `Tracker.track(...)`. Module = feature/package directory (`share`, `addbutton`, `playback`, `about`, etc.). Multiple breadcrumbs allowed — emit one `Tracker.log` per key.
+- **Don't use "button" to describe a Sound/Bomp in error or log messages.** It's the legacy term; user-facing copy uses the brand name "Bomp" but internal messages use the neutral "audio" so the brand doesn't leak into ops/BigQuery. The Material Compose `Button` component name is fine — this rule applies to domain references, not framework identifiers or code-level package/class names like `addbutton/`/`AddButtonFeature` (those are out-of-scope churn).
+- For caught exceptions, follow the established pattern (see `PlayerControllerImpl.kt`): wrap the cause in a `RuntimeException` whose **static** message describes the operation, then hand it to `Tracker.track`. The wrapper message becomes the Crashlytics title; the original throwable is preserved as `cause`.
   ```kotlin
   } catch (e: ActivityNotFoundException) {
-      Tracker.track(RuntimeException("Could not launch ACTION_VIEW for $url", e))
+      Tracker.log("about.url=$url")
+      Tracker.track(RuntimeException("Could not launch ACTION_VIEW", e))
       // ...recovery UI (snackbar, fallback) goes here
   }
   ```
 - Expected and recoverable exceptions (e.g. user dismissed a chooser) don't need `Tracker.track`. Reserve it for things you want to investigate.
-- In tests, mock `Tracker` with MockK (see `PlayerControllerTest.kt`): `every { Tracker.track(any()) } answers { nothing }`.
+- In tests, mock `Tracker` with MockK (see `PlayerControllerTest.kt`): `every { Tracker.track(any()) } answers { nothing }` and `every { Tracker.log(any()) } answers { nothing }` for sites that emit breadcrumbs. Lock in the contract with `verify(atLeast = 1) { Tracker.log(any()) }` next to the existing `Tracker.track` assertion — no need to assert exact breadcrumb text (overspecification).
 
 For SQL post-mortem on accumulated crash history, see `CONTRIBUTING.md` § *BigQuery export*. Releases-only — `bomp-prod` exports Crashlytics, Analytics, and Performance to BigQuery (`us` multi-region, daily); `bomp-debug` does not export.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -270,6 +270,20 @@ file store-listing/<locale>/images/*.png   # confirms dimensions and color depth
 ls -lh store-listing/<locale>/images/*.png # confirms weight (Play caps icon at 1024 KB)
 ```
 
+## Error tracking 📡
+
+Non-fatal exceptions go to Crashlytics via the `Tracker` wrapper at
+`commons_android/.../error/Trackable.kt`. The canonical rules and rationale
+live in [`CLAUDE.md` § Error tracking (non-fatals)](CLAUDE.md#error-tracking-non-fatals);
+TL;DR for human contributors:
+
+- Wrap the cause: `Tracker.track(RuntimeException("Static description of the failure", e))`. Keep the message stable — it becomes the Crashlytics issue title.
+- Attach dynamic per-event context as a breadcrumb on the line right above `Tracker.track(...)`:
+  `Tracker.log("module.field=value")`. Module is the feature directory (`share`, `addbutton`, `playback`, `about`, …). Use as many breadcrumbs as needed — one per key.
+- Don't say "button" in messages or comments. These are "audio" internally, "Bomp" in user-facing copy.
+- Verify locally with `adb logcat | grep -E "Tracker|FirebaseCrashlytics"` — the `log(...)` call should appear immediately before the `recordException(...)` line. Crashlytics DebugView surfaces the breadcrumb under the event detail panel.
+- In unit tests that exercise a site that emits a breadcrumb, mock both methods (`every { Tracker.log(any()) } answers { nothing }`) and assert the contract with `verify(atLeast = 1) { Tracker.log(any()) }` alongside the existing track assertion.
+
 ## Analytics events 📊
 
 The app emits Firebase Analytics through the `AnalyticsTracker` wrapper at

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
@@ -70,8 +70,9 @@ private class AddButtonFeatureImpl : AddButtonFeature {
                 FileOutputStream(targetFile).use { fileOutputStream ->
                     context.contentResolver.openInputStream(parsed).use { inputStream ->
                         if (inputStream == null) {
+                            Tracker.log("addbutton.uri=$uri")
                             Tracker.track(
-                                RuntimeException("Inbound URI returned null inputStream after validation: $uri"),
+                                RuntimeException("Inbound URI returned null inputStream after validation"),
                             )
                             return@async R.string.app_addbutton_feedback_uri_unreadable
                         } else {
@@ -88,8 +89,9 @@ private class AddButtonFeatureImpl : AddButtonFeature {
                                         retriever.release()
                                     }
                                 }.onFailure {
+                                    Tracker.log("addbutton.fileName=$fileName")
                                     Tracker.track(
-                                        RuntimeException("Failed to extract duration metadata for $fileName", it),
+                                        RuntimeException("Failed to extract duration metadata", it),
                                     )
                                 }.getOrNull()
                             if (durationMs != null) {
@@ -101,9 +103,11 @@ private class AddButtonFeatureImpl : AddButtonFeature {
                     }
                 }
             } catch (e: FileNotFoundException) {
-                Tracker.track(RuntimeException("Can't create new button's path: $fileName", e))
+                Tracker.log("addbutton.fileName=$fileName")
+                Tracker.track(RuntimeException("Can't create new audio's path", e))
             } catch (e: IOException) {
-                Tracker.track(RuntimeException("Can't copy original audio: $fileName", e))
+                Tracker.log("addbutton.fileName=$fileName")
+                Tracker.track(RuntimeException("Can't copy original audio", e))
             }
 
             feedbackMessage

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerImpl.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerImpl.kt
@@ -35,7 +35,7 @@ internal class PlayerControllerImpl(
         sound: Sound,
     ) {
         if (mediaPlayer.isPlaying) {
-            // User clicked on a new button while still listening an audio, then we should turn that running button off.
+            // User clicked on a new audio while still listening another, then we should turn that running audio off.
             mediaPlayer.stop()
             listener?.onPlayerStop(currentSound!!, completed = false)
         }
@@ -91,14 +91,14 @@ internal class PlayerControllerImpl(
             try {
                 MediaPlayerHelper.setupSoundSource(context, mediaPlayer, sound.rawRes)
             } catch (e: IOException) {
-                Tracker.track(java.lang.RuntimeException("User custom button is not playable", e))
+                Tracker.track(java.lang.RuntimeException("User custom audio is not playable", e))
                 false
             }
         } else {
             try {
                 MediaPlayerHelper.setupSoundSource(context, mediaPlayer, sound.file!!)
             } catch (e: IOException) {
-                Tracker.track(java.lang.RuntimeException("Bundled button is not playable", e))
+                Tracker.track(java.lang.RuntimeException("Bundled audio is not playable", e))
                 false
             }
         }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
@@ -94,7 +94,7 @@ private class ShareFeatureImpl : ShareFeature {
         sound: Sound,
         surface: String,
     ): ShareIntentOutcome {
-        Timber.d("Preparing share intent for button: %s", sound.name)
+        Timber.d("Preparing share intent for audio: %s", sound.name)
 
         val resolution = withContext(Dispatchers.IO) { resolveContentUri(applicationContext, sound) }
         return when (resolution) {
@@ -162,7 +162,8 @@ private class ShareFeatureImpl : ShareFeature {
         try {
             ShareOutcome.Success(FileProvider.getUriForFile(context, authority, file))
         } catch (e: IllegalArgumentException) {
-            Tracker.track(RuntimeException("Couldn't create FileProvider URI for sound: ${sound.file}", e))
+            Tracker.log("share.soundFile=${sound.file}")
+            Tracker.track(RuntimeException("Couldn't create FileProvider URI for sound", e))
             ShareOutcome.Failure(R.string.app_share_feedback_unshareable)
         }
 
@@ -173,7 +174,8 @@ private class ShareFeatureImpl : ShareFeature {
         when {
             sound.file != null -> ShareOutcome.Success(getFile(context, sound.file!!))
             sound.rawRes == 0 -> {
-                Tracker.track(RuntimeException("Sound has neither file URI nor raw resource ID: ${sound.name}"))
+                Tracker.log("share.soundName=${sound.name}")
+                Tracker.track(RuntimeException("Sound has neither file URI nor raw resource ID"))
                 ShareOutcome.Failure(R.string.app_share_feedback_broken_data)
             }
             else -> resolveBundledFileForSharing(context, sound)
@@ -202,7 +204,8 @@ private class ShareFeatureImpl : ShareFeature {
             copy(context.resources.openRawResource(sound.rawRes), FileOutputStream(fileForSharing))
             ShareOutcome.Success(fileForSharing)
         } catch (e: IOException) {
-            Tracker.track(RuntimeException("Couldn't copy bundled audio to shareable directory: ${sound.name}", e))
+            Tracker.log("share.soundName=${sound.name}")
+            Tracker.track(RuntimeException("Couldn't copy bundled audio to shareable directory", e))
             ShareOutcome.Failure(R.string.app_share_feedback_copy_failed)
         }
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreen.kt
@@ -469,6 +469,7 @@ private fun openUrl(
         context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
         true
     } catch (e: ActivityNotFoundException) {
-        Tracker.track(RuntimeException("Could not launch ACTION_VIEW for $url", e))
+        Tracker.log("about.url=$url")
+        Tracker.track(RuntimeException("Could not launch ACTION_VIEW", e))
         false
     }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeatureTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeatureTest.kt
@@ -156,6 +156,7 @@ internal class AddButtonFeatureTest : AbstractRobolectricTest() {
 
         mockkObject(Tracker)
         every { Tracker.track(any()) } answers { nothing }
+        every { Tracker.log(any()) } answers { nothing }
 
         val result =
             runBlocking {
@@ -164,6 +165,7 @@ internal class AddButtonFeatureTest : AbstractRobolectricTest() {
 
         assertThat(result).isEqualTo(R.string.app_addbutton_feedback_uri_unreadable)
         verify(exactly = 1) { Tracker.track(any()) }
+        verify(atLeast = 1) { Tracker.log(any()) }
     }
 
     @Test
@@ -191,6 +193,7 @@ internal class AddButtonFeatureTest : AbstractRobolectricTest() {
 
         mockkObject(Tracker)
         every { Tracker.track(any()) } answers { nothing }
+        every { Tracker.log(any()) } answers { nothing }
 
         val result =
             runBlocking {
@@ -199,6 +202,7 @@ internal class AddButtonFeatureTest : AbstractRobolectricTest() {
 
         assertThat(result).isEqualTo(R.string.app_addbutton_feedback_save_failed)
         verify(exactly = 1) { Tracker.track(any()) }
+        verify(atLeast = 1) { Tracker.log(any()) }
     }
 
     @Test
@@ -208,6 +212,7 @@ internal class AddButtonFeatureTest : AbstractRobolectricTest() {
 
         mockkObject(Tracker)
         every { Tracker.track(any()) } answers { nothing }
+        every { Tracker.log(any()) } answers { nothing }
         mockkConstructor(MediaMetadataRetriever::class)
         every { anyConstructed<MediaMetadataRetriever>().setDataSource(any<String>()) } throws
             RuntimeException("Retriever blew up")
@@ -220,6 +225,7 @@ internal class AddButtonFeatureTest : AbstractRobolectricTest() {
 
         assertThat(result).isEqualTo(R.string.app_addbutton_feedback_saved_ok)
         verify(exactly = 1) { Tracker.track(any()) }
+        verify(atLeast = 1) { Tracker.log(any()) }
     }
 
     /**

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
@@ -104,6 +104,7 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
         mockkObject(Tracker)
         val tracked = slot<Throwable>()
         every { Tracker.track(capture(tracked)) } answers { nothing }
+        every { Tracker.log(any()) } answers { nothing }
         every { mockedContext.startActivity(any()) } answers { nothing }
 
         val outcome =
@@ -111,6 +112,7 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
 
         assertThat((outcome as ShareIntentOutcome.Failure).feedback).isEqualTo(R.string.app_share_feedback_unshareable)
         verify(exactly = 1) { Tracker.track(any()) }
+        verify(atLeast = 1) { Tracker.log(any()) }
         assertThat(tracked.captured).isInstanceOf(RuntimeException::class.java)
         assertThat(tracked.captured.cause).isInstanceOf(IllegalArgumentException::class.java)
         verify(exactly = 0) { mockedContext.startActivity(any()) }
@@ -124,6 +126,7 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
         mockkObject(Tracker)
         val tracked = slot<Throwable>()
         every { Tracker.track(capture(tracked)) } answers { nothing }
+        every { Tracker.log(any()) } answers { nothing }
         every { mockedContext.startActivity(any()) } answers { nothing }
 
         val outcome =
@@ -131,6 +134,7 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
 
         assertThat((outcome as ShareIntentOutcome.Failure).feedback).isEqualTo(R.string.app_share_feedback_broken_data)
         verify(exactly = 1) { Tracker.track(any()) }
+        verify(atLeast = 1) { Tracker.log(any()) }
         assertThat(tracked.captured).isInstanceOf(RuntimeException::class.java)
         verify(exactly = 0) { mockedContext.startActivity(any()) }
     }
@@ -158,6 +162,7 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
         mockkObject(Tracker)
         val tracked = slot<Throwable>()
         every { Tracker.track(capture(tracked)) } answers { nothing }
+        every { Tracker.log(any()) } answers { nothing }
         every { mockedContext.startActivity(any()) } answers { nothing }
 
         val outcome =
@@ -165,6 +170,7 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
 
         assertThat((outcome as ShareIntentOutcome.Failure).feedback).isEqualTo(R.string.app_share_feedback_copy_failed)
         verify(exactly = 1) { Tracker.track(any()) }
+        verify(atLeast = 1) { Tracker.log(any()) }
         assertThat(tracked.captured).isInstanceOf(RuntimeException::class.java)
         assertThat(tracked.captured.cause).isInstanceOf(IOException::class.java)
         verify(exactly = 0) { mockedContext.startActivity(any()) }


### PR DESCRIPTION
### Summary
- Splits every `Tracker.track(RuntimeException("... for $name", e))` into a stable wrapper message + a `Tracker.log("module.field=value")` breadcrumb emitted right before the track call. Crashlytics groups by stack signature in either case, but issue **titles** in the dashboard now stop flickering between sound names per event, so triage and BigQuery searches by message become useful.
- Retires "button" from the few error/log messages and one inline comment that still used it. User-facing copy already migrated to "Bomp" in v2.0.0; internal messages move to the neutral "audio" so the brand doesn't leak into ops or BigQuery. Code identifiers (`addbutton/`, `AddButtonFeature`, etc.) intentionally stay as-is — that rename is a separate scope-break that would touch every file in the package.
- Codifies both rules in `CLAUDE.md` § *Error tracking (non-fatals)* (replaces the example, adds two hard rules) and adds a TL;DR subsection in `CONTRIBUTING.md` so human contributors have the recipe without reading the full ruleset.

### Code review tips
- All 8 dynamic interpolation sites had a `cause` already wired through the `RuntimeException(message, cause)` constructor — preserved unchanged. The cause chain in Crashlytics still surfaces the original `IOException`/`IllegalArgumentException`/etc.
- `AddButtonFeature.kt` carried the `String` `cause` only on the `MediaMetadataRetriever` path's `.onFailure { ... }` and the two outer catches; the null-inputStream synthetic non-fatal still has no cause (correct — there isn't one to chain).
- `ShareFeature.kt` line numbers shifted earlier this week when share moved to a `prepareShareIntent`/`launchChooser` split via `SoundsViewModel`; the refactor here lands on top of that — one Timber breadcrumb at the new ordering ("Preparing share intent for audio") was caught in the same pass.
- Tests now also stub `Tracker.log(any())` and `verify(atLeast = 1) { Tracker.log(any()) }` for refactored sites — locks in the breadcrumb-precedes-track contract without overspecifying the breadcrumb text.

### Already tested
- [x] `./gradlew check` (lint + unit tests clean)
- [x] 4 new tests covering each silent-failure path; all existing tests pass
- [ ] Manual emulator smoke pending (B1: corrupt audio file; B2: revoked URI mid-copy; B3: unsupported codec)

### Stacking note
Depends on #1127 (test-infra fix that neutralises `Tracker` in `AbstractRobolectricTest`). Without #1127 merged first, this PR's CI hits the latent `UncaughtExceptionsBeforeTest` flake on `LandingScreenAnalyticsTest.search_sound` under some class orderings. Plan: merge #1127 → develop, then update this branch with develop and merge.