### PR TITLE
fix(test): neutralise Tracker globally to stop UncaughtExceptionsBeforeTest flake

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,7 +365,7 @@ Hard rules:
   }
   ```
 - Expected and recoverable exceptions (e.g. user dismissed a chooser) don't need `Tracker.track`. Reserve it for things you want to investigate.
-- In tests, mock `Tracker` with MockK (see `PlayerControllerTest.kt`): `every { Tracker.track(any()) } answers { nothing }`.
+- In tests, `AbstractRobolectricTest` already calls `mockkObject(Tracker)` and stubs both `track` / `log` to no-ops in `@Before` (and unmocks in `@After`). Required because `TestApplication` does not initialise Firebase, so `Tracker.track`'s underlying `FirebaseCrashlytics.getInstance()` would throw `IllegalStateException` and the leaked exception lands in `kotlinx.coroutines.test`'s `ExceptionCollector`, surfacing later as `UncaughtExceptionsBeforeTest` on whichever Compose UI test happens to drain the buffer first. Subclasses do not need to re-mock; just add `verify(exactly = 1) { Tracker.track(any()) }` to lock in the invocation contract. Override the global stub only if you need to capture the throwable (`every { Tracker.track(capture(slot)) } answers { nothing }`).
 
 For SQL post-mortem on accumulated crash history, see `CONTRIBUTING.md` § *BigQuery export*. Releases-only — `bomp-prod` exports Crashlytics, Analytics, and Performance to BigQuery (`us` multi-region, daily); `bomp-debug` does not export.
 

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/AbstractRobolectricTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/AbstractRobolectricTest.kt
@@ -6,6 +6,12 @@
 package com.github.barriosnahuel.vossosunboton
 
 import android.os.Build
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.junit.After
+import org.junit.Before
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -19,4 +25,26 @@ import org.robolectric.annotation.Config
     sdk = [Build.VERSION_CODES.M, Build.VERSION_CODES.TIRAMISU, Build.VERSION_CODES.VANILLA_ICE_CREAM],
     application = TestApplication::class,
 )
-internal abstract class AbstractRobolectricTest
+internal abstract class AbstractRobolectricTest {
+    /**
+     * Globally neutralise [Tracker] so production code paths that fire `Tracker.track(...)` from a
+     * coroutine launched on a `TestDispatcher` do not crash with
+     * `IllegalStateException("Default FirebaseApp is not initialized")` — `TestApplication` does
+     * not initialise Firebase. The escaping exception otherwise lands in
+     * `kotlinx.coroutines.test.internal.ExceptionCollector` (a JVM-global singleton) and surfaces
+     * later as `UncaughtExceptionsBeforeTest` on whichever Compose UI test happens to drain the
+     * buffer first under CI's class-ordering. Subclasses that need to assert specific track
+     * invocations still get them via MockK's `verify { ... }` — the stub only neutralises the body.
+     */
+    @Before
+    fun neutraliseTrackerInTests() {
+        mockkObject(Tracker)
+        every { Tracker.track(any()) } answers { nothing }
+        every { Tracker.log(any()) } answers { nothing }
+    }
+
+    @After
+    fun restoreTrackerAfterTest() {
+        unmockkObject(Tracker)
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeatureTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeatureTest.kt
@@ -18,7 +18,6 @@ import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkConstructor
-import io.mockk.mockkObject
 import io.mockk.spyk
 import io.mockk.unmockkAll
 import io.mockk.verify
@@ -129,9 +128,6 @@ internal class AddButtonFeatureTest : AbstractRobolectricTest() {
         val context = spyk(realContext)
         every { context.contentResolver } returns resolver
 
-        mockkObject(Tracker)
-        every { Tracker.track(any()) } answers { nothing }
-
         val result =
             runBlocking {
                 AddButtonFeature.instance.saveNewButtonAsync(context, "revoked", uri.toString()).await()
@@ -153,9 +149,6 @@ internal class AddButtonFeatureTest : AbstractRobolectricTest() {
         every { resolver.openInputStream(uri) } returns null
         val context = spyk(realContext)
         every { context.contentResolver } returns resolver
-
-        mockkObject(Tracker)
-        every { Tracker.track(any()) } answers { nothing }
 
         val result =
             runBlocking {
@@ -189,9 +182,6 @@ internal class AddButtonFeatureTest : AbstractRobolectricTest() {
         val context = spyk(realContext)
         every { context.contentResolver } returns resolver
 
-        mockkObject(Tracker)
-        every { Tracker.track(any()) } answers { nothing }
-
         val result =
             runBlocking {
                 AddButtonFeature.instance.saveNewButtonAsync(context, "ioerror", uri.toString()).await()
@@ -206,8 +196,6 @@ internal class AddButtonFeatureTest : AbstractRobolectricTest() {
         val uri = Uri.parse("content://test/retriever-fail")
         val context = contextWith(uri, mime = "audio/mpeg", sizeBytes = 1024L)
 
-        mockkObject(Tracker)
-        every { Tracker.track(any()) } answers { nothing }
         mockkConstructor(MediaMetadataRetriever::class)
         every { anyConstructed<MediaMetadataRetriever>().setDataSource(any<String>()) } throws
             RuntimeException("Retriever blew up")

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerTest.kt
@@ -113,8 +113,6 @@ internal class PlayerControllerTest : AbstractRobolectricTest() {
         val listener = mockk<PlayerControllerListener>(relaxed = true)
         every { mp.prepare() } throws java.io.IOException("fail")
 
-        mockkObject(Tracker)
-        every { Tracker.track(any()) } answers { nothing }
         mockkStatic(MediaPlayerHelper::class)
         every { MediaPlayerHelper.setupSoundSource(any(), any(), any<Int>()) } returns true
 
@@ -157,8 +155,6 @@ internal class PlayerControllerTest : AbstractRobolectricTest() {
         val listener = mockk<PlayerControllerListener>(relaxed = true)
         every { mp.start() } throws IllegalStateException("MediaPlayer in invalid state")
 
-        mockkObject(Tracker)
-        every { Tracker.track(any()) } answers { nothing }
         mockkStatic(MediaPlayerHelper::class)
         every { MediaPlayerHelper.setupSoundSource(any(), any(), any<Int>()) } returns true
 

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
@@ -23,7 +23,6 @@ import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
-import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.spyk
@@ -101,7 +100,6 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
         every { FileProvider.getUriForFile(mockedContext, any(), any()) } throws
             IllegalArgumentException("Failed to find configured root that contains /data/local/tmp/external/x.mp3")
 
-        mockkObject(Tracker)
         val tracked = slot<Throwable>()
         every { Tracker.track(capture(tracked)) } answers { nothing }
         every { mockedContext.startActivity(any()) } answers { nothing }
@@ -121,7 +119,6 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
         val sound = givenASoundWithNullUri()
         val mockedContext = spyk<Context>(ApplicationProvider.getApplicationContext<Context>())
 
-        mockkObject(Tracker)
         val tracked = slot<Throwable>()
         every { Tracker.track(capture(tracked)) } answers { nothing }
         every { mockedContext.startActivity(any()) } answers { nothing }
@@ -155,7 +152,6 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
                 .copy(any(), any())
         } throws IOException("simulated disk full while copying raw resource")
 
-        mockkObject(Tracker)
         val tracked = slot<Throwable>()
         every { Tracker.track(capture(tracked)) } answers { nothing }
         every { mockedContext.startActivity(any()) } answers { nothing }
@@ -226,7 +222,6 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
         val baseIntent = Intent().apply { action = Intent.ACTION_SEND }
         every { mockedContext.startActivity(any()) } throws ActivityNotFoundException("no app handles audio share")
 
-        mockkObject(Tracker)
         val tracked = slot<Throwable>()
         every { Tracker.track(capture(tracked)) } answers { nothing }
 


### PR DESCRIPTION
### Summary
- `LandingScreenAnalyticsTest.search_sound` started flaking on CI with `kotlinx.coroutines.test.UncaughtExceptionsBeforeTest`. Root cause is in `SoundsViewModel.init`'s catch handler (introduced 2026-05-03 in `62e9146` alongside `dbd9c57`'s migration of `WelcomeStickerStore` from SharedPreferences to DataStore): when `welcomeStore.isActive()` or `loadSounds()` throws, the catch fires `Tracker.track(...)`, which calls `FirebaseCrashlytics.getInstance()`. `TestApplication` does not initialise Firebase, so that call throws `IllegalStateException` and the leaked exception lands in `kotlinx.coroutines.test`'s `ExceptionCollector` (a JVM-global singleton). Any later `composeTestRule.setContent` invocation drains the buffer via its internal `runTest` and surfaces the buffered exceptions on whichever test happens to be next under CI's class-ordering.
- Fix is purely in the test layer: `AbstractRobolectricTest` now `mockkObject(Tracker)` + stubs `track` / `log` to no-ops in `@Before` (and unmocks in `@After`). Every existing and future Robolectric test inherits the neutralisation.
- Production code is untouched. Considered (and rejected) wrapping `Tracker.track(...)` in `runCatching {}` inside the init catch — that would mask a real production incident if Firebase ever fails to initialise; the right place to fix a test-env quirk is the test layer.
- Cleanup: removes now-redundant `mockkObject(Tracker)` + simple stubs from `ShareFeatureTest`, `AddButtonFeatureTest`, and `PlayerControllerTest`. The capture-slot stubs in `ShareFeatureTest` (`every { Tracker.track(capture(tracked)) }`) stay because they extend the global stub to capture the throwable for assertion. Updates `CLAUDE.md` § *Error tracking (non-fatals)* so future contributors know the base class already mocks `Tracker` and don't re-mock by hand.

### Code review tips
- The fix covers all 5 test classes that construct `SoundsViewModel` (`LandingScreen{Test,AnalyticsTest}`, `SoundsViewModel{Test,SearchTest,AnalyticsTest}`) plus the 3 already-leaking-but-self-mocking ones, plus any future class. Nothing else in the test tree currently exercises Tracker on a coroutine that touches a TestDispatcher.
- JUnit 4 calls `@Before` on the superclass before the subclass; `@After` is reversed. So if a subclass calls `unmockkAll()` in its `@After`, my super `@After`'s `unmockkObject(Tracker)` is a no-op (already unmocked) — safe.
- The flake was 7 days latent (`62e9146` landed 2026-05-03). Earlier PRs went green by luck of CI's inter-class scheduling missing the 3-condition alignment described in the commit message.

### Already tested
- [x] `./gradlew check` (lint + unit tests clean) on this branch
- [x] Reproduced the original flake locally before applying the fix to confirm the diagnosis
- [ ] Will verify CI on this branch turns green before recommending merge