### PR TITLE
chore: enforce ADR 0005 audio engine invariant in check-adr-invariants.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 #### Added
 - Analytics event `sound_add_abandoned_after_error` fires when the user leaves the Add Button screen with an unresolved save error (lifecycle-driven via `ON_STOP` and explicit Snackbar dismiss); best-effort — process death drops the signal
+- Enforce ADR 0005 audio engine invariant via `check-adr-invariants.sh` and the CircleCI `adr-invariants` job — fails the build if a `MediaPlayer()` constructor appears in `src/main` outside `PlayerControllerImpl.kt`
 
 #### Removed
 - Dead post-save plumbing: `EXTRA_BUTTON_SAVED` / `EXTRA_BUTTON_RENAMED` / `EXTRA_BUTTON_NAME` Intent extras, `SoundsViewModel.buttonSavedEvent` / `buttonRenamedEvent` channels and their `onButtonSaved` / `onButtonRenamed` setters, the `LandingScreen` `LaunchedEffect`s that consumed them, and `AddButtonActivity.navigateBackSaved` / `navigateBackRenamed`

--- a/scripts/check-adr-invariants.sh
+++ b/scripts/check-adr-invariants.sh
@@ -63,6 +63,23 @@ Supersede ADR 0004 or move the call site. The no-runBlocking rule is in CLAUDE.m
 fi
 
 # ============================================================================
+# ADR 0005 — docs/adr/0005-unified-audio-player.md
+# Invariant: the only MediaPlayer() constructor in src/main lives inside
+# feature/playback/PlayerControllerImpl.kt. New audio surfaces must route
+# through PlayerController, not allocate their own player.
+# ============================================================================
+ALLOWED_MEDIAPLAYER="app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerImpl.kt"
+unexpected_mediaplayer=$(
+    grep -rlE --include="*.kt" 'MediaPlayer\s*\(\s*\)' $MAIN_DIRS 2>/dev/null \
+        | grep -vxF "$ALLOWED_MEDIAPLAYER" || true
+)
+if [ -n "$unexpected_mediaplayer" ]; then
+    fail "ADR 0005 broken: MediaPlayer() constructor outside PlayerControllerImpl.kt:
+$unexpected_mediaplayer
+Route through PlayerController.startPlayingUri / startPlayingSound, or supersede ADR 0005."
+fi
+
+# ============================================================================
 # ADR 0006 — docs/adr/0006-no-kotlin-assert-in-tests.md
 # Invariant: no bare kotlin.assert(...) in any test sourceset. The JVM only
 # evaluates the condition under -ea, so a misused assert silently no-ops on


### PR DESCRIPTION
### Summary
- Adds the missing ADR 0005 block to `scripts/check-adr-invariants.sh`. The script now fails if a second `MediaPlayer()` constructor appears anywhere in `src/main` outside `feature/playback/PlayerControllerImpl.kt`, closing the gap left when the ADR was added in c023390.
- Mirrors the structure of the ADR 0004 / 0006 blocks (allowlist + `grep -vxF` + accionable `fail` message).

### Code review tips
- Regex is `MediaPlayer\s*\(\s*\)` (not literal `MediaPlayer()`) to tolerate formatter variations like `MediaPlayer ()` / `MediaPlayer( )`. Current single hit (`PlayerControllerImpl.kt:30`) still matches.
- Scope is `$MAIN_DIRS` (all four modules) rather than just `app/src/main` — paridad con ADR 0002/0003/0004 y consistente con la frase "New audio surfaces must route through PlayerController" del ADR.
- `adr-invariants` CI job re-ejecuta este script, así que el cambio cubre tanto el run local como CI sin tocar `.circleci/config.yml`.

### Already tested
- [x] `bash scripts/check-adr-invariants.sh` pasa clean sobre la branch
- [x] Inyectar manualmente `val foo = MediaPlayer()` en `AddButtonScreen.kt` hace fallar el script con el mensaje correcto, y revertir vuelve a verde
- [x] `./gradlew check -x test` verde (script-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)