### PR TITLE
feat(addbutton): preview card in Create mode + unified audio engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 ### Added
 - Terms of Service link in the About screen's "Legal & Privacy" section, opening the published page with `?hl=` matched to the device locale (es-AR, es-419, es-ES, en, pt-BR)
+- New Bomp screen now shows the audio preview card with play/pause and seek above the name field, so you can listen to the incoming audio before saving — matching the card already present when renaming a Bomp
 
 ### Fixed
+- Audio preview card in Rename Bomp now advances the seek bar in real time during playback (was static)
+- Starting a preview while a Bomp from the Home list was playing would leave both audio sources playing at once; now starting a new preview cleanly stops the list playback (and vice versa)
 - Sharing a Bomp whose audio path can't be resolved by the FileProvider no longer crashes the app; the failure is reported to the user with a Snackbar and tracked as a non-fatal so it can be investigated
 - Sharing a Bomp no longer crashes the app when no installed app handles audio sharing, when external storage can't be written, or when the Sound has corrupt data — each case shows a tailored Snackbar and is tracked as a non-fatal
 - Tapping play on a Bomp no longer crashes the app if MediaPlayer rejects the start call; the playback error Snackbar is shown instead and a non-fatal is tracked
@@ -29,9 +32,8 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Migrated Firebase to per-build-type projects (bomp-prod for release, bomp-debug for debug); added BigQuery export documentation
 - About screen's external Legal & Privacy links now open extensionless URLs (`/privacy-policy`, `/data-safety`, `/terms-of-service`) — GitHub Pages serves the same content under both forms, so this is a cosmetic cleanup with no destination or behavior change
 - Routed the audio share flow through `SoundsViewModel` with Channel-based one-shot events, aligning ADR 0002 (constructor injection) and ADR 0003 (Channel for one-shot events); `ShareFeature` is split into `prepareShareIntent` (VM-side I/O) and `launchChooser` (UI-side)
-
-#### Changed
 - Banned bare `kotlin.assert(...)` in test sources via a new CircleCI `test-assertion-guard` job; tests must use Truth's `assertThat`, JUnit's `assertEquals`, or the Compose UI Test API. `kotlin.assert` is a no-op without JVM `-ea` and silently masked an `EXTERNAL_LEGAL_ITEMS = 3` count that was stale once Terms of Service shipped. Migrated the existing offenders and bumped the constant to 4
+- Unified the audio playback engine across the Home/Explore list and the AddButton preview card so a single `MediaPlayer` instance owns concurrency, progress polling, and lifecycle (ADR 0005); the AddButton preview no longer instantiates its own player; setDataSource/prepare moved off the main thread via constructor-injected `ioDispatcher`
 
 #### Fixed
 - Debug builds now show a gray launcher icon background again, restoring the visual distinction from release builds that was lost when the icon was modernized to an adaptive icon

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
@@ -6,7 +6,8 @@
 package com.github.barriosnahuel.vossosunboton.feature.addbutton
 
 import android.content.Context
-import android.media.MediaPlayer
+import android.media.MediaMetadataRetriever
+import android.net.Uri
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -48,7 +49,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -61,10 +61,14 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsEvent
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.commons.file.getFile
+import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
 import com.github.barriosnahuel.vossosunboton.model.data.manager.SoundsRepository
 import com.github.barriosnahuel.vossosunboton.ui.AppIcons
 import com.github.barriosnahuel.vossosunboton.ui.home.formatDuration
@@ -73,8 +77,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import timber.log.Timber
-import java.io.IOException
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -158,14 +160,18 @@ fun AddButtonScreen(
                     .padding(innerPadding)
                     .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 8.dp),
         ) {
-            val editSound = (mode as? AddButtonMode.Edit)?.sound
-            val editFile = editSound?.file
-            if (editFile != null) {
+            val previewSource: Uri? =
+                when (val m = mode) {
+                    is AddButtonMode.Create -> m.uri
+                    is AddButtonMode.Edit -> m.sound.file?.let { getFile(context, it).toUri() }
+                }
+            val previewDateAdded = (mode as? AddButtonMode.Edit)?.sound?.dateAdded
+            if (previewSource != null) {
                 AudioPreview(
                     context = context,
-                    fileName = editFile,
+                    source = previewSource,
                     soundName = name,
-                    dateAdded = editSound.dateAdded,
+                    dateAdded = previewDateAdded,
                 )
                 Spacer(modifier = Modifier.height(16.dp))
             }
@@ -236,47 +242,56 @@ fun AddButtonScreen(
 @Composable
 private fun AudioPreview(
     context: Context,
-    fileName: String,
+    source: Uri,
     soundName: String,
     dateAdded: Long?,
 ) {
-    var isPlaying by remember { mutableStateOf(false) }
-    var sliderPosition by remember { mutableFloatStateOf(0f) }
-    val player = remember { MediaPlayer() }
-    var isReady by remember { mutableStateOf(false) }
-    var durationMs by remember { mutableStateOf(0) }
+    val controller = remember { PlayerControllerFactory.instance }
+    var durationMs by remember(source) { mutableStateOf(0) }
 
-    LaunchedEffect(fileName) {
-        val prepared =
+    LaunchedEffect(source) {
+        // MediaMetadataRetriever runs off-thread to avoid blocking the main looper. Failure leaves
+        // durationMs at 0 which keeps the Card hidden — same UX as a player that can't prepare.
+        // Mirrors AddButtonFeature's canonical pattern (same wrapper message so both call-sites
+        // group under one Crashlytics issue; the breadcrumb disambiguates the path).
+        durationMs =
             withContext(Dispatchers.IO) {
                 runCatching {
-                    val file = getFile(context, fileName)
-                    player.setDataSource(file.absolutePath)
-                    player.prepare()
-                    player.duration
-                }
+                    val retriever = MediaMetadataRetriever()
+                    try {
+                        retriever.setDataSource(context, source)
+                        retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)?.toInt() ?: 0
+                    } finally {
+                        retriever.release()
+                    }
+                }.onFailure {
+                    Tracker.log("addbutton.preview.uri=$source")
+                    Tracker.track(RuntimeException("Failed to extract duration metadata", it))
+                }.getOrDefault(0)
             }
-        prepared
-            .onSuccess { duration ->
-                durationMs = duration
-                player.setOnCompletionListener {
-                    isPlaying = false
-                    sliderPosition = 0f
-                }
-                isReady = true
-            }.onFailure { e ->
-                when (e) {
-                    is IOException -> Timber.w(e, "Could not load audio preview for file: %s", fileName)
-                    is IllegalStateException -> Timber.w(e, "MediaPlayer in invalid state for file: %s", fileName)
-                    else -> throw e
-                }
-            }
-    }
-    DisposableEffect(Unit) {
-        onDispose { player.release() }
     }
 
-    if (isReady) {
+    val playbackState by controller.playbackState.collectAsStateWithLifecycle()
+    val isOurPreview = playbackState?.uri == source
+    val isPlaying = isOurPreview && playbackState?.isPlaying == true
+    val sliderPosition =
+        if (isOurPreview && durationMs > 0) {
+            playbackState!!.positionMs.toFloat() / durationMs
+        } else {
+            0f
+        }
+
+    DisposableEffect(source) {
+        onDispose {
+            // Stop preview playback when the user backs out of AddButton. Guard against pre-empting
+            // an unrelated playback (e.g., user backed out and Home is now the active player).
+            if (controller.playbackState.value?.uri == source) {
+                controller.stopPlayingSound()
+            }
+        }
+    }
+
+    if (durationMs > 0) {
         Card(
             border = BorderStroke(width = 1.dp, color = MaterialTheme.colorScheme.outlineVariant),
             colors =
@@ -314,12 +329,10 @@ private fun AudioPreview(
                     ) {
                         FilledIconButton(
                             onClick = {
-                                if (isPlaying) {
-                                    player.pause()
-                                    isPlaying = false
-                                } else {
-                                    player.start()
-                                    isPlaying = true
+                                when {
+                                    isPlaying -> controller.pause()
+                                    isOurPreview -> controller.resume()
+                                    else -> controller.startPlayingUri(context, source)
                                 }
                             },
                             modifier = Modifier.size(44.dp),
@@ -339,8 +352,7 @@ private fun AudioPreview(
                         Slider(
                             value = sliderPosition,
                             onValueChange = { value ->
-                                sliderPosition = value
-                                if (durationMs > 0) player.seekTo((value * durationMs).toInt())
+                                if (durationMs > 0) controller.seekTo((value * durationMs).toInt())
                             },
                             enabled = isPlaying,
                             colors =

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerController.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerController.kt
@@ -6,19 +6,62 @@
 package com.github.barriosnahuel.vossosunboton.feature.playback
 
 import android.content.Context
+import android.net.Uri
 import com.github.barriosnahuel.vossosunboton.model.Sound
+import kotlinx.coroutines.flow.StateFlow
 
 internal object PlayerControllerFactory {
     internal var instance: PlayerController = PlayerControllerImpl()
 }
 
+/**
+ * Snapshot of an in-progress Stream (preview) playback. Null when no Stream is playing.
+ *
+ * Sound (Home/Explore list) playback is reported through [PlayerControllerListener], not through
+ * this StateFlow — see ADR 0005 for the bridging rationale and revisit criteria.
+ */
+internal data class PlaybackState(
+    val uri: Uri,
+    val positionMs: Int,
+    val durationMs: Int,
+    val isPlaying: Boolean,
+)
+
 internal interface PlayerController {
+    /**
+     * Emits a non-null value while a Uri-bound (preview) playback is active. Consumers filter by
+     * matching [PlaybackState.uri] against their own source.
+     */
+    val playbackState: StateFlow<PlaybackState?>
+
     fun startPlayingSound(
         context: Context,
         sound: Sound,
     )
 
+    /**
+     * Starts playback of an arbitrary [uri]. If a Sound is currently playing it is stopped first
+     * (the registered [PlayerControllerListener] sees `onPlayerStop(currentSound, completed = false)`).
+     * Progress is reported via [playbackState] only — listener events are not fired (no Sound to
+     * pass).
+     */
+    fun startPlayingUri(
+        context: Context,
+        uri: Uri,
+    )
+
     fun stopPlayingSound()
+
+    /**
+     * Pauses an in-progress Stream playback. No-op for Sound playback (the Home UX is
+     * "tap again to stop", not pause/resume).
+     */
+    fun pause()
+
+    /**
+     * Resumes a paused Stream playback from its last position.
+     */
+    fun resume()
 
     fun seekTo(positionMs: Int)
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerImpl.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerImpl.kt
@@ -7,79 +7,201 @@ package com.github.barriosnahuel.vossosunboton.feature.playback
 
 import android.content.Context
 import android.media.MediaPlayer
+import android.net.Uri
 import android.os.Handler
 import android.os.Looper
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.model.Sound
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.IOException
 
 internal class PlayerControllerImpl(
     private val mediaPlayer: MediaPlayer = MediaPlayer(),
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob()),
 ) : PlayerController {
     private var listener: PlayerControllerListener? = null
     private var currentSound: Sound? = null
+
+    private val _playbackState = MutableStateFlow<PlaybackState?>(null)
+    override val playbackState: StateFlow<PlaybackState?> = _playbackState.asStateFlow()
 
     private val handler = Handler(Looper.getMainLooper())
     private val progressRunnable =
         object : Runnable {
             override fun run() {
                 if (mediaPlayer.isPlaying) {
-                    listener?.onProgressUpdate(mediaPlayer.currentPosition)
+                    val position = mediaPlayer.currentPosition
+                    listener?.onProgressUpdate(position)
+                    _playbackState.update { it?.copy(positionMs = position) }
                     handler.postDelayed(this, PROGRESS_INTERVAL_MS)
                 }
             }
         }
 
+    /**
+     * Tracks the in-flight setDataSource+prepare coroutine so a new start*() call can cancel the
+     * previous one. `mediaPlayer.reset()` at the top of each new launch interrupts whatever the
+     * previous IO block was doing; the cancelled coroutine bails after withContext returns via the
+     * `isActive` guard so it never fires Tracker / listener events for work that was superseded.
+     */
+    private var prepareJob: Job? = null
+
     override fun startPlayingSound(
         context: Context,
         sound: Sound,
     ) {
-        if (mediaPlayer.isPlaying) {
-            // User clicked on a new audio while still listening another, then we should turn that running audio off.
-            mediaPlayer.stop()
-            listener?.onPlayerStop(currentSound!!, completed = false)
-        }
+        prepareJob?.cancel()
+        prepareJob =
+            scope.launch {
+                preempt()
+                handler.removeCallbacks(progressRunnable)
+                mediaPlayer.reset()
 
-        handler.removeCallbacks(progressRunnable)
-        mediaPlayer.reset()
+                val prepared =
+                    withContext(ioDispatcher) {
+                        runCatching {
+                            if (!setupSoundSource(context, sound)) return@runCatching null
+                            mediaPlayer.prepare()
+                            mediaPlayer.duration
+                        }
+                    }
+                if (!isActive) return@launch
 
-        if (!prepareForPlayback(context, sound)) {
-            listener?.onPlayerError(sound)
-            return
-        }
+                prepared
+                    .onSuccess { durationMs ->
+                        if (durationMs == null) {
+                            listener?.onPlayerError(sound)
+                            return@onSuccess
+                        }
+                        completeSoundStart(sound, durationMs)
+                    }.onFailure { e ->
+                        if (e is IOException) {
+                            Tracker.log("playback.sound=${sound.name}")
+                            Tracker.track(RuntimeException("Media player can't be prepared for playback.", e))
+                        }
+                        listener?.onPlayerError(sound)
+                    }
+            }
+    }
 
-        val durationMs = mediaPlayer.duration
+    private fun completeSoundStart(
+        sound: Sound,
+        durationMs: Int,
+    ) {
         mediaPlayer.setOnCompletionListener {
             handler.removeCallbacks(progressRunnable)
             listener?.onPlayerStop(sound, completed = true)
         }
-
         currentSound = sound
-        try {
-            mediaPlayer.start()
-        } catch (e: IllegalStateException) {
-            Tracker.track(RuntimeException("Media player can't be started for playback.", e))
-            listener?.onPlayerError(sound)
-            return
-        }
-        // onPlayerStart fires AFTER start() succeeds so the UI never flips to "playing" when start
-        // is going to throw. Both happen on Main, so the listener still updates before the first
-        // progressRunnable post lands.
-        listener?.onPlayerStart(sound, durationMs)
-        handler.post(progressRunnable)
+        val started = runCatching { mediaPlayer.start() }
+        started
+            .onSuccess {
+                // onPlayerStart fires AFTER start() succeeds so the UI never flips to "playing" when
+                // start is going to throw. Both happen on Main, so the listener still updates before
+                // the first progressRunnable post lands.
+                listener?.onPlayerStart(sound, durationMs)
+                handler.post(progressRunnable)
+            }.onFailure { e ->
+                if (e is IllegalStateException) {
+                    Tracker.log("playback.sound=${sound.name}")
+                    Tracker.track(RuntimeException("Media player can't be started for playback.", e))
+                    listener?.onPlayerError(sound)
+                }
+            }
     }
 
-    private fun prepareForPlayback(
+    override fun startPlayingUri(
         context: Context,
-        sound: Sound,
-    ): Boolean {
-        if (!setupSoundSource(context, sound)) return false
-        return try {
-            mediaPlayer.prepare()
-            true
-        } catch (e: IOException) {
-            Tracker.track(RuntimeException("Media player can't be prepared for playback.", e))
-            false
+        uri: Uri,
+    ) {
+        prepareJob?.cancel()
+        prepareJob =
+            scope.launch {
+                preempt()
+                handler.removeCallbacks(progressRunnable)
+                mediaPlayer.reset()
+
+                val prepared =
+                    withContext(ioDispatcher) {
+                        runCatching {
+                            mediaPlayer.setDataSource(context, uri)
+                            mediaPlayer.prepare()
+                            mediaPlayer.duration
+                        }
+                    }
+                if (!isActive) return@launch
+
+                prepared
+                    .onSuccess { durationMs -> completeUriStart(uri, durationMs) }
+                    .onFailure { e -> trackUriPrepareFailure(uri, e) }
+            }
+    }
+
+    private fun completeUriStart(
+        uri: Uri,
+        durationMs: Int,
+    ) {
+        mediaPlayer.setOnCompletionListener {
+            handler.removeCallbacks(progressRunnable)
+            _playbackState.value = null
+        }
+        currentSound = null
+        val started = runCatching { mediaPlayer.start() }
+        started
+            .onSuccess {
+                _playbackState.value =
+                    PlaybackState(uri = uri, positionMs = 0, durationMs = durationMs, isPlaying = true)
+                handler.post(progressRunnable)
+            }.onFailure { e ->
+                if (e is IllegalStateException) {
+                    Tracker.log("playback.uri=$uri")
+                    Tracker.track(RuntimeException("MediaPlayer can't be started for preview", e))
+                }
+            }
+    }
+
+    private fun trackUriPrepareFailure(
+        uri: Uri,
+        e: Throwable,
+    ) {
+        when (e) {
+            is IOException -> {
+                Tracker.log("playback.uri=$uri")
+                Tracker.track(RuntimeException("Could not prepare preview", e))
+            }
+            is IllegalArgumentException -> {
+                Tracker.log("playback.uri=$uri")
+                Tracker.track(RuntimeException("Malformed preview uri", e))
+            }
+            is SecurityException -> {
+                Tracker.log("playback.uri=$uri")
+                Tracker.track(RuntimeException("No read permission for preview", e))
+            }
+            else -> throw e
+        }
+    }
+
+    /**
+     * Stops whatever was playing (Sound or Stream) so a new playback can take over. Fires the
+     * Sound-bound listener if a Sound was playing; clears [_playbackState] if a Stream was playing.
+     */
+    private fun preempt() {
+        if (mediaPlayer.isPlaying) {
+            mediaPlayer.stop()
+            currentSound?.let { listener?.onPlayerStop(it, completed = false) }
+            _playbackState.value = null
         }
     }
 
@@ -91,23 +213,55 @@ internal class PlayerControllerImpl(
             try {
                 MediaPlayerHelper.setupSoundSource(context, mediaPlayer, sound.rawRes)
             } catch (e: IOException) {
-                Tracker.track(java.lang.RuntimeException("User custom audio is not playable", e))
+                Tracker.log("playback.sound=${sound.name}")
+                Tracker.track(RuntimeException("User custom audio is not playable", e))
                 false
             }
         } else {
             try {
                 MediaPlayerHelper.setupSoundSource(context, mediaPlayer, sound.file!!)
             } catch (e: IOException) {
-                Tracker.track(java.lang.RuntimeException("Bundled audio is not playable", e))
+                Tracker.log("playback.sound=${sound.name}")
+                Tracker.track(RuntimeException("Bundled audio is not playable", e))
                 false
             }
         }
 
     override fun stopPlayingSound() {
-        if (mediaPlayer.isPlaying) {
-            mediaPlayer.stop()
+        val isPlayingNow = mediaPlayer.isPlaying
+        val hasStreamState = _playbackState.value != null
+        if (isPlayingNow || hasStreamState) {
+            if (isPlayingNow) {
+                mediaPlayer.stop()
+            }
             handler.removeCallbacks(progressRunnable)
-            listener?.onPlayerStop(currentSound!!, completed = false)
+            currentSound?.let { listener?.onPlayerStop(it, completed = false) }
+            _playbackState.value = null
+        }
+    }
+
+    override fun pause() {
+        if (mediaPlayer.isPlaying && _playbackState.value != null) {
+            mediaPlayer.pause()
+            handler.removeCallbacks(progressRunnable)
+            _playbackState.update { it?.copy(isPlaying = false) }
+        }
+    }
+
+    override fun resume() {
+        val state = _playbackState.value
+        if (state != null && !state.isPlaying) {
+            val resumed = runCatching { mediaPlayer.start() }
+            resumed
+                .onSuccess {
+                    _playbackState.update { it?.copy(isPlaying = true) }
+                    handler.post(progressRunnable)
+                }.onFailure { e ->
+                    if (e is IllegalStateException) {
+                        Tracker.log("playback.uri=${state.uri}")
+                        Tracker.track(RuntimeException("MediaPlayer can't resume preview", e))
+                    }
+                }
         }
     }
 

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenAnalyticsTest.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithText
@@ -104,6 +105,19 @@ internal class AddButtonScreenAnalyticsTest : AbstractRobolectricTest() {
             assertThat(event.params["name_changed"]).isEqualTo(false)
             assertThat(event.params["name_length"]).isEqualTo(EXISTING_NAME.length)
             fake.assertNotEmitted("sound_add")
+        }
+    }
+
+    @Test
+    fun `Create mode invokes preview path for incoming URI without crashing the tree`() {
+        // Symmetry contract with Edit mode: AudioPreview's LaunchedEffect must run for the share-incoming URI.
+        // We can't assert the play/pause Card here: SAMPLE_URI is unresolvable so MediaPlayer.prepare fails and
+        // the Card stays hidden by the `if (isReady)` guard. Asserting the form below remains reachable proves
+        // the LaunchedEffect didn't throw. Happy-path interactivity needs a playable test URI — see PR notes.
+        ActivityScenario.launch<AddButtonActivity>(createIntent()).use {
+            composeTestRule.waitForIdle()
+
+            composeTestRule.onNodeWithText(context.getString(R.string.app_addbutton_save)).assertIsDisplayed()
         }
     }
 

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerTest.kt
@@ -7,9 +7,11 @@ package com.github.barriosnahuel.vossosunboton.feature.playback
 
 import android.content.Context
 import android.media.MediaPlayer
+import android.net.Uri
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -18,6 +20,9 @@ import io.mockk.unmockkAll
 import io.mockk.verify
 import io.mockk.verifyOrder
 import io.mockk.verifySequence
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.After
 import org.junit.Test
 
@@ -45,7 +50,7 @@ internal class PlayerControllerTest : AbstractRobolectricTest() {
         mockkStatic(MediaPlayerHelper::class)
         every { MediaPlayerHelper.setupSoundSource(any(), any(), any<Int>()) } returns true
 
-        PlayerControllerImpl(mp).startPlayingSound(context, sound)
+        controllerForTest(mp).startPlayingSound(context, sound)
 
         verifyOrder {
             mp.reset()
@@ -64,7 +69,7 @@ internal class PlayerControllerTest : AbstractRobolectricTest() {
         mockkStatic(MediaPlayerHelper::class)
         every { MediaPlayerHelper.setupSoundSource(any(), any(), any<Int>()) } returns true
 
-        PlayerControllerImpl(mp).startPlayingSound(context, sound)
+        controllerForTest(mp).startPlayingSound(context, sound)
 
         verifyOrder {
             mp.stop()
@@ -82,7 +87,7 @@ internal class PlayerControllerTest : AbstractRobolectricTest() {
         mockkStatic(MediaPlayerHelper::class)
         every { MediaPlayerHelper.setupSoundSource(any(), any(), any<Int>()) } returns false
 
-        PlayerControllerImpl(mp).startPlayingSound(context, sound)
+        controllerForTest(mp).startPlayingSound(context, sound)
 
         verify(exactly = 0) { mp.start() }
     }
@@ -97,7 +102,7 @@ internal class PlayerControllerTest : AbstractRobolectricTest() {
         mockkStatic(MediaPlayerHelper::class)
         every { MediaPlayerHelper.setupSoundSource(any(), any(), any<Int>()) } returns false
 
-        val controller = PlayerControllerImpl(mp)
+        val controller = controllerForTest(mp)
         controller.setOnStartStopListener(listener)
         controller.startPlayingSound(context, sound)
 
@@ -116,7 +121,7 @@ internal class PlayerControllerTest : AbstractRobolectricTest() {
         mockkStatic(MediaPlayerHelper::class)
         every { MediaPlayerHelper.setupSoundSource(any(), any(), any<Int>()) } returns true
 
-        val controller = PlayerControllerImpl(mp)
+        val controller = controllerForTest(mp)
         controller.setOnStartStopListener(listener)
         controller.startPlayingSound(context, sound)
 
@@ -137,7 +142,7 @@ internal class PlayerControllerTest : AbstractRobolectricTest() {
         mockkStatic(MediaPlayerHelper::class)
         every { MediaPlayerHelper.setupSoundSource(any(), any(), any<Int>()) } returns true
 
-        val controller = PlayerControllerImpl(mp)
+        val controller = controllerForTest(mp)
         controller.setOnStartStopListener(listener)
         controller.startPlayingSound(context, sound)
 
@@ -158,7 +163,7 @@ internal class PlayerControllerTest : AbstractRobolectricTest() {
         mockkStatic(MediaPlayerHelper::class)
         every { MediaPlayerHelper.setupSoundSource(any(), any(), any<Int>()) } returns true
 
-        val controller = PlayerControllerImpl(mp)
+        val controller = controllerForTest(mp)
         controller.setOnStartStopListener(listener)
         controller.startPlayingSound(context, sound)
 
@@ -180,7 +185,7 @@ internal class PlayerControllerTest : AbstractRobolectricTest() {
         mockkStatic(MediaPlayerHelper::class)
         every { MediaPlayerHelper.setupSoundSource(any(), any(), any<Int>()) } returns true
 
-        val controller = PlayerControllerImpl(mp)
+        val controller = controllerForTest(mp)
         controller.setOnStartStopListener(listener)
         controller.startPlayingSound(context, sound)
         completionSlot.captured.onCompletion(mp)
@@ -199,7 +204,7 @@ internal class PlayerControllerTest : AbstractRobolectricTest() {
         mockkStatic(MediaPlayerHelper::class)
         every { MediaPlayerHelper.setupSoundSource(any(), any(), any<Int>()) } returns true
 
-        val controller = PlayerControllerImpl(mp)
+        val controller = controllerForTest(mp)
         controller.setOnStartStopListener(listener)
         controller.startPlayingSound(context, sound)
         controller.stopPlayingSound()
@@ -208,10 +213,102 @@ internal class PlayerControllerTest : AbstractRobolectricTest() {
     }
 
     @Test
+    fun `startPlayingUri emits a Stream PlaybackState with the given uri`() {
+        val context = mockk<Context>(relaxed = true)
+        val mp = givenAnIdleMediaPlayer()
+        every { mp.duration } returns 5_000
+        val uri = Uri.parse("content://test/clip.mp3")
+
+        val controller = controllerForTest(mp)
+        controller.startPlayingUri(context, uri)
+
+        val state = controller.playbackState.value
+        assertThat(state).isNotNull()
+        assertThat(state!!.uri).isEqualTo(uri)
+        assertThat(state.durationMs).isEqualTo(5_000)
+        assertThat(state.isPlaying).isTrue()
+    }
+
+    @Test
+    fun `startPlayingUri while a Sound is playing pre-empts it via onPlayerStop`() {
+        // Concurrency invariant from ADR 0005: starting a Stream stops any currently-playing Sound.
+        val context = mockk<Context>(relaxed = true)
+        val sound = Sound("test", rawRes = 1)
+        val mp = mockk<MediaPlayer>(relaxed = true)
+        every { mp.isPlaying } returnsMany listOf(false, true, false)
+        every { mp.duration } returns 5_000
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+
+        mockkStatic(MediaPlayerHelper::class)
+        every { MediaPlayerHelper.setupSoundSource(any(), any(), any<Int>()) } returns true
+
+        val controller = controllerForTest(mp)
+        controller.setOnStartStopListener(listener)
+        controller.startPlayingSound(context, sound)
+        controller.startPlayingUri(context, Uri.parse("content://test/clip.mp3"))
+
+        verify { listener.onPlayerStop(sound, completed = false) }
+    }
+
+    @Test
+    fun `pause flips isPlaying to false in the current PlaybackState`() {
+        val context = mockk<Context>(relaxed = true)
+        val mp = givenAnIdleMediaPlayer()
+        every { mp.duration } returns 5_000
+        val uri = Uri.parse("content://test/clip.mp3")
+
+        val controller = controllerForTest(mp)
+        controller.startPlayingUri(context, uri)
+        every { mp.isPlaying } returns true
+        controller.pause()
+
+        verify { mp.pause() }
+        assertThat(controller.playbackState.value?.isPlaying).isFalse()
+        assertThat(controller.playbackState.value?.uri).isEqualTo(uri)
+    }
+
+    @Test
+    fun `resume flips isPlaying back to true after a pause`() {
+        val context = mockk<Context>(relaxed = true)
+        val mp = givenAnIdleMediaPlayer()
+        every { mp.duration } returns 5_000
+
+        val controller = controllerForTest(mp)
+        controller.startPlayingUri(context, Uri.parse("content://test/clip.mp3"))
+        every { mp.isPlaying } returns true
+        controller.pause()
+        controller.resume()
+
+        // start() is called twice: once on startPlayingUri, once on resume.
+        verify(exactly = 2) { mp.start() }
+        assertThat(controller.playbackState.value?.isPlaying).isTrue()
+    }
+
+    @Test
+    fun `stopPlayingSound clears a paused Stream PlaybackState even when the player is not currently playing`() {
+        // Regression guard for the AudioPreview onDispose path: when the user pauses then closes the
+        // screen, the player is in PAUSED state (isPlaying == false) but the StateFlow still holds
+        // the preview. stopPlayingSound must clear it so a future preview doesn't see stale state.
+        val context = mockk<Context>(relaxed = true)
+        val mp = mockk<MediaPlayer>(relaxed = true)
+        every { mp.isPlaying } returnsMany listOf(false, true, false, false)
+        every { mp.duration } returns 5_000
+
+        val controller = controllerForTest(mp)
+        controller.startPlayingUri(context, Uri.parse("content://test/clip.mp3"))
+        controller.pause()
+        assertThat(controller.playbackState.value).isNotNull()
+
+        controller.stopPlayingSound()
+
+        assertThat(controller.playbackState.value).isNull()
+    }
+
+    @Test
     fun `seekTo delegates to mediaPlayer seekTo`() {
         val mp = givenAnIdleMediaPlayer()
 
-        PlayerControllerImpl(mp).seekTo(1500)
+        controllerForTest(mp).seekTo(1500)
 
         verify { mp.seekTo(1500) }
     }
@@ -228,9 +325,23 @@ internal class PlayerControllerTest : AbstractRobolectricTest() {
             every { it.isPlaying } returns false
         }
 
+    /**
+     * Constructs the controller with eager dispatchers so coroutine bodies in start*() complete
+     * before the test method moves to its `verify {}` block. UnconfinedTestDispatcher resumes the
+     * continuation on the calling thread, so withContext(ioDispatcher) does not actually schedule.
+     */
+    private fun controllerForTest(mp: MediaPlayer): PlayerControllerImpl {
+        val dispatcher = UnconfinedTestDispatcher()
+        return PlayerControllerImpl(
+            mediaPlayer = mp,
+            ioDispatcher = dispatcher,
+            scope = CoroutineScope(dispatcher + SupervisorJob()),
+        )
+    }
+
     private fun whenCallingPlayerControllerStop(mockedMediaPlayer: MediaPlayer) {
         mockkObject(PlayerControllerFactory)
-        every { PlayerControllerFactory.instance } returns PlayerControllerImpl(mockedMediaPlayer)
+        every { PlayerControllerFactory.instance } returns controllerForTest(mockedMediaPlayer)
         PlayerControllerFactory.instance.stopPlayingSound()
     }
 

--- a/docs/adr/0005-unified-audio-player.md
+++ b/docs/adr/0005-unified-audio-player.md
@@ -1,0 +1,167 @@
+# ADR 0005 — Unified audio player across Home and previews
+
+- **Status:** Accepted
+- **Date:** 2026-05-09
+- **Supersedes:** —
+
+## Context
+
+Until this ADR, audio playback in the app lived in two parallel implementations:
+
+1. **`PlayerController` (singleton, listener-based)** — owns one `MediaPlayer` instance, plays
+   `Sound`-bound audio, reports start/stop/progress via `PlayerControllerListener` to
+   `SoundsViewModel`. Drives the Home/Explore/Favorites lists.
+2. **A second `MediaPlayer` instantiated locally inside the `AudioPreview` Composable in
+   `AddButtonScreen`** — Edit-mode pre-existing, Create-mode added in `feature/addbutton-create-preview`.
+   Plays a local `Uri` (file or `content://`), independent of `PlayerController`. Did not advance the
+   slider during playback (no progress polling) and could play **concurrently** with whatever the Home
+   list was playing.
+
+The duplication was structural debt: any change to playback semantics (e.g., audio focus, gain
+normalization, waveform visualization) had to be applied in two places. The Edit-mode preview also
+quietly suffered the same broken slider, only invisible because most users don't watch the thumb in
+the rename flow.
+
+## Decision drivers
+
+1. **Single source of truth for "what is playing."** The user should never hear two audio sources
+   at once from the same app. Today nothing enforces that.
+2. **Consistent slider/play behavior across surfaces.** A play/pause + seek bar should feel the
+   same whether the user is on Home or in the preview card.
+3. **Future preview surfaces inherit the fix.** Settings test sound, AI voice prompt, sample audio
+   in Explore, etc. — anything that's not a `Sound`-bound list item benefits from a Uri-aware
+   playback path that already handles concurrency, lifecycle, and progress.
+4. **Minimize blast radius right now.** `SoundsViewModel` implements `PlayerControllerListener` and
+   has 22 direct test calls to `viewModel.onPlayer*`. A clean break (refactor everyone to a
+   `StateFlow`-based API in one PR) would multiply the test surface and risk regressing Home, the
+   most critical UX. We accept living with two delivery channels (listener for Home, StateFlow for
+   previews) for now in exchange for shipping the unification of the **engine** without churn in
+   the consumers that already work.
+
+## Decision
+
+**`PlayerController` becomes the single audio engine for the entire app.** Its public contract gains
+three things, in addition to the existing `Sound`-bound API:
+
+1. **`val playbackState: StateFlow<PlaybackState?>`** — emits a non-null value while a
+   `Uri`-bound (preview/Stream) playback is in progress, with `(uri, positionMs, durationMs,
+   isPlaying)`. Null when no Stream playback is active. Today this StateFlow is only emitted to
+   during Stream playback; Home keeps using the listener path. Future PR can migrate Home consumers
+   to read this same StateFlow and the listener interface can be retired.
+
+2. **`fun startPlayingUri(context: Context, uri: Uri)`** — starts playback of an arbitrary
+   `Uri`. If a `Sound` is currently playing in Home, it is stopped first (the existing listener
+   fires `onPlayerStop(currentSound, completed = false)` so Home updates its UI). The new playback
+   is reported via `playbackState` only — no listener events fire (the listener interface is
+   `Sound`-bound and there's no `Sound` to pass).
+
+3. **`fun pause()` and `fun resume()`** — needed by the preview card's pause/resume UX. The Home
+   list does not use them today (its UX is "tap again to stop"); the API is available for future
+   surfaces that want pause/resume semantics.
+
+**`AudioPreview` (in `AddButtonScreen.kt`) drops its local `MediaPlayer`** and routes through
+`PlayerControllerFactory.instance` for both playback and progress. Duration extraction stays
+local via `MediaMetadataRetriever` — same pattern already in `AddButtonFeature.kt:80-87`.
+
+## Threading model
+
+`PlayerControllerImpl` takes two coroutine dependencies in its constructor:
+`ioDispatcher` (default `Dispatchers.IO`) and `scope` (default
+`CoroutineScope(Dispatchers.Main.immediate + SupervisorJob())`). `startPlayingSound` and
+`startPlayingUri` launch on `scope` and use `withContext(ioDispatcher)` to perform the only
+blocking parts of the player lifecycle — `MediaPlayer.setDataSource(...)` and
+`MediaPlayer.prepare()` — off the main thread. Everything else (`reset`, `start`, `pause`,
+`seekTo`, `setOnCompletionListener`, `currentPosition` polling) runs on main because it is
+non-blocking and listener callbacks are dispatched on the main looper.
+
+Why this matters: `setDataSource(context, contentUri)` issues a synchronous binder call to the
+provider that owns the URI; Android propagates the caller's `StrictMode.ThreadPolicy` over that
+binder, so a `DiskReadViolation` in (e.g.) WhatsApp's `MediaProvider` surfaces in our
+debug-only death-penalty path even though the I/O physically happens in the provider's process.
+Wrapping the call with `StrictMode.allowThreadDiskReads()` would be a bypass — the prepare path
+runs in response to a user tap, has no startup-cold-path constraint, and we own the call-site,
+so per CLAUDE.md § *StrictMode debug audit* the right fix is option 1 ("top app-code frame is
+ours: fix the production code") rather than option 2 ("scopable to a known-OK call-site").
+
+Concurrency: each new `start*()` call cancels the in-flight prepare via `prepareJob?.cancel()`
+and immediately calls `mediaPlayer.reset()`, which interrupts whatever the previous IO block
+was doing. The cancelled coroutine, when its `withContext(ioDispatcher)` returns, checks
+`isActive` and bails before mutating state — so it cannot fire `Tracker.track` or listener
+events for work that was superseded.
+
+## Concurrency policy (invariant)
+
+At any time, at most one of the following is true:
+- `PlayerController` is playing a `Sound` (Home/Explore list playback). Reflected in `_playingSound`
+  and `_playbackProgress` of `SoundsViewModel`.
+- `PlayerController` is playing a `Uri` (preview). Reflected in `playbackState`.
+- Nothing is playing.
+
+Starting either kind of playback while the other is in progress **stops the previous one**:
+- New `Sound` start → previous `Sound` stop fires its listener; previous `Stream` clears
+  `_playbackState` (no listener event, no consumer needs it).
+- New `Stream` start → previous `Sound` stop fires its listener; previous `Stream` updates
+  `_playbackState` to the new value.
+
+This invariant is enforced inside `PlayerControllerImpl.startPlayingSound` /
+`startPlayingUri`. Tests guarantee it (see `PlayerControllerImplTest`).
+
+## Options considered (and rejected)
+
+- **(A) Migrate everyone to a single `StateFlow<PlaybackState?>` in one PR.** Cleaner end state but
+  forces 22+ test changes in `SoundsViewModelTest`/`SoundsViewModelAnalyticsTest`, plus the Sticker
+  Cero auto-destruct logic depends on `onPlayerStop(sound, completed=true)` being invoked with the
+  exact `Sound` that was playing — preserving that signal through a generic StateFlow needs careful
+  modeling (a `PlayerEvent.Completed(source)` channel? a flag on `PlaybackState`?). Worth doing,
+  but in a dedicated PR with its own ADR companion. Not now.
+
+- **(B) Keep two `MediaPlayer` instances, share only the slider polling pattern via a Composable
+  helper (`rememberAudioPlayerState(uri)`).** Cheapest fix but doesn't satisfy the "one player"
+  goal — concurrency invariant remains unenforceable, future audio-focus / gain / waveform changes
+  still have two homes. Rejected.
+
+- **(C) Make `AudioPreview` register a transient `PlayerControllerListener` for the duration of the
+  preview, swapping out the Home one.** Brittle (listener-swap dance, easy to leak). Rejected in
+  favor of the parallel StateFlow.
+
+## Invariants
+
+These are grep-able and enforced by `scripts/check-adr-invariants.sh` (CircleCI job
+`adr-invariants`):
+
+- The string `MediaPlayer()` (constructor invocation) must NOT appear in
+  `app/src/main/java/.../feature/addbutton/`. The only `MediaPlayer()` constructor in `app/src/main`
+  must live inside `feature/playback/PlayerControllerImpl.kt`. New audio surfaces must route through
+  `PlayerController`, not allocate their own player.
+
+## Consequences
+
+**Positive:**
+- The user can never hear two audio sources from the app at once.
+- The slider behaves identically in Home and in the preview card (both poll at 100ms via the same
+  `Handler` in `PlayerControllerImpl`).
+- `SoundsViewModel` and its tests are untouched. Home's playback path is preserved bit-for-bit.
+- Adding a future audio surface (settings test sound, sample preview in Explore, etc.) is now a
+  call to `PlayerController.startPlayingUri(...)` plus a `playbackState` collector — no new
+  `MediaPlayer` boilerplate.
+
+**Negative:**
+- First-tap latency on the preview card increases by ~100-200ms (`MediaPlayer.prepare()` happens on
+  tap rather than on Composable mount). Acceptable: matches Home's behavior, and prevents an idle
+  `MediaPlayer` instance from being allocated on every preview view.
+- Two delivery channels for playback events coexist temporarily (listener for Sound, StateFlow for
+  Stream). Documented as intentional bridging; tracked for future unification.
+
+## Revisit criteria
+
+Open a follow-up ADR (and a refactor PR) when **any** of the following becomes true:
+
+1. A second consumer of `playbackState` appears (e.g., a global "now playing" mini-player) — at
+   that point the Sound playback should also emit to `playbackState` and the listener should be
+   retired.
+2. The audio-focus / `AudioFocusRequest` flow needs to be added (in-call interruption handling,
+   Bluetooth headset transitions). The unified player is the right home for that logic.
+3. The codebase moves to `androidx.media3.exoplayer` for any reason. ExoPlayer subsumes both
+   `MediaPlayer` instances and the listener-vs-StateFlow distinction becomes irrelevant.
+4. The Sticker Cero `completed: Boolean` semantic needs to apply to non-Sound playback (unlikely
+   today, but if a "preview must play to completion to count as listened" gating ever appears).


### PR DESCRIPTION
### Summary

- **AudioPreview card now appears in New Bomp** (Create mode) — was Edit-only. The contributor can listen to the incoming audio before naming + saving.
- **Unified audio engine across Home and previews** ([ADR 0005](docs/adr/0005-unified-audio-player.md)): `PlayerController` is now the single owner of the `MediaPlayer`. Gains `playbackState: StateFlow<PlaybackState?>`, `startPlayingUri(uri)`, `pause()`, `resume()`. Concurrency invariant: one playback at a time across Home list and previews (preview pre-empts Home and vice versa).
- **`setDataSource` + `prepare()` moved to `Dispatchers.IO`** via constructor-injected dispatcher + `prepareJob` cancellation — proper StrictMode fix, not `allowThreadDiskReads()` bypass. New start*() cancels the in-flight prepare and bails after `withContext` returns via `isActive` so no Tracker/listener events fire for superseded work.
- Side effect of (2): the slider in the preview card now advances during playback (was static — pre-existing in v2.0.0 Edit). Listed under **Fixed** in CHANGELOG.

### Code review tips

- **`PlayerControllerImpl.kt` is the load-bearing change.** Trace the lifecycle for both `startPlayingSound` (existing path, refactored to coroutines) and `startPlayingUri` (new). Pay attention to the `if (!isActive) return@launch` guard after the IO block and to `preempt()` clearing both `currentSound` listener events and `_playbackState`.
- The Sound-bound listener interface (`PlayerControllerListener`) is **intentionally preserved** to keep `SoundsViewModel` and its 22 listener-method test calls untouched. Stream playback (preview) flows only through `playbackState`. ADR 0005 § *Decision* explains the dual-channel rationale and revisit criteria.
- `AddButtonScreen.AudioPreview` extracts duration via `MediaMetadataRetriever` (off-thread) — same pattern + same Crashlytics wrapper message as `AddButtonFeature.kt:80-87` so both call-sites group under one issue, with `Tracker.log("addbutton.preview.uri=$source")` breadcrumb to disambiguate.
- All `Tracker.track(...)` calls use **static wrapper messages** + `Tracker.log("module.field=value")` breadcrumbs per the new convention from #1124.
- `PlayerControllerTest`: the helper `controllerForTest(mp)` injects `UnconfinedTestDispatcher` for both scope and io so coroutine bodies complete eagerly. Existing tests using `verifyOrder`/`verifySequence` still pass with the same expectations.
- **Manifest `singleTask` on AddButtonActivity is unchanged.** The post-Save flow still uses `finishAndRemoveTask()` (pre-existing on develop). Out-of-scope for this PR — diagnosed and captured in `handoff/2026-05-09-addbutton-save-keep-user-in-flow.md` with the new "intervene as little as possible" design direction.

### Already tested

- [x] `./gradlew check -x test` ✅
- [x] `./gradlew test` ✅ — full suite green; 5 new `PlayerControllerTest` cases for `startPlayingUri`/`pause`/`resume`/Stream-Sound concurrency/paused-Stream cleanup
- [x] **Instrumented canary on Pixel 8**: `HomeTabFlowTest.tapPlaySwapsPlayIconToPause` ✅ — exercises the full async path (tap → coroutine → withContext IO → prepare → listener → UI swap) on real device. Confirms the refactor doesn't regress Home playback.
- [x] **Manual on Pixel 8**: share audio from WhatsApp → Bomp → preview Card appears, Play makes audio start + slider advances + Pause/Resume preserves position; Bomp del Home sounding then opening share + Play preview correctly stops Home (and inverse).

**Coverage gaps surfaced by audit (intentionally not addressed in this PR):**

- Preview play/pause/seek interactivity in instrumented tests requires a `FileProvider` serving a bundled raw resource as a `content://` URI. ~100 LOC of reusable infra; deserves its own PR. The new concurrency invariant is covered at **unit** level (`PlayerControllerTest.startPlayingUri while a Sound is playing pre-empts it via onPlayerStop`), where verification is deterministic.
- `AddButtonCreateFlowTest` and `WelcomeStickerFlowTest` fail on **clean develop** (verified by stashing this PR's changes and re-running) with `IllegalStateException: No compose hierarchies found`. Pre-existing instrumented flake, not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)