### PR TITLE
fix(addbutton): preview source resolution off main thread

### DIFF
--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -160,16 +161,23 @@ fun AddButtonScreen(
                     .padding(innerPadding)
                     .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 8.dp),
         ) {
-            val previewSource: Uri? =
-                when (val m = mode) {
-                    is AddButtonMode.Create -> m.uri
-                    is AddButtonMode.Edit -> m.sound.file?.let { getFile(context, it).toUri() }
-                }
+            // Edit mode resolves the file Uri via getExternalFilesDir(), which trips a StrictMode
+            // DiskReadViolation if it runs synchronously during composition. produceState + IO keeps
+            // composition non-blocking; the null window is invisible because AudioPreview gates on durationMs > 0.
+            val previewSource: Uri? by produceState<Uri?>(initialValue = null, mode) {
+                value =
+                    withContext(Dispatchers.IO) {
+                        when (val m = mode) {
+                            is AddButtonMode.Create -> m.uri
+                            is AddButtonMode.Edit -> m.sound.file?.let { getFile(context, it).toUri() }
+                        }
+                    }
+            }
             val previewDateAdded = (mode as? AddButtonMode.Edit)?.sound?.dateAdded
-            if (previewSource != null) {
+            previewSource?.let { source ->
                 AudioPreview(
                     context = context,
-                    source = previewSource,
+                    source = source,
                     soundName = name,
                     dateAdded = previewDateAdded,
                 )

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenStrictModeTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenStrictModeTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.addbutton
+
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.ui.home.LandingActivity
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.robolectric.annotation.Config
+
+// Smoke coverage for the Edit-mode preview-source resolution path with a non-null Sound.file.
+// The actual StrictMode DiskReadViolation lives in dalvik's BlockGuard hooks (not simulated by
+// Robolectric's JVM File ops), so the disk-on-main-thread guarantee is verified end-to-end by the
+// instrumented AddButtonEditFlowTest on a real debug build with StrictModeConfigurator armed. This
+// test proves the composable launches without throwing when the bug-prone branch is reachable.
+@Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+internal class AddButtonScreenStrictModeTest : AbstractRobolectricTest() {
+    @get:Rule
+    val composeTestRule = createEmptyComposeRule()
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `Edit mode with a non-null sound file launches without crashing`() {
+        val intent =
+            Intent(context, AddButtonActivity::class.java).apply {
+                putExtra(LandingActivity.EXTRA_EDIT_SOUND_NAME, "Existing sound")
+                putExtra(LandingActivity.EXTRA_EDIT_SOUND_FILE, "existing.mp3")
+            }
+
+        ActivityScenario.launch<AddButtonActivity>(intent).use { scenario ->
+            composeTestRule.waitForIdle()
+            assertThat(scenario.state).isEqualTo(Lifecycle.State.RESUMED)
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- StrictMode `DiskReadViolation` killed debug builds when long-pressing a Bomp → tapping "Renombrar"
- Root cause: c023390 resolved the Edit-branch preview Uri synchronously during composition (`getFile()` → `getExternalFilesDir()` → `File.exists()` on main thread)
- Fix: wrap source resolution in `produceState` + `withContext(Dispatchers.IO)`; AudioPreview's `durationMs > 0` gate keeps the brief null window invisible
- No CHANGELOG entry — regression introduced in same `[unreleased]` cycle (v2.0.1), never reached users (per CLAUDE.md)

### Code review tips
- `produceState` key is `mode` so Edit↔Create transitions re-resolve cleanly
- `if (previewSource != null)` → `previewSource?.let { source -> AudioPreview(source = source, ...) }` preserves the same gating semantics
- `AddButtonScreenStrictModeTest` is a smoke test only; the WHY in its file-level comment explains that Robolectric's JVM `File` ops bypass dalvik BlockGuard, so the actual StrictMode hook is verified end-to-end by the instrumented `AddButtonEditFlowTest`

### Already tested
- [x] `./gradlew check -x test` green
- [x] `./gradlew test` green
- [x] `:app:connectedDebugAndroidTest` filtered to `AddButtonEditFlowTest` → 4/4 green on Android_14_API_34
- [x] Verified the violation does NOT reproduce on pristine `origin/develop` (rules out a coincidental GMS flake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)