### PR TITLE
fix(home): refresh My Sounds after AddButton save/rename

### DIFF
--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -26,6 +26,7 @@ import com.github.barriosnahuel.vossosunboton.feature.welcome.isWelcomeSticker
 import com.github.barriosnahuel.vossosunboton.feature.welcome.welcomeSticker
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.model.data.manager.SoundsRepository
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -35,6 +36,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
@@ -142,15 +144,15 @@ class SoundsViewModel(
 
     init {
         PlayerControllerFactory.instance.setOnStartStopListener(this)
-        // Single coroutine: read welcome-sticker visibility BEFORE loadSounds so the prepend
-        // logic sees the right state on the first paint. selectTab cannot fire before VM init
-        // returns, so loadSounds() always observes a stable `_welcomeStickerVisible` snapshot.
+        // Single coroutine: read welcome-sticker visibility BEFORE the first loadSounds so the
+        // prepend logic sees the right state on the first paint. selectTab cannot fire before VM
+        // init returns, so the first loadSounds always observes a stable
+        // `_welcomeStickerVisible` snapshot.
         //
         // The whole block is wrapped in try/catch so that any failure between `isActive()` and the
         // `try/finally` inside `loadSounds()` still flips `mutableInitialLoadComplete` — otherwise
         // tests that await `isInitialLoadComplete.first { it }` would deadlock.
         viewModelScope.launch(ioDispatcher) {
-            @Suppress("TooGenericExceptionCaught")
             try {
                 val active = welcomeStore.isActive()
                 _welcomeStickerVisible.value = active
@@ -158,12 +160,38 @@ class SoundsViewModel(
                     tracker.log(AnalyticsEvent.WelcomeStickerShown)
                 }
                 loadSounds()
-            } catch (e: Throwable) {
-                // Intentionally broad: anything that escapes between `isActive()` and the
-                // `try/finally` inside `loadSounds()` still has to flip
-                // `mutableInitialLoadComplete` so awaiting tests don't deadlock.
+            } catch (e: CancellationException) {
+                throw e
+            } catch (
+                @Suppress("TooGenericExceptionCaught") e: Throwable,
+            ) {
                 Tracker.track(RuntimeException("SoundsViewModel init failed", e))
                 mutableInitialLoadComplete.value = true
+            }
+        }
+        // Reactive trigger: any change to the persisted sound list (save / rename / pin /
+        // duration / delete) re-runs `loadSounds` so the visible list catches up. This is the
+        // fix for the post-PR-#1130 regression where AddButton save/rename never propagated to
+        // Home — `loadSounds` only ran on cold start and tab switch.
+        //
+        // `drop(1)` skips this collector's own initial snapshot — the `loadSounds()` above has
+        // already consumed it. `repo.sounds` is `distinctUntilChanged` upstream, so a write
+        // that re-encodes to the same JSON does not redundantly re-trigger `loadSounds`.
+        //
+        // `CancellationException` is rethrown so structured concurrency keeps working when
+        // `viewModelScope` is cancelled — important in tests where each VM is cancelled in
+        // `@After` to stop the collector outliving the test.
+        viewModelScope.launch(ioDispatcher) {
+            try {
+                repo.sounds
+                    .drop(1)
+                    .collect { loadSounds() }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (
+                @Suppress("TooGenericExceptionCaught") e: Throwable,
+            ) {
+                Tracker.track(RuntimeException("SoundsViewModel repo observation failed", e))
             }
         }
     }
@@ -401,10 +429,13 @@ class SoundsViewModel(
 
     private fun consumeWelcomeAsync() {
         viewModelScope.launch(ioDispatcher) {
-            @Suppress("TooGenericExceptionCaught")
             try {
                 welcomeStore.consume()
-            } catch (e: Throwable) {
+            } catch (e: CancellationException) {
+                throw e
+            } catch (
+                @Suppress("TooGenericExceptionCaught") e: Throwable,
+            ) {
                 // The in-memory cache flip in `welcomeStore.consume()` already happened, so the
                 // current process behaves correctly. Surface the persistence failure so we can see
                 // why the welcome reappears on the next cold start.
@@ -415,10 +446,13 @@ class SoundsViewModel(
 
     private fun restoreWelcomeAsync() {
         viewModelScope.launch(ioDispatcher) {
-            @Suppress("TooGenericExceptionCaught")
             try {
                 welcomeStore.restore()
-            } catch (e: Throwable) {
+            } catch (e: CancellationException) {
+                throw e
+            } catch (
+                @Suppress("TooGenericExceptionCaught") e: Throwable,
+            ) {
                 // Same shape as `consumeWelcomeAsync` — the in-memory state is already correct;
                 // we only lose the disk persistence of the demoted-position flag.
                 Tracker.track(RuntimeException("Welcome sticker restore persistence failed", e))

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.lifecycle.viewModelScope
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
@@ -17,6 +18,7 @@ import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -32,6 +34,8 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
     @get:Rule
     val composeTestRule = createComposeRule()
 
+    private val createdViewModels = mutableListOf<SoundsViewModel>()
+
     @Before
     fun setUp() {
         mockkObject(PlayerControllerFactory)
@@ -40,6 +44,10 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
 
     @After
     fun tearDown() {
+        // Cancel each VM's `viewModelScope` to stop the reactive `repo.sounds` collector added
+        // in the post-PR-#1130 fix; otherwise it survives the test boundary.
+        createdViewModels.forEach { it.viewModelScope.cancel() }
+        createdViewModels.clear()
         unmockkAll()
     }
 
@@ -72,6 +80,7 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
                 ApplicationProvider.getApplicationContext(),
                 ioDispatcher = UnconfinedTestDispatcher(),
             )
+        createdViewModels += vm
         // Wait for init's loadSounds to populate state — DataStore IO suspends off
         // UnconfinedTestDispatcher, so without this wait, reflection-based injection
         // races with the in-flight load and gets overwritten.

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelAnalyticsTest.kt
@@ -5,6 +5,7 @@
  */
 package com.github.barriosnahuel.vossosunboton.ui.home
 
+import androidx.lifecycle.viewModelScope
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.R
@@ -21,6 +22,7 @@ import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -33,6 +35,7 @@ import org.junit.Test
 
 internal class SoundsViewModelAnalyticsTest : AbstractRobolectricTest() {
     private lateinit var fake: FakeAnalyticsTracker
+    private val createdViewModels = mutableListOf<SoundsViewModel>()
 
     @Before
     fun setUp() {
@@ -50,6 +53,13 @@ internal class SoundsViewModelAnalyticsTest : AbstractRobolectricTest() {
 
     @After
     fun tearDown() {
+        // Cancel each VM's `viewModelScope` so the reactive `repo.sounds` collector added in the
+        // post-PR-#1130 fix doesn't survive past the test boundary. Without this cleanup, the
+        // next test's `clearForTest()` would emit through the old VM's collector, fire
+        // `loadSounds` against the old VM's `_searchQuery`, and leak `search_zero_results`
+        // events into the new test's `fake`.
+        createdViewModels.forEach { it.viewModelScope.cancel() }
+        createdViewModels.clear()
         AnalyticsTrackerProvider.setForTest(null)
         unmockkAll()
     }
@@ -243,6 +253,7 @@ internal class SoundsViewModelAnalyticsTest : AbstractRobolectricTest() {
                 ioDispatcher = UnconfinedTestDispatcher(),
                 searchDebounceMs = searchDebounceMs,
             )
+        createdViewModels += vm
         runBlocking { vm.isInitialLoadComplete.first { it } }
         return vm
     }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelSearchTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelSearchTest.kt
@@ -5,6 +5,7 @@
  */
 package com.github.barriosnahuel.vossosunboton.ui.home
 
+import androidx.lifecycle.viewModelScope
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
 import com.github.barriosnahuel.vossosunboton.model.Sound
@@ -13,6 +14,7 @@ import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.After
@@ -20,6 +22,8 @@ import org.junit.Before
 import org.junit.Test
 
 internal class SoundsViewModelSearchTest : AbstractRobolectricTest() {
+    private val createdViewModels = mutableListOf<SoundsViewModel>()
+
     @Before
     fun setUp() {
         mockkObject(PlayerControllerFactory)
@@ -28,6 +32,11 @@ internal class SoundsViewModelSearchTest : AbstractRobolectricTest() {
 
     @After
     fun tearDown() {
+        // Cancel each VM's `viewModelScope` to stop the reactive `repo.sounds` collector added
+        // in the post-PR-#1130 fix; otherwise it survives the test boundary and pollutes the
+        // next test by re-running `loadSounds` against stale in-memory state.
+        createdViewModels.forEach { it.viewModelScope.cancel() }
+        createdViewModels.clear()
         unmockkAll()
     }
 
@@ -134,11 +143,15 @@ internal class SoundsViewModelSearchTest : AbstractRobolectricTest() {
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    private fun givenAViewModel(): SoundsViewModel =
-        SoundsViewModel(
-            androidx.test.core.app.ApplicationProvider
-                .getApplicationContext(),
-            ioDispatcher = UnconfinedTestDispatcher(),
-            searchDebounceMs = 0L,
-        )
+    private fun givenAViewModel(): SoundsViewModel {
+        val vm =
+            SoundsViewModel(
+                androidx.test.core.app.ApplicationProvider
+                    .getApplicationContext(),
+                ioDispatcher = UnconfinedTestDispatcher(),
+                searchDebounceMs = 0L,
+            )
+        createdViewModels += vm
+        return vm
+    }
 }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
@@ -6,6 +6,7 @@
 package com.github.barriosnahuel.vossosunboton.ui.home
 
 import android.content.Intent
+import androidx.lifecycle.viewModelScope
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.R
@@ -25,6 +26,7 @@ import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -36,7 +38,10 @@ import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Test
 
+@Suppress("LargeClass")
 internal class SoundsViewModelTest : AbstractRobolectricTest() {
+    private val createdViewModels = mutableListOf<SoundsViewModel>()
+
     @Before
     fun setUp() {
         runBlocking {
@@ -49,6 +54,11 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
 
     @After
     fun tearDown() {
+        // Cancel each VM's `viewModelScope` so the reactive `repo.sounds` collector added in the
+        // post-PR-#1130 fix doesn't survive past the test boundary and pollute the next test
+        // (e.g. firing `loadSounds` against the prior VM's stale `_searchQuery`).
+        createdViewModels.forEach { it.viewModelScope.cancel() }
+        createdViewModels.clear()
         unmockkAll()
     }
 
@@ -431,6 +441,47 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
         }
 
     @Test
+    fun `repo save after VM init makes the new sound appear without selectTab`() {
+        // Regression for the post-PR-#1130 bug: AddButton save persisted but the visible list
+        // stayed stale until the user killed and reopened the app. The reactive `combine` in
+        // `observeSoundsList` is what pulls the new emission through. Uses `runBlocking` rather
+        // than `runTest` because the underlying `repo.save` suspends on real `Dispatchers.IO`
+        // (StateFlow propagation runs in real time, not virtual).
+        val context = ApplicationProvider.getApplicationContext<android.app.Application>()
+        val repo = SoundsRepository(context)
+        val viewModel = givenAViewModel()
+        assertThat(viewModel.sounds.value.none { it.name == "fresh" }).isTrue()
+
+        runBlocking {
+            repo.save(Sound("fresh", "fresh.mp3"))
+            withTimeoutOrNull(5_000L) {
+                viewModel.sounds.first { list -> list.any { it.name == "fresh" } }
+            }
+        }
+        assertThat(viewModel.sounds.value.any { it.name == "fresh" }).isTrue()
+    }
+
+    @Test
+    fun `repo rename after VM init replaces the old name in the list without selectTab`() {
+        // Same regression family as the save test above, but for the Edit-flow rename path —
+        // see `AddButtonActivity` and `SoundsRepository.rename`.
+        val context = ApplicationProvider.getApplicationContext<android.app.Application>()
+        val repo = SoundsRepository(context)
+        runBlocking { repo.save(Sound("old-name", "old.mp3")) }
+        val viewModel = givenAViewModel()
+        assertThat(viewModel.sounds.value.any { it.name == "old-name" }).isTrue()
+
+        runBlocking {
+            repo.rename("old-name", "new-name")
+            withTimeoutOrNull(5_000L) {
+                viewModel.sounds.first { list -> list.any { it.name == "new-name" } }
+            }
+        }
+        assertThat(viewModel.sounds.value.any { it.name == "new-name" }).isTrue()
+        assertThat(viewModel.sounds.value.none { it.name == "old-name" }).isTrue()
+    }
+
+    @Test
     fun `sounds are sorted alphabetically`() {
         val viewModel = givenAViewModel()
         val sounds = viewModel.sounds.value
@@ -472,6 +523,7 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
                 welcomeStore = welcomeStore ?: WelcomeStickerStore(context),
                 shareFeature = shareFeature ?: ShareFeature.instance,
             )
+        createdViewModels += vm
         runBlocking { vm.isInitialLoadComplete.first { it } }
         return vm
     }


### PR DESCRIPTION
### Summary
- AddButton save / rename now reflects in My Sounds without needing to kill the app. `SoundsViewModel` was reading `repo.sounds.first()` on cold start + tab switch only; PR #1130 removed the `EXTRA_BUTTON_SAVED`/`EXTRA_BUTTON_RENAMED` Channel that previously refreshed the in-memory list, leaving the VM blind to DataStore writes from `AddButtonActivity`.
- Add a `repo.sounds.drop(1).collect { loadSounds() }` listener in `SoundsViewModel.init`. Any DataStore mutation now fans out as a fresh load. `drop(1)` skips the collector's own initial snapshot since the cold-start `loadSounds()` already consumed it; `repo.sounds` is `distinctUntilChanged` upstream so identical re-encodes do not re-trigger.
- Rethrow `CancellationException` in the four `viewModelScope` launches (init read, repo collector, welcome consume / restore) so structured concurrency works when the scope is cancelled — needed for the new `@After` VM-scope cleanup added across the four `SoundsViewModel*Test` classes (the new collector outliving a test was leaking events and `Tracker.track` calls into the next test's mocks).

### Code review tips
- `SoundsViewModel.kt` `init`: the second `viewModelScope.launch` is the load-bearing change. The KDoc on `SoundsRepository.sounds` warned against multiple collectors calling for `.shareIn(...)`; we still have a single VM-side collector (the existing `loadSounds()` snapshots are independent flow collections of the same cold flow, not subscribers to a shared instance), so the warning's invariant is preserved.
- `togglePin` / `deleteSound` / `restoreSound` / `onPlayerStart` / `onPlayerStop` keep their optimistic in-memory mutations. The new collector triggers `loadSounds()` after each mutation lands in DataStore, producing the same final state — no flicker risk in practice because the optimistic write and the re-derivation produce identical lists.
- Test cleanup: every test class that constructs `SoundsViewModel` now tracks the instance and cancels `viewModelScope` in `@After`. Without this, `clearForTest()` in the next test's `setUp` would emit through the prior VM's collector and call `loadSounds()` against the prior VM's `_searchQuery`, leaking spurious `search_zero_results` events into the next test's `FakeAnalyticsTracker`.
- `CHANGELOG.md` was intentionally NOT updated. Per `CLAUDE.md` § *Changelog*, "Never add a `Fixed` entry for a bug introduced in the same `[unreleased]` cycle". The regression was introduced in PR #1130 which is in the same v2.0.1 cycle, so users never saw it. Flagging this judgment call here for reviewer override if you'd rather document it.

### Already tested
- [x] `./gradlew test` — full suite green (527 tests, 0 failures).
- [x] `./gradlew check -x test` — KtLint, Detekt, Spotless, Android Lint all green.
- [x] `./scripts/check-adr-invariants.sh` — green.
- [x] Two new failing-on-develop regression tests in `SoundsViewModelTest` (repo save / rename after VM init) confirmed to fail before the fix and pass after.
- [ ] Local instrumented suite (`AddButtonCreateFlowTest`, `AddButtonEditFlowTest`, `HomeTabFlowTest`) on Android 14 emulator — **blocked** by a pre-existing `LeakedClosableViolation` from Firebase Crashlytics → `HttpGetRequest` → `OkHttp Inflater` that fires before any test body runs and crashes the process under StrictMode. Reproduced on `develop` HEAD without this PR's changes. Out of scope here; deserves its own ADR-or-matcher fix.

### Closes
Related: #1134 (independent, can merge separately).