### PR TITLE
fix(test): de-flake 3 instrumented tests with waitForIdle settle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Debug builds now show a gray launcher icon background again, restoring the visual distinction from release builds that was lost when the icon was modernized to an adaptive icon
 - Failures while extracting duration metadata for a newly imported audio are now tracked as non-fatals (Crashlytics) for visibility; the save still succeeds
 - Stopped a duplicate startup log breadcrumb fired from both CustomBuildTypeApplication and MainApplication; renamed the surviving log to "Starting <build-type> application"
+- De-flaked three instrumented tests by adding animation-settle `waitForIdle()` between deterministic actions and the next assertion: `SearchOverlayTest.systemBackClosesOverlay` (post `Espresso.pressBack()`), `SearchOverlayTest.searchOverlayExposesA11yContentDescriptions` (defensive close at end so the overlay/IME doesn't leak to the next test) and `HomeTabFlowTest.swipeLeftToDeleteThenUndoRestoresSound` (between snackbar appearing and undo click so the M3 enter animation is settled)
+- Bumped stale `AboutScreenFlowTest.EXTERNAL_LEGAL_ITEMS` constant from 3 to 4 to match the Terms of Service link added in the same release
 
 ## \[v2.0.0] - 2026-05-07
 

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenFlowTest.kt
@@ -245,7 +245,7 @@ internal class AboutScreenFlowTest : AbstractUiTest() {
 
     companion object {
         private const val WAIT_TIMEOUT_MS = 5_000L
-        private const val EXTERNAL_LEGAL_ITEMS = 3
+        private const val EXTERNAL_LEGAL_ITEMS = 4
         private val SUPPORTED_HL = setOf("es-AR", "es-419", "es-ES", "en", "pt-BR")
     }
 }

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/HomeTabFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/HomeTabFlowTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeLeft
@@ -92,7 +93,12 @@ internal class HomeTabFlowTest : AbstractUiTest() {
         ActivityScenario.launch(LandingActivity::class.java).use {
             composeRule.awaitNodeWithText(sound.name).performTouchInput { swipeLeft() }
             val undoLabel = context.getString(R.string.app_undo)
-            composeRule.awaitNodeWithText(undoLabel).performClick()
+            // awaitNodeWithText only confirms the snackbar's undo button exists in the
+            // semantics tree; the M3 snackbar enter animation may still be sliding it up.
+            // Settle the animation before clicking so the touch target is stable.
+            composeRule.awaitNodeWithText(undoLabel)
+            composeRule.waitForIdle()
+            composeRule.onNodeWithText(undoLabel).performClick()
             composeRule.awaitNodeWithText(sound.name).assertIsDisplayed()
         }
     }

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlayTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlayTest.kt
@@ -107,6 +107,9 @@ internal class SearchOverlayTest : AbstractUiTest() {
             // Wait for overlay to be on screen before pressing back, otherwise pressBack closes the Activity instead.
             composeRule.awaitNodeWithContentDescription(closeSearchLabel()).assertIsDisplayed()
             Espresso.pressBack()
+            // pressBack is deterministic; flush the back-handler recomposition so the FAB is
+            // settled in the next frame before assertIsDisplayed checks visibility.
+            composeRule.waitForIdle()
             composeRule.awaitNodeWithContentDescription(searchLabel()).assertIsDisplayed()
         }
     }
@@ -120,6 +123,10 @@ internal class SearchOverlayTest : AbstractUiTest() {
             composeRule.awaitNodeWithContentDescription(closeSearchLabel()).assertHasClickAction()
             composeRule.awaitNode(hasSetTextAction()).performTextInput("c")
             composeRule.awaitNodeWithContentDescription(clearSearchLabel()).assertHasClickAction()
+            // Defensive cleanup: close the overlay so the activity tears down with the IME hidden
+            // and no soft-input residue carries over to the next test in the suite.
+            composeRule.awaitNodeWithContentDescription(closeSearchLabel()).performClick()
+            composeRule.waitForIdle()
         }
     }
 


### PR DESCRIPTION
### Summary
- Diagnosed the 3 named flaky instrumented tests (`SearchOverlayTest.systemBackClosesOverlay`, `searchOverlayExposesA11yContentDescriptions`, `HomeTabFlowTest.swipeLeftToDeleteThenUndoRestoresSound`) as the **`render → animation settled`** race that the existing `awaitNode*` helpers don't cover: those wait for the node to exist in semantics, but `assertIsDisplayed`/`performClick` then run on the current frame, hitting a target that is still mid-animation (M3 snackbar enter, overlay close, FAB return).
- Inserted `waitForIdle()` between each deterministic action (`Espresso.pressBack`, snackbar surfacing) and the next assertion/click, per the CLAUDE.md guideline (lines 280-284).
- `searchOverlayExposesA11yContentDescriptions` was the only test in the file leaving the overlay + IME open at teardown — added a defensive close so the next test starts in a canonical state.
- Collateral: bumped stale `AboutScreenFlowTest.EXTERNAL_LEGAL_ITEMS` 3→4 (out of date since the Terms of Service link landed in this same release; was failing on every run).

### Code review tips
- The full diagnostic explored a broader analytics-singleton-isolation hypothesis (`AnalyticsTrackerProvider.setForTest(FakeAnalyticsTracker())` in `AbstractUiTest`) but **that branch was reverted** — empirically it triggered `Process crashed` failures across unrelated tests when added. The minimal animation-settle fix here passed 5 consecutive full-suite runs; broader infrastructure changes can land separately if telemetry-on-test surfaces a real need.
- The `awaitNodeWithText` → `waitForIdle` → `onNodeWithText.performClick` pattern in `swipeLeftToDeleteThenUndoRestoresSound` is the new canonical shape for "wait for the node to appear AND for the animation that brought it on-screen to settle". Worth pulling up into `ComposeTestExtensions` as `awaitDisplayedNode*` if it gets repeated.
- The `EXTERNAL_LEGAL_ITEMS = 4` constant matches the four `isExternal = true` rows in `LegalAndPrivacySection.kt:57-81` (ToS, Privacy Policy, Data Safety, third-party). Future legal additions need both files updated.

### Already tested
- [x] `./gradlew check -x test` — green
- [x] `./gradlew test` (full JVM suite) — green
- [x] `./gradlew app:connectedDebugAndroidTest` × **5 consecutive runs** on cold-booted `Android_14_API_34` AVD — 5/5 green, 49/49 tests passing in each (2 skipped — locale-gated, expected)