### PR TITLE
feat(addbutton): reject haptic when saving Bomp without a name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Shortened the welcome-dismissal snackbar from 10 s to 4 s so the feedback no longer lingers; user-deleted sounds keep the longer Undo window
 - Saving a new Bomp or renaming an existing one now confirms with a brand "voice bubble" overlay that briefly fills the screen with the Bomp's name (inflates with a spring, holds, slides out — metaphor for "your Bomp is on its way") and returns the user to wherever they came from, instead of a long snackbar that lingered after the form. Honors the system "Remove animations" setting with an equivalent static confirmation
 - The "name your Bomp" field now opens with focus and the keyboard ready, saving one tap
+- Tapping Save on the new-Bomp form without a name now plays a "reject" haptic alongside the existing error message, matching the tactile feedback used elsewhere for rejected actions
 
 ### For nerds 🤓
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
@@ -71,6 +72,7 @@ import com.github.barriosnahuel.vossosunboton.commons.android.analytics.Analytic
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
 import com.github.barriosnahuel.vossosunboton.commons.file.getFile
 import com.github.barriosnahuel.vossosunboton.model.data.manager.SoundsRepository
+import com.github.barriosnahuel.vossosunboton.ui.haptics.performRejectHaptic
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -101,6 +103,7 @@ fun AddButtonScreen(
     val retryLabel = stringResource(R.string.app_snackbar_action_retry)
     val tracker = remember(context) { AnalyticsTrackerProvider.get(context.applicationContext) }
     val nameFocusRequester = remember { FocusRequester() }
+    val view = LocalView.current
 
     LaunchedEffect(Unit) {
         // Save the user one tap: the name field is the primary action on this screen, so focus it
@@ -124,6 +127,7 @@ fun AddButtonScreen(
     fun save() {
         if (name.text.isBlank()) {
             nameError = context.getString(R.string.app_addbutton_name_is_required_error)
+            performRejectHaptic(view)
             return
         }
         if (saveOutcome != SaveOutcome.Idle || pendingErrorReason != null) return

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/haptics/Haptics.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/haptics/Haptics.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.haptics
+
+import android.os.Build
+import android.view.HapticFeedbackConstants
+import android.view.View
+
+internal fun performConfirmHaptic(view: View) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+    } else {
+        view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+    }
+}
+
+internal fun performRejectHaptic(view: View) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        view.performHapticFeedback(HapticFeedbackConstants.REJECT)
+    } else {
+        view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+    }
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
@@ -5,9 +5,6 @@
  */
 package com.github.barriosnahuel.vossosunboton.ui.home
 
-import android.os.Build
-import android.view.HapticFeedbackConstants
-import android.view.View
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
@@ -65,6 +62,8 @@ import androidx.compose.ui.unit.dp
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.ui.AppIcons
+import com.github.barriosnahuel.vossosunboton.ui.haptics.performConfirmHaptic
+import com.github.barriosnahuel.vossosunboton.ui.haptics.performRejectHaptic
 import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -245,22 +244,6 @@ fun SoundItem(
             onDelete = onDelete,
             originLabel = originLabel,
         )
-    }
-}
-
-private fun performConfirmHaptic(view: View) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-        view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
-    } else {
-        view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
-    }
-}
-
-private fun performRejectHaptic(view: View) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-        view.performHapticFeedback(HapticFeedbackConstants.REJECT)
-    } else {
-        view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
     }
 }
 

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenHapticTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenHapticTest.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.addbutton
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.view.HapticFeedbackConstants
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.FakeAnalyticsTracker
+import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+
+@Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+internal class AddButtonScreenHapticTest : AbstractRobolectricTest() {
+    @get:Rule
+    val composeTestRule = createEmptyComposeRule()
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    private lateinit var fake: FakeAnalyticsTracker
+    private lateinit var feature: FakeAddButtonFeature
+
+    @Before
+    fun setUp() {
+        fake = FakeAnalyticsTracker()
+        AnalyticsTrackerProvider.setForTest(fake)
+        feature = FakeAddButtonFeature()
+        AddButtonFeatureProvider.setForTest(feature)
+    }
+
+    @After
+    fun tearDown() {
+        AnalyticsTrackerProvider.setForTest(null)
+        AddButtonFeatureProvider.setForTest(null)
+    }
+
+    @Test
+    fun `tapping Save with a blank name triggers reject haptic and keeps the user on the form`() {
+        ActivityScenario.launch<AddButtonActivity>(createIntent()).use { scenario ->
+            composeTestRule.waitForIdle()
+            composeTestRule.onNodeWithText(context.getString(R.string.app_addbutton_save)).performClick()
+            composeTestRule.waitForIdle()
+
+            var lastHaptic = HAPTIC_NEVER_PERFORMED
+            scenario.onActivity { activity ->
+                lastHaptic = activity.window.decorView.findHapticPerformed()
+            }
+
+            assertThat(lastHaptic).isEqualTo(HapticFeedbackConstants.REJECT)
+            assertThat(feature.saveNewCalls).isEqualTo(0)
+            composeTestRule
+                .onNodeWithText(context.getString(R.string.app_addbutton_name_is_required_error))
+                .assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun `tapping Save with a valid name does not trigger reject haptic`() {
+        ActivityScenario.launch<AddButtonActivity>(createIntent()).use { scenario ->
+            composeTestRule.waitForIdle()
+            composeTestRule.onNode(hasSetTextAction()).performTextInput(NEW_NAME)
+            composeTestRule.onNodeWithText(context.getString(R.string.app_addbutton_save)).performClick()
+            composeTestRule.waitForIdle()
+
+            var lastHaptic = HAPTIC_NEVER_PERFORMED
+            scenario.onActivity { activity ->
+                lastHaptic = activity.window.decorView.findHapticPerformed()
+            }
+
+            // The contract guarded here is "REJECT is reserved for failed validation".
+            // Other haptic constants (CONFIRM from the success overlay, etc.) are out of scope for this test.
+            assertThat(lastHaptic).isNotEqualTo(HapticFeedbackConstants.REJECT)
+            assertThat(feature.saveNewCalls).isEqualTo(1)
+        }
+    }
+
+    // Walks the view tree depth-first and returns the first non-default haptic constant recorded by any
+    // ShadowView, since `performHapticFeedback` is called on `LocalView.current` (the AndroidComposeView)
+    // rather than on the decorView. Default value `-1` means "no haptic performed yet" on that view.
+    private fun View.findHapticPerformed(): Int {
+        val ownHaptic = Shadows.shadowOf(this).lastHapticFeedbackPerformed()
+        return when {
+            ownHaptic != HAPTIC_NEVER_PERFORMED -> ownHaptic
+            this is ViewGroup ->
+                (0 until childCount)
+                    .asSequence()
+                    .map { getChildAt(it).findHapticPerformed() }
+                    .firstOrNull { it != HAPTIC_NEVER_PERFORMED }
+                    ?: HAPTIC_NEVER_PERFORMED
+            else -> HAPTIC_NEVER_PERFORMED
+        }
+    }
+
+    private fun createIntent(): Intent =
+        Intent(context, AddButtonActivity::class.java).apply {
+            action = Intent.ACTION_SEND
+            type = "audio/*"
+            putExtra(Intent.EXTRA_STREAM, SAMPLE_URI)
+        }
+
+    private class FakeAddButtonFeature : AddButtonFeature {
+        var saveNewFeedback: Int = R.string.app_addbutton_feedback_saved_ok
+        var saveNewCalls: Int = 0
+
+        override fun saveNewButtonAsync(
+            context: Context,
+            name: String,
+            uri: String,
+        ): Deferred<Int> {
+            saveNewCalls += 1
+            return CompletableDeferred(saveNewFeedback)
+        }
+
+        override fun renameButtonAsync(
+            context: Context,
+            sound: Sound,
+            newName: String,
+        ): Deferred<Unit> = CompletableDeferred(Unit)
+    }
+
+    private companion object {
+        const val HAPTIC_NEVER_PERFORMED = -1
+        val SAMPLE_URI: Uri = Uri.parse("content://test/audio.mp3")
+        const val NEW_NAME = "Test sound"
+    }
+}


### PR DESCRIPTION
### Summary
- Adds a "reject" haptic pulse (`HapticFeedbackConstants.REJECT` on R+, `LONG_PRESS` fallback) inside the blank-name guard of `AddButtonScreen.save()`, so a Save tap on an unnamed Bomp is felt — not just shown via the existing `nameError` message.
- Extracts the two haptic helpers out of `SoundItem.kt` into a shared `ui/haptics/Haptics.kt` (both `internal`), giving future screens (gamification roadmap, Share, About) a single extension point instead of three private copies.
- Picked `View.performHapticFeedback` over Compose's `LocalHapticFeedback` deliberately — `CONFIRM`/`REJECT` constants aren't exposed by Compose at the current pin yet, and the rest of the codebase already follows this pattern.

### Code review tips
- `AddButtonScreen.kt` reads `LocalView.current` at the Composable top level once and closes over `view` from inside `save()`. The captured reference is stable for the lifetime of the composition — same pattern as SoundItem.
- The retry path (snackbar → `save()` again) re-triggers the haptic only if the user deleted the name between attempts. That's intentional — each blank-name attempt is a discrete rejection event.
- Test approach for haptics is non-obvious: `LocalView.current` resolves to the AndroidComposeView hosting the composition, not the activity's decorView. `findHapticPerformed()` walks the view tree depth-first and reads `ShadowView.lastHapticFeedbackPerformed()` (default `-1`) on each. Verified directly against the Robolectric 4.16.1 bytecode.

### Already tested
- [x] `./gradlew check -x test` (ktlint, detekt, spotless, android lint) — green
- [x] `./gradlew test` — all green, including 2 new cases in `AddButtonScreenHapticTest`
- [x] `./scripts/check-adr-invariants.sh` — all invariants pass
- [ ] Manual smoke on physical device (emulator doesn't vibrate): Save with empty name → reject pulse felt; Save with name → no pulse + normal save
- [ ] Local instrumented suite (`app:connectedDebugAndroidTest`) — recommended pre-merge per `CONTRIBUTING.md` since this touches a Composable