### PR TITLE
chore: install CLAUDE.md size-budget system

### DIFF
--- a/.claude/skills/claude-md-audit/SKILL.md
+++ b/.claude/skills/claude-md-audit/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: claude-md-audit
+description: Audit CLAUDE.md against the 40K size budget; propose moves of reference-time content to CONTRIBUTING.md or new/existing ADRs, then apply with user approval. Use when CLAUDE.md approaches 40K chars or feels bloated.
+---
+
+# claude-md-audit
+
+Codified procedure for trimming CLAUDE.md back under the size budget without losing write-time utility. The routing rule lives in CLAUDE.md § "What goes in this file" — apply it here mechanically.
+
+## Procedure
+
+### 1. Measure
+- `wc -c CLAUDE.md` — anchor the audit to this number.
+- Report it back to the user alongside the budget (hard fail at 40K, target ≤ 35K for headroom) and the delta to target.
+
+### 2. Walk the file with the routing axis
+For each `##` section, classify:
+
+- **Write-time → KEEP** — invariants, hard nos, project-specific overrides on platform docs, small canonical snippets (≤ 5 lines) the agent will reach for inline, decision tables (role → intent, label → use).
+- **Reference-time → MOVE to CONTRIBUTING.md § X** — setup procedures, run commands, debugging walkthroughs, operator workflows, ASCII art, multi-step verification flows.
+- **Decision + rationale → MOVE to docs/adr/XXXX-*.md** — *why* the project diverges, alternatives considered, revisit criteria. Mirror format of `docs/adr/0001-*.md` through the latest. Increment the next ADR number.
+- Sections that mix both: **split**. Keep the invariant in CLAUDE.md; link out for the procedure / rationale.
+
+### 3. Sections never to trim
+Flag and stop if proposed changes touch these — they are pure write-time invariant content and trimming them costs more than the chars they save:
+
+- § Sources of truth
+- § Project-specific overrides
+- § Security boundaries
+- § Accessibility (WCAG 2.2 AA)
+- § Design system (role → intent table)
+- § Analytics events (hard rules)
+- § Error tracking (hard rules + RuntimeException wrap snippet)
+- § Copyright headers (the block IS the invariant)
+
+User must explicitly approve any exception.
+
+### 4. Propose, do not execute yet
+Print a section-by-section table to the user:
+
+| Section | Current chars | Action | Δ chars |
+|---|---|---|---|
+| ... | ... | KEEP / TRIM / MOVE TO CONTRIBUTING.md § X / NEW ADR | ... |
+
+Wait for explicit approval before any edit. If plan mode is active, write the plan to the plan file.
+
+### 5. Execute (after approval)
+- Move content to target file. Match target's heading hierarchy and writing style (English; see CLAUDE.md § Repo writing language).
+- In CLAUDE.md, replace moved content with a one-line link: `... see CONTRIBUTING.md § X.` or `... see ADR XXXX`.
+- New ADRs: include an `## Invariants` section if grep-enforceable, and **extend `scripts/check-adr-invariants.sh` in the same PR**.
+- Cross-refs: every `see CONTRIBUTING.md § X` must match an existing heading; every `see ADR XXXX` must map to a real file under `docs/adr/`. Grep verify.
+
+### 6. Re-measure and verify
+- `wc -c CLAUDE.md` — must be under 35K (target) or at minimum under 40K.
+- `bash scripts/check-adr-invariants.sh` — must pass.
+- `./gradlew check -x test` — sanity (meta-only changes shouldn't break the build).
+- **Smoke read**: read CLAUDE.md as a fresh agent. The file still answers: "can I use Hilt?" / "what dispatcher?" / "how do I track errors?" / "top-bar accent color?" / "inbound URI policy?" — if yes, trim preserved write-time utility.
+
+### 7. Commit + PR
+Single PR with `a:docs` label. Frame the description around *what the agent gains* (or doesn't lose), not what content moved where.

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,8 @@ gradle/gradle-daemon-jvm.properties
 *.iml
 
 ### AI Agents
-.claude
+.claude/*
+!.claude/skills/
 
 ### Static Code Analyzers
 config/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 #### Added
 - Analytics event `sound_add_abandoned_after_error` fires when the user leaves the Add Button screen with an unresolved save error (lifecycle-driven via `ON_STOP` and explicit Snackbar dismiss); best-effort — process death drops the signal
 - Enforce ADR 0005 audio engine invariant via `check-adr-invariants.sh` and the CircleCI `adr-invariants` job — fails the build if a `MediaPlayer()` constructor appears in `src/main` outside `PlayerControllerImpl.kt`
+- Three-layer system to keep CLAUDE.md within budget: new top-of-file routing rule that codifies write-time vs reference-time intent, a 40K-char hard limit enforced by `check-adr-invariants.sh`, and a versioned `/claude-md-audit` skill at `.claude/skills/claude-md-audit/SKILL.md` that mechanizes the audit procedure; first run trimmed CLAUDE.md from 41K to ~35K by moving procedures, checklists, and examples to CONTRIBUTING.md while keeping write-time invariants in place
 
 #### Removed
 - Dead post-save plumbing: `EXTRA_BUTTON_SAVED` / `EXTRA_BUTTON_RENAMED` / `EXTRA_BUTTON_NAME` Intent extras, `SoundsViewModel.buttonSavedEvent` / `buttonRenamedEvent` channels and their `onButtonSaved` / `onButtonRenamed` setters, the `LandingScreen` `LaunchedEffect`s that consumed them, and `AddButtonActivity.navigateBackSaved` / `navigateBackRenamed`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Run `/claude-md-audit` when this file approaches 40K or feels bloated.
 ./gradlew :model:test --tests "com.github.barriosnahuel.vossosunboton.model.SomeTest"   # Single test class
 ```
 
-Release-only commands (`app:lintVitalRelease`, `app:bundle`) and emulator workflows in CONTRIBUTING.md. The Android CLI tools — `adb`, `fastboot`, `emulator` — are on `PATH`.
+Release-only commands (`app:lintVitalRelease`, `app:bundle`) in CONTRIBUTING.md § *Release builds*; emulator workflows in § *Testing → Local UI test suite*. The Android CLI tools — `adb`, `fastboot`, `emulator` — are on `PATH`.
 
 ## Module Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,47 +2,40 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## What goes in this file
+
+This file is loaded into every agent's context window. Hard limit: **40K chars** — Claude Code performance degrades above this (enforced by `scripts/check-adr-invariants.sh`). Target ≤ 35K to leave headroom for the next invariant.
+
+Before adding content here, ask: **does the agent need this while typing the next line of code?**
+
+- **Yes** — invariants, hard nos, project-specific overrides on platform docs → here.
+- **No, it's a procedure or run command** → `CONTRIBUTING.md`.
+- **No, it's a decision + rationale + revisit criteria** → `docs/adr/*.md`.
+
+Small canonical snippets (≤ 5 lines) may duplicate across CLAUDE.md and CONTRIBUTING.md when the agent needs them at write-time *and* the human at reference-time. Bash blocks, setup procedures, operator workflows should not — link to CONTRIBUTING.md.
+
+Run `/claude-md-audit` when this file approaches 40K or feels bloated.
+
 ## Commands
 
 ```bash
-# Run unit tests
-./gradlew test
-
-# Run all checks (tests + linting)
-./gradlew check
-
-# Run linting only (detekt + ktlint + checkstyle)
-./gradlew check -x test
-
-# Run Android lint for release
-./gradlew app:lintVitalRelease
-
-# Auto-fix Kotlin code style
-./gradlew ktlintFormat
-
-# Run detekt static analysis
-./gradlew detekt
-
-# Build (skip checks)
-./gradlew app:build -x check
-
-# Build release bundle for Play Store
-./gradlew app:bundle
-
-# Run a single test class
-./gradlew :model:test --tests "com.github.barriosnahuel.vossosunboton.model.SomeTest"
-
-# Apply AGPLv3 copyright header to all .kt files (auto-fix for Spotless violations)
-./gradlew spotlessApply
+./gradlew test                 # Unit tests
+./gradlew check                # Tests + linting
+./gradlew check -x test        # Linting only (detekt + ktlint + spotless + Android Lint)
+./gradlew ktlintFormat         # Auto-fix Kotlin style
+./gradlew detekt               # Static analysis
+./gradlew spotlessApply        # Auto-fix AGPLv3 copyright headers
+./gradlew app:build -x check   # Build, skip checks
+./gradlew :model:test --tests "com.github.barriosnahuel.vossosunboton.model.SomeTest"   # Single test class
 ```
 
-The Android command-line tools — `adb`, `fastboot`, `emulator` — are on `PATH` and available directly when needed.
+Release-only commands (`app:lintVitalRelease`, `app:bundle`) and emulator workflows in CONTRIBUTING.md. The Android CLI tools — `adb`, `fastboot`, `emulator` — are on `PATH`.
 
 ## Module Architecture
 
 Push Me is an Android soundboard app with 4 Gradle modules:
 
-- **`app`** — Activities, Fragments, RecyclerView adapters, feature layer (playback, share, permissions, add-button). Entry point is `LandingActivity`. The Add Button flow lives at `feature/addbutton/` inside this module.
+- **`app`** — Activities, Fragments, RecyclerView adapters, feature layer (playback, share, permissions, add-button). Entry: `LandingActivity`. Add Button flow: `feature/addbutton/`.
 - **`model`** — Business logic: `Sound` data model, data managers, persistence. No Android UI dependencies.
 - **`commons_android`** — Foundation library: Firebase init, Timber logging setup, annotations.
 - **`commons_file`** — File handling utilities (audio I/O).
@@ -51,76 +44,76 @@ Dependency direction: `app` → `model`, `commons_android`, `commons_file`. No d
 
 ## Sources of truth for Android / Kotlin / Compose decisions
 
-For non-trivial decisions, consult the authoritative source first (WebFetch the page, or invoke the linked skill) and cite it. Don't answer from training-data memory in version-sensitive areas — the platform moves. If the source is unreachable, say so and mark the answer as a heuristic.
+For non-trivial decisions, consult the authoritative source first (WebFetch or linked skill) and cite it. Don't answer from training memory in version-sensitive areas — the platform moves. Unreachable source → say so, mark answer as heuristic.
 
 | Area | Authoritative source |
 |---|---|
-| Jetpack Compose: state, recomposition, side-effects, performance, lifecycle-aware APIs | https://developer.android.com/develop/ui/compose |
-| Navigation in Compose | Linked skill `navigation-3` (covers Navigation 3 install/migration, deep links, multi-backstack, Hilt/ViewModel integration) |
+| Jetpack Compose: state, recomposition, side-effects, performance, lifecycle | https://developer.android.com/develop/ui/compose |
+| Navigation in Compose | Linked skill `navigation-3` |
 | XML view → Compose migration | Linked skill `migrate-xml-views-to-jetpack-compose` |
 | Edge-to-edge / system bars / insets | Linked skill `edge-to-edge` |
-| Coroutines, Flow, StateFlow, structured concurrency, dispatchers, testing with `runTest` | https://kotlinlang.org/docs/coroutines-guide.html and https://developer.android.com/kotlin/coroutines |
-| Lifecycle: `repeatOnLifecycle`, `collectAsStateWithLifecycle`, lifecycle-aware components | https://developer.android.com/topic/libraries/architecture/lifecycle |
-| App architecture (UI / domain / data, UDF, ViewModel + UI state, UI events) | https://developer.android.com/topic/architecture and https://developer.android.com/topic/architecture/ui-layer/events |
+| Coroutines, Flow, StateFlow, dispatchers, `runTest` | https://kotlinlang.org/docs/coroutines-guide.html + https://developer.android.com/kotlin/coroutines |
+| Lifecycle: `repeatOnLifecycle`, `collectAsStateWithLifecycle` | https://developer.android.com/topic/libraries/architecture/lifecycle |
+| App architecture (UI/domain/data, UDF, ViewModel + UI state, UI events) | https://developer.android.com/topic/architecture + .../ui-layer/events |
 | DataStore (Preferences/Proto), migration from SharedPreferences | https://developer.android.com/topic/libraries/architecture/datastore |
 | Background work, WorkManager, foreground services, exact alarms | https://developer.android.com/develop/background-work |
 | Permissions / runtime permissions / scoped storage | https://developer.android.com/training/permissions |
-| Accessibility in Compose (semantics, traversal, click labels, custom actions, large text) | https://developer.android.com/develop/ui/compose/accessibility — pairs with WCAG 2.2 AA (see § Accessibility) |
+| Accessibility in Compose (semantics, click labels, custom actions, large text) | https://developer.android.com/develop/ui/compose/accessibility — pairs with WCAG 2.2 AA (§ Accessibility) |
 | AGP 9 migration | Linked skill `agp-9-upgrade` |
 | R8 keep rules audit | Linked skill `r8-analyzer` |
 | Play Billing | Linked skill `play-billing-library-version-upgrade` |
-| Kotlin idioms, conventions, KEEP proposals | https://kotlinlang.org/docs/coding-conventions.html and KEEP at https://github.com/Kotlin/KEEP |
-| Project-specific architectural decisions | `docs/adr/*.md` — read the relevant ADR before changing the area it governs |
+| Kotlin idioms, conventions, KEEP proposals | https://kotlinlang.org/docs/coding-conventions.html + KEEP at https://github.com/Kotlin/KEEP |
+| Project-specific architectural decisions | `docs/adr/*.md` — read the relevant ADR before changing that area |
 
 ## Project-specific overrides (read before changing platform-touching code)
 
-Decisions this repo took that diverge from — or narrow — the generic Android recommendation. The override wins over the public docs *for this codebase*. If you think an override is wrong, raise it before changing — don't silently flip.
+Decisions diverging from or narrowing the generic Android recommendation. The override wins over public docs *for this codebase*. If you think an override is wrong, raise it before changing — don't silently flip.
 
-- **DI: manual factories, no Hilt.** ViewModels are constructed via `viewModelFactory { initializer { ... } }` (see `SoundsViewModel.kt`). Do not introduce Hilt, Koin, or any DI framework without superseding [ADR 0002](docs/adr/0002-no-hilt-manual-viewmodel-factory.md) (rationale, options considered, revisit criteria).
-- **One-shot UI events: `Channel<T>` + `receiveAsFlow()`.** Pattern in `SoundsViewModel._scrollToTopEvent`. Reuse for new events; don't introduce event-as-state ad-hoc, don't add `SharedFlow` "for events". See [ADR 0003](docs/adr/0003-channel-for-one-shot-ui-events.md) for trade-offs and the explicit revisit criteria (delivery-guarantee flows, lost-event reports).
-- **Async / state model:** `viewModelScope` + `StateFlow` for screen state. Pick `Channel` (existing convention, ADR 0003) for one-shot events.
-- **Threading:** dispatchers are *constructor-injected* into ViewModels (default `Dispatchers.IO`). No `runBlocking` in production code, except the analytics-cache-prime exception ([ADR 0004](docs/adr/0004-datastore-sync-api-cache-prime.md)). No raw `Thread { ... }` or `AsyncTask`. No I/O on the main thread.
-- **Persistence:** see § *Persistence* — DataStore Preferences only, `SharedPreferences` forbidden, the sync-API pattern is in-memory cache + async write-back.
+- **DI: manual factories, no Hilt.** ViewModels constructed via `viewModelFactory { initializer { ... } }` (see `SoundsViewModel.kt`). Don't introduce Hilt, Koin, or any DI framework without superseding [ADR 0002](docs/adr/0002-no-hilt-manual-viewmodel-factory.md).
+- **One-shot UI events: `Channel<T>` + `receiveAsFlow()`.** Pattern in `SoundsViewModel._scrollToTopEvent`. Reuse for new events; don't add `SharedFlow` "for events". See [ADR 0003](docs/adr/0003-channel-for-one-shot-ui-events.md) for trade-offs and revisit criteria.
+- **Async / state model:** `viewModelScope` + `StateFlow` for screen state. `Channel` (ADR 0003) for one-shot events.
+- **Threading:** dispatchers *constructor-injected* into ViewModels (default `Dispatchers.IO`). No `runBlocking` in production (except analytics-cache-prime, [ADR 0004](docs/adr/0004-datastore-sync-api-cache-prime.md)). No raw `Thread { ... }` / `AsyncTask`. No I/O on the main thread.
+- **Persistence:** see § *Persistence* — DataStore Preferences only; `SharedPreferences` forbidden; sync-API pattern is in-memory cache + async write-back.
 - **Networking, image loading, Room:** none in the dependency graph today. New deps for any of these need an ADR before the feature PR.
 - **Analytics, error tracking, StrictMode, security, design system, accessibility:** see the dedicated sections below — those rules are stricter than any generic Android guidance and override it.
 
-**Each substantive override is backed by an ADR.** This section is the index; rationale + revisit criteria live in `docs/adr/*.md`. Grep-able invariants are enforced by `scripts/check-adr-invariants.sh` (CircleCI job `adr-invariants`) — failures name the ADR you broke. On dependency bumps (`gradle/libs.versions.toml`, wrapper, any `build.gradle(.kts)`) or after running an upgrade skill, re-read this section and § *Sources of truth* in the same PR.
+**Each substantive override is backed by an ADR.** Rationale + revisit criteria in `docs/adr/*.md`; grep invariants enforced by `scripts/check-adr-invariants.sh` (CI job `adr-invariants`) — failures name the ADR. Re-read this section and § *Sources of truth* on dependency bumps or upgrade-skill runs.
 
 ### Known migration debt
 
 Things the current codebase does that are *not* the recommended pattern. New code uses the recommended form; existing call-sites migrate when touched.
 
-- **`collectAsState()` → `collectAsStateWithLifecycle()`.** The lifecycle-aware variant stops collection in `STOPPED`, avoiding wasted work and stale `StateFlow` references. New Composables collecting a ViewModel `StateFlow` must use `collectAsStateWithLifecycle()`; existing call-sites migrate when their file is touched.
-- **String resources: every user-facing string via `stringResource(R.string.app_*)`.** Plain best practice (i18n + a11y + maintainability). No hardcoded literals in Composables. `contentDescription` for non-decorative `Icon`/`Image` is mandatory and must come from a string resource (see § *Accessibility*); decorative assets use `contentDescription = null` explicitly.
+- **`collectAsState()` → `collectAsStateWithLifecycle()`.** The lifecycle-aware variant stops collection in `STOPPED`, avoiding wasted work and stale `StateFlow` refs. New Composables: `collectAsStateWithLifecycle()`. Existing call-sites migrate when the file is touched.
+- **String resources: every user-facing string via `stringResource(R.string.app_*)`.** Plain best practice (i18n + a11y + maintainability). No hardcoded literals in Composables. `contentDescription` for non-decorative `Icon`/`Image` is mandatory and from a string resource (see § *Accessibility*); decorative assets use `contentDescription = null` explicitly.
 
 ## Stateful Composables — `rememberSaveable` for durable state
 
-`remember { mutableStateOf(...) }` is for transient gesture state (drag offset, dismissable popups). State that represents user progress — typed text, an opened overlay/sheet/sub-screen, an in-flight error — goes through `rememberSaveable` so an Activity recreate (rotation, theme change, system kill) does not silently rewind the user. For non-autosaveable types (sealed classes with data, etc.), write an explicit `Saver` next to the Composable; canonical template is `SaveOutcomeSaver` at the bottom of `AddButtonScreen.kt`, including which variants intentionally collapse on restore and why.
+`remember { mutableStateOf(...) }` is for transient gesture state. Durable progress (typed text, opened overlay/sheet/sub-screen, in-flight error) uses `rememberSaveable` so an Activity recreate (rotation, theme, system kill) doesn't silently rewind the user. Non-autosaveable types need an explicit `Saver` next to the Composable; canonical: `SaveOutcomeSaver` in `AddButtonScreen.kt`.
 
-When a `LaunchedEffect` calls `FocusRequester.requestFocus()` on first composition, wait for the first frame then guard the call: `withFrameNanos { } ; runCatching { requestFocus() }.onFailure { Tracker.log(...) ; Tracker.track(RuntimeException("static title", it)) }`. The bare call silently no-ops if the node is not yet attached (the user loses the IME on the screen's primary input). Reference: `AddButtonScreen.kt`, `SearchOverlay.kt`.
+`LaunchedEffect` calling `FocusRequester.requestFocus()` on first composition: wait for the first frame, then guard: `withFrameNanos { } ; runCatching { requestFocus() }.onFailure { Tracker.log(...) ; Tracker.track(RuntimeException("static title", it)) }`. Bare call no-ops silently if the node isn't yet attached (user loses the IME on the primary input). Reference: `AddButtonScreen.kt`, `SearchOverlay.kt`.
 
 ## Persistence
 
-Use **Jetpack DataStore Preferences** for any new persistent key-value storage. Pattern lives in `model/.../SoundsRepository.kt` (top-level `Context.bompsStore` delegate via `preferencesDataStore(...)` + `ReplaceFileCorruptionHandler`). Mirror it. `WelcomeStickerStore`, `DataStoreFirstFlagStore`, `DataStoreCounterStore` are reference implementations.
+Use **Jetpack DataStore Preferences** for new persistent key-value storage. Pattern: `model/.../SoundsRepository.kt` (top-level `Context.bompsStore` via `preferencesDataStore(...)` + `ReplaceFileCorruptionHandler`). Reference impls: `WelcomeStickerStore`, `DataStoreFirstFlagStore`, `DataStoreCounterStore`.
 
-`SharedPreferences` is **forbidden**. The grep `getSharedPreferences|EncryptedSharedPreferences` must return zero hits in `src/main` across all modules. Reviewers reject any new SharedPrefs in PRs.
+`SharedPreferences` is **forbidden** — grep `getSharedPreferences|EncryptedSharedPreferences` must return zero hits in `src/main` across all modules.
 
-When a call site needs a synchronous read on top of DataStore (e.g. analytics tracker firing events right before navigating to a chooser), use the in-memory-cache + async-write-back pattern from `DataStoreFirstFlagStore.kt` / `DataStoreCounterStore.kt`. This is the **only** documented exception to the no-`runBlocking`-in-production rule — see [ADR 0004](docs/adr/0004-datastore-sync-api-cache-prime.md) for context, scope, and why we don't generalize it. Test fixtures (every store ships `clearForTest()`) are documented in `CONTRIBUTING.md` § *Testing → Test fixtures*.
+For synchronous reads on top of DataStore (e.g. analytics before nav to a chooser), use the in-memory cache + async write-back pattern from `DataStoreFirstFlagStore.kt` / `DataStoreCounterStore.kt`. Only documented exception to the no-`runBlocking`-in-production rule — see [ADR 0004](docs/adr/0004-datastore-sync-api-cache-prime.md). Test fixtures (`clearForTest()` on every store) documented in CONTRIBUTING.md § *Testing → Test fixtures*.
 
 ## Worktree setup
 
 Invariants:
 
-- The repo commits **scrubbed dummy** `google-services.json` at `app/src/{debug,release}/google-services.json` (real `project_id` / `project_number` / `package_name`, fake `mobilesdk_app_id` and `api_key`) so CI compiles and GitGuardian doesn't flag real keys. Real values live only in the working tree, hidden from git via `git update-index --skip-worktree` — **never** unmark skip-worktree and `git add` without first stashing the real file (CONTRIBUTING.md § *Firebase config file* has the safe edit sequence).
-- Two Firebase projects back the build types: `bomp-prod` for release (`com.github.barriosnahuel.vossosunboton`) and `bomp-debug` for debug (`com.github.barriosnahuel.vossosunboton.debug`). The Google Services Gradle plugin auto-resolves per-variant JSON by `package_name`.
-- Release signing requires `nahuelbarrios.keystore-appbundle.pkcs12` and `secure.properties` (with `key.alias`, `key.password`, `store.password`) in the project root — not committed. Debug builds use the included debug keystore and work without these.
-- Bundled audio files (`model/src/debug/res/raw/*.mp3` and `*.ogg`) are not committed; without them debug builds compile and run but the Explore tab is empty.
+- Scrubbed dummy `google-services.json` at `app/src/{debug,release}/` (real `project_id`/`project_number`/`package_name`, fake `mobilesdk_app_id`/`api_key`) is committed so CI compiles. Real values live only in the working tree via `git update-index --skip-worktree` — **never** unmark + `git add` without first stashing the real file.
+- Two Firebase projects: `bomp-prod` (release, `com.github.barriosnahuel.vossosunboton`) + `bomp-debug` (debug, `...vossosunboton.debug`). Google Services plugin auto-resolves per-variant JSON by `package_name`.
+- Release signing requires `nahuelbarrios.keystore-appbundle.pkcs12` + `secure.properties` (`key.alias`, `key.password`, `store.password`) at project root — not committed. Debug uses the included debug keystore.
+- Bundled debug audio (`model/src/debug/res/raw/*.{mp3,ogg}`) not committed — without them Explore tab is empty.
 
-Setup procedures (fresh clone swap, primary-worktree copy, safe edit of the dummy) live in CONTRIBUTING.md § *Firebase config file*.
+Setup procedures (fresh-clone swap, primary-worktree copy, safe edit sequence) in CONTRIBUTING.md § *Firebase config file*.
 
 ## Android resources naming
 
-Every resource name must start with the `resourcePrefix` defined in the module's `build.gradle`:
+Every resource name must start with the `resourcePrefix` from the module's `build.gradle`:
 
 | Module | Prefix |
 |---|---|
@@ -129,13 +122,11 @@ Every resource name must start with the `resourcePrefix` defined in the module's
 | `commons_file` | `commons_file_` |
 | `model` | `model_` |
 
-Logical sub-areas inside `:app` (e.g. Add Button at `feature/addbutton/`) use a secondary prefix on top of `app_` for grouping — `app_addbutton_*`, `app_about_*`. Cluster new resources by feature.
-
-Android Lint enforces this (`ResourceName` check). Violating it fails the build.
+Sub-areas inside `:app` (e.g. `feature/addbutton/`) use a secondary prefix: `app_addbutton_*`, `app_about_*`. Cluster by feature. Android Lint enforces this (`ResourceName`) — violations fail the build.
 
 ## Copyright headers
 
-Every `.kt` source file must start with the AGPLv3 copyright block (enforced by Spotless at CI):
+Every `.kt` source file must start with the AGPLv3 copyright block (enforced by Spotless; `./gradlew spotlessApply` to auto-fix):
 
 ```
 /*
@@ -145,56 +136,36 @@ Every `.kt` source file must start with the AGPLv3 copyright block (enforced by 
  */
 ```
 
-If `./gradlew check` fails with a Spotless violation, run `./gradlew spotlessApply` to auto-fix.
-
-**Do not remove or hide the About screen.** It's the "Appropriate Legal Notices" mechanism required by AGPLv3 §0 (paired with the headers above). Entry point: TopAppBar overflow menu in `LandingScreen.kt`.
+**Do not remove or hide the About screen.** It's the "Appropriate Legal Notices" mechanism required by AGPLv3 §0 (paired with the headers above). Entry: TopAppBar overflow menu in `LandingScreen.kt`.
 
 ## Bug fixes — TDD workflow
 
-When the user reports a bug or says we are going to fix one, follow TDD:
-
-1. **Write a failing test first** that reproduces the bug. Run it to confirm it fails for the right reason.
-2. **Fix the production code** with the minimum change to make it pass.
-3. **Run the full test suite** (`./gradlew test`).
-
-Skip TDD only when the bug lives exclusively in UI rendering or platform wiring that can't be exercised by unit / Robolectric tests (e.g. a pure layout glitch). Note why TDD was skipped.
-
-For **production bugs reported by users** (not local-repro), scope frequency, affected versions, OS distribution, and recurring stack frames in Crashlytics + BigQuery first — see `CONTRIBUTING.md` § *BigQuery export*.
+Bug fixes follow TDD: failing test reproducing the bug → minimum production fix → `./gradlew test`. Skip only when the bug is exclusively in UI rendering or platform wiring not exercisable by unit / Robolectric tests; note why in the PR. For production bugs (not local-repro), scope frequency, versions, OS, recurring stack frames in Crashlytics + BigQuery first. Full procedure + BigQuery patterns: CONTRIBUTING.md § *Testing → Bug fixes — TDD procedure* + § *BigQuery export*.
 
 ## Features — test coverage workflow
 
-Before writing production code for a new feature, identify and agree on the minimum test scenarios:
-
-1. **Happy path** — works as intended under normal conditions.
-2. **Failure modes at system boundaries** — audio I/O, MediaPlayer errors, permissions denied, Play feature delivery failures.
-3. **Smoke test** — see § Activity smoke tests.
-
-Implement tests **alongside** the feature, not after. Any scenario not listed before starting is out of scope for the current PR — note in the PR description.
-
-Skip a scenario only when it lives exclusively in platform wiring not exercisable by unit / Robolectric tests. Note why.
+Before writing production code, agree on minimum scenarios: happy path, failure modes at boundaries (audio I/O, MediaPlayer errors, permissions denied, Play feature delivery), smoke test (§ *Activity smoke tests*). Implement tests **alongside** the feature, not after — anything not listed up-front is out of scope; note in the PR. Skip a scenario only when it's exclusively platform wiring not exercisable by tests; note why. Full procedure: CONTRIBUTING.md § *Testing → Features — test coverage procedure*.
 
 ## Test naming convention
 
-Test names are descriptive sentences, never opaque identifiers. Reports list them verbatim, so they read like a spec.
+Test names are descriptive sentences, never opaque identifiers — reports list them verbatim.
 
-- **JVM tests** under `src/test/` (Robolectric, pure Kotlin): backtick-quoted strings, sentence-case, no trailing period.
+- **JVM tests** (`src/test/`): backtick-quoted strings, sentence-case, no trailing period.
   ```kotlin
-  @Test
-  fun `searchResults emits empty list when query is blank`() { ... }
+  @Test fun `searchResults emits empty list when query is blank`() { ... }
   ```
-- **Instrumented tests** under `src/androidTest/`: camelCase descriptive names — backticks with spaces require DEX format 040, which the current AGP/D8 won't emit at `minSdk` 23. Migrate to backticks when that boundary moves.
+- **Instrumented tests** (`src/androidTest/`): camelCase. Backticks need DEX 040, not emitted by AGP/D8 at `minSdk` 23 — migrate to backticks when that boundary moves.
   ```kotlin
-  @Test
-  fun swipeRightPinsACustomSound() { ... }
+  @Test fun swipeRightPinsACustomSound() { ... }
   ```
 
 ## Test assertions
 
-No bare `kotlin.assert(...)` in test sources — see [ADR 0006](docs/adr/0006-no-kotlin-assert-in-tests.md). Grep-enforced by `scripts/check-adr-invariants.sh` and the CircleCI `test-assertion-guard` job. Use Truth `assertThat(...)`, JUnit `assertEquals`/`assertTrue`/`assertNotNull`, or the Compose UI Test API (`assertCountEquals`, `assertIsDisplayed`). The local check command is in CONTRIBUTING.md § *Testing → Test assertions*.
+No bare `kotlin.assert(...)` in test sources — see [ADR 0006](docs/adr/0006-no-kotlin-assert-in-tests.md). Grep-enforced by `scripts/check-adr-invariants.sh` + CircleCI `test-assertion-guard`. Use Truth `assertThat(...)`, JUnit `assertEquals`/`assertTrue`/`assertNotNull`, or Compose UI Test API (`assertCountEquals`, `assertIsDisplayed`). Local check command: CONTRIBUTING.md § *Testing → Test assertions*.
 
 ## Activity smoke tests
 
-Every `Activity` in `app` must have a smoke test (in `app/src/test/`, extending `AbstractRobolectricTest`) that verifies it reaches `Lifecycle.State.RESUMED` without crashing:
+Every `Activity` in `app` must have a smoke test in `app/src/test/` (extending `AbstractRobolectricTest`) that reaches `Lifecycle.State.RESUMED` without crashing:
 
 ```kotlin
 ActivityScenario.launch(MyActivity::class.java).use { scenario ->
@@ -202,20 +173,15 @@ ActivityScenario.launch(MyActivity::class.java).use { scenario ->
 }
 ```
 
-Mock singleton factories (e.g. `PlayerControllerFactory`) that would crash under Robolectric — canonical template: `LandingActivityTest`. Full-screen Composables with their own business logic (PackageManager calls, raw resource reads, significant state) need a `createComposeRule()` smoke test — canonical template: `AboutScreenTest`.
+Mock singleton factories (e.g. `PlayerControllerFactory`) that crash under Robolectric — canonical: `LandingActivityTest`. Full-screen Composables with business logic (PackageManager calls, raw resources, significant state) need a `createComposeRule()` smoke test — canonical: `AboutScreenTest`.
 
 ## Local UI test suite
 
-Instrumented UI/functional tests live under `app/src/androidTest/`. CircleCI intentionally does not run them — see [ADR 0001](docs/adr/0001-local-ui-test-suite.md). Setup, run commands, and report paths live in CONTRIBUTING.md § *Testing → Local UI test suite*.
-
-### When to run
-
-- After any change to a Composable, ViewModel, intent flow, navigation, deep link, or persistence layer.
-- Not required for: CHANGELOG, copy strings, README, comments, off-device tooling config.
+Instrumented UI/functional tests live under `app/src/androidTest/`. CircleCI intentionally does not run them — see [ADR 0001](docs/adr/0001-local-ui-test-suite.md). When to run, setup, run commands, report paths: CONTRIBUTING.md § *Testing → Local UI test suite*.
 
 ### Synchronization (avoid bare `waitForIdle()` for state-dependent nodes)
 
-`waitForIdle()` only flushes Compose recompositions — not the `DataStore → StateFlow → render` chain (canonical race in this repo, PR #1111). For nodes whose existence depends on ViewModel/DataStore state, use the `awaitNode*` helpers in `app/src/androidTest/.../ComposeTestExtensions.kt` (rationale in KDoc):
+`waitForIdle()` only flushes Compose recompositions — not the `DataStore → StateFlow → render` chain (canonical race, PR #1111). For nodes whose existence depends on ViewModel/DataStore state, use `awaitNode*` helpers in `app/src/androidTest/.../ComposeTestExtensions.kt` (rationale in KDoc):
 
 ```kotlin
 composeRule.awaitNodeWithContentDescription(pinLabel()).performClick()
@@ -223,33 +189,15 @@ composeRule.awaitNodeWithText(homeTabLabel()).assertIsDisplayed()
 composeRule.awaitNode(hasSetTextAction()).performTextInput(name)
 ```
 
-Bare `waitForIdle()` / `waitUntil { onAllNodes(...).isNotEmpty() }` is still correct after deterministic actions (`performClick`, `pressBack`); before negative assertions like `assertCountEquals(0)`; before `.onFirst()` chains; and when the matcher would multi-match — the helpers' terminal `onNode*` throws on multi-match.
+Bare `waitForIdle()` / `waitUntil { onAllNodes(...).isNotEmpty() }` is still correct after deterministic actions (`performClick`, `pressBack`), before negative assertions (`assertCountEquals(0)`), before `.onFirst()` chains, and when the matcher would multi-match (the helpers' terminal `onNode*` throws on multi-match).
 
-## Pre-PR checklist
+## Pre-PR and pre-push checklists
 
-Before opening a PR for any feature or bug fix, verify:
+Full checklists: CONTRIBUTING.md § *Testing → Pre-PR checklist* / *Pre-push checklist*. Key write-time invariants here:
 
-- [ ] Happy path is covered by at least one test
-- [ ] Failure modes at system/external boundaries have tests (file I/O, MediaPlayer, permissions, network, Play feature delivery)
-- [ ] New `Activity` has a smoke test (§ Activity smoke tests)
-- [ ] New full-screen Composable with business logic has a `createComposeRule()` smoke test
-- [ ] Composables with durable state (text input, opened overlays/sheets, sub-screens, in-flight error) have at least one `scenario.recreate()` test (§ *Stateful Composables*)
-- [ ] Any skipped scenario is explicitly noted with a reason
-- [ ] Self code review: re-read every changed file as a reviewer, not author — logic gaps, missing edge cases, unclear naming
-
-Then run the **Pre-push checklist** below.
-
-## Pre-push checklist
-
-CI linters that must pass:
-- **KtLint** — style (part of `check`; auto-fix `ktlintFormat`)
-- **Detekt** — static analysis (config `config/detekt/detekt-config.yml`; max line length 150)
-- **Spotless** — AGPLv3 headers (part of `check`; auto-fix `spotlessApply`)
-- **Android Lint** — rules in `config/android/android-lint.xml`
-
-Run `./gradlew check -x test && ./gradlew test` before pushing — catches the same failures CI reports without waiting for a full CI run.
-
-**Functional changes also require the local UI test suite** (§ *Local UI test suite*). If the change touches Composables, ViewModels, intents, navigation, deep links, or persistence — run the instrumented suite on an emulator before pushing. CircleCI does not execute it. Cosmetic-only changes (CHANGELOG, copy strings, README, comments) are exempt.
+- Smoke tests required: new `Activity` (§ *Activity smoke tests*); new full-screen Composable with business logic (`createComposeRule()`); Composables with durable state need at least one `scenario.recreate()` test (§ *Stateful Composables*).
+- Run `./gradlew check -x test && ./gradlew test` before pushing — same failures CI reports. Detekt max line length: **150**.
+- **Functional changes also require the local UI test suite** (§ *Local UI test suite*). Touching Composables, ViewModels, intents, navigation, deep links, or persistence → run the instrumented suite on an emulator. CircleCI does not execute it. Cosmetic-only changes (CHANGELOG, copy, README, comments) are exempt.
 
 ## Analytics events
 
@@ -260,9 +208,9 @@ Hard rules:
 - Never call `FirebaseAnalytics.getInstance(...)` or `.logEvent(...)` outside the wrapper — the `analytics-wrapper-guard` CI job fails the build.
 - Auto `screen_view` is disabled via manifest meta-data; every screen emits `tracker.logScreen(CanonicalScreenName.X)` manually with a canonical literal.
 - The `first_*` variant is emitted by the wrapper when the event declares `hasFirstVariant = true` — call-sites never reference `first_*` directly.
-- In tests, substitute via `AnalyticsTrackerProvider.setForTest(FakeAnalyticsTracker())` and assert with `fake.assertEmitted(...)` / `fake.assertScreenView(...)` — never mock `AnalyticsTracker` directly. The fake lives in `:commons_android` test fixtures.
+- In tests: substitute with `AnalyticsTrackerProvider.setForTest(FakeAnalyticsTracker())`, assert with `fake.assertEmitted(...)` / `fake.assertScreenView(...)`. Never mock `AnalyticsTracker` directly. Fake lives in `:commons_android` test fixtures.
 
-When adding a new track, follow `CONTRIBUTING.md` § "Analytics events 📊" — naming rules, regression-test matrix, and DebugView / `adb logcat -s FA FA-SVC` verification commands. Don't shortcut the manual smoke before merging; aggregated Reports dashboards have a 24–48 h delay.
+Naming rules, regression-test matrix, and DebugView / `adb logcat -s FA FA-SVC` verification in CONTRIBUTING.md § *Analytics events 📊*. Don't skip the manual smoke before merging — aggregated Reports have a 24–48 h delay.
 
 ## Error tracking (non-fatals)
 
@@ -270,15 +218,15 @@ Non-fatal exceptions go to Firebase Crashlytics through the `Tracker` wrapper at
 
 | Method | Effect | When to use |
 |---|---|---|
-| `Tracker.track(throwable)` | `recordException(...)` — full stack trace, **shows up as non-fatal in the dashboard** | Any caught exception you want operations to see |
-| `Tracker.log(message)` | `log(...)` — **breadcrumb only**, attached to the next crash/non-fatal recorded after it; invisible in the dashboard until then | Right before a `Tracker.track(...)` to attach context — not as a standalone report |
+| `Tracker.track(throwable)` | `recordException(...)` — full stack trace; **non-fatal in dashboard** | Any caught exception you want ops to see |
+| `Tracker.log(message)` | `log(...)` — **breadcrumb only**, attached to the next crash/non-fatal; invisible until then | Right before `Tracker.track(...)` to attach context — not standalone |
 
 Hard rules:
 
-- **Do NOT rely on `Timber.e(throwable, message)` to surface a non-fatal.** The `ErrorTrackerTree` (planted in debug and release) forwards only the formatted message via `Tracker.log(...)` — the throwable parameter is silently dropped. `Timber.e` / `Timber.w` are fine for logcat-only diagnostics during dev.
-- **Wrapper message MUST be static.** Crashlytics shows the latest event's message as the issue title in the dashboard, so dynamic interpolation (`"... for $name"`) makes titles flicker between events and breaks BigQuery searches by message. Attach per-event context as a Crashlytics breadcrumb via `Tracker.log("module.field=value")` emitted **immediately before** `Tracker.track(...)`. Module = stable feature/surface concept, mirroring the `CanonicalScreenName` literal when one exists (`addbutton` ↔ `ADD_SOUND`, `about` ↔ `ABOUT`, `search` ↔ `SEARCH_SOUND`). Don't use the source directory if it's a layout grouping that may shift over time — `SearchOverlay.kt` lives under `ui/home/` but its module is `search`, not `home`, because the surrounding tab can change without the search feature changing. Multiple breadcrumbs allowed — emit one `Tracker.log` per key.
+- **`Timber.e(throwable, msg)` does NOT surface a non-fatal.** `ErrorTrackerTree` forwards only the formatted message via `Tracker.log(...)`; the throwable is silently dropped. `Timber.e` / `Timber.w` are fine for logcat-only dev diagnostics.
+- **Wrapper message MUST be static.** Dynamic interpolation makes Crashlytics titles flicker between events and breaks BigQuery searches by message. Attach per-event context as a breadcrumb via `Tracker.log("module.field=value")` **immediately before** `Tracker.track(...)`. Module = stable feature/surface concept matching `CanonicalScreenName` when one exists (`addbutton` ↔ `ADD_SOUND`, `about` ↔ `ABOUT`, `search` ↔ `SEARCH_SOUND`) — not a source directory if it's a shifting layout grouping (`SearchOverlay.kt` lives under `ui/home/` but its module is `search`). Multiple breadcrumbs allowed, one `Tracker.log` per key.
 - **Don't say "button" for a Sound/Bomp in error or log messages.** Use neutral "audio" so the brand doesn't leak into ops/BigQuery. Framework/code identifiers (`addbutton/`, `AddButtonFeature`, Material `Button`) are out of scope.
-- For caught exceptions, follow the established pattern (see `PlayerControllerImpl.kt`): wrap the cause in a `RuntimeException` whose **static** message describes the operation, then hand it to `Tracker.track`. The wrapper message becomes the Crashlytics title; the original throwable is preserved as `cause`.
+- For caught exceptions, follow the established pattern (see `PlayerControllerImpl.kt`): wrap the cause in a `RuntimeException` with a **static** message describing the operation, then `Tracker.track(...)`. The wrapper message becomes the Crashlytics title; original throwable preserved as `cause`.
   ```kotlin
   } catch (e: ActivityNotFoundException) {
       Tracker.log("about.url=$url")
@@ -287,19 +235,19 @@ Hard rules:
   }
   ```
 - Expected and recoverable exceptions (e.g. user dismissed a chooser) don't need `Tracker.track`. Reserve it for things you want to investigate.
-- In tests, `AbstractRobolectricTest` already mocks `Tracker.track` / `Tracker.log` to no-ops in `@Before` — **do not re-mock**. Subclasses just `verify(exactly = 1) { Tracker.track(any()) }` (and `verify(atLeast = 1) { Tracker.log(any()) }` for breadcrumb sites) to lock in the invocation contract. Don't assert exact breadcrumb text (overspecification). Override the global stub only when you need to capture the throwable (`every { Tracker.track(capture(slot)) } answers { nothing }`).
+- In tests, `AbstractRobolectricTest` mocks `Tracker.track`/`Tracker.log` to no-ops in `@Before` — **don't re-mock**. Subclasses just `verify(exactly = 1) { Tracker.track(any()) }` (and `verify(atLeast = 1) { Tracker.log(any()) }` for breadcrumb sites). Don't assert exact breadcrumb text (overspecification). Override the global stub only to capture the throwable: `every { Tracker.track(capture(slot)) } answers { nothing }`.
 
-For SQL post-mortem on accumulated crash history, see `CONTRIBUTING.md` § *BigQuery export*. Releases-only — `bomp-prod` exports Crashlytics, Analytics, and Performance to BigQuery (`us` multi-region, daily); `bomp-debug` does not export.
+SQL post-mortem on crash history: CONTRIBUTING.md § *BigQuery export*. Releases-only — `bomp-prod` exports Crashlytics/Analytics/Performance to BigQuery (`us`, daily). `bomp-debug` does not export.
 
 ## StrictMode debug audit
 
-Single source of truth: `app/src/debug/.../StrictModeConfigurator.kt` (debug-only, never reaches release). Unknown violations crash debug and instrumented runs by design — `Tracker.track(StrictModeException(violation))` with the wrapper message `"StrictMode: <ViolationClassName>"`. Filter logcat with `adb logcat | grep StrictMode` (operator workflow in `CONTRIBUTING.md` § *Terminal: StrictMode violations*).
+Source of truth: `app/src/debug/.../StrictModeConfigurator.kt` (debug-only, never reaches release). Unknown violations crash debug + instrumented runs by design — `Tracker.track(StrictModeException(violation))` with wrapper `"StrictMode: <ViolationClassName>"`. Filter logcat: `adb logcat | grep StrictMode` (operator workflow: CONTRIBUTING.md § *Terminal: StrictMode violations*).
 
 When a new violation surfaces, choose in this order:
 
 1. **Top app-code frame is ours** (`com.github.barriosnahuel.vossosunboton.*`): fix the production code. Don't filter.
-2. **Scopable to a known-OK call-site we own** (e.g. SDK init that legitimately reads disk on first call): wrap with `StrictMode.allowThreadDiskReads()` + `try/finally` at that call-site. Canonical example: `AnalyticsTrackerProvider.createTracker`. Don't add a matcher.
-3. **Third-party class running its own code** (Compose, Espresso, GMS, framework finalizers): add a `KnownThirdPartyViolation` to the list with a comment naming the library + (when public) the upstream issue. Use `methodNameContains` when the class prefix would over-match (the framework's own `android.os.StrictMode` does); use `fileNameContains` when the classes are obfuscated and unstable (GMS Dynamite ships as `m7.*` etc., loader/module identifier lives in `StackTraceElement.fileName`).
+2. **Scopable to a known-OK call-site we own** (e.g. SDK init that legitimately reads disk on first call): wrap with `StrictMode.allowThreadDiskReads()` + `try/finally` at the call-site. Canonical: `AnalyticsTrackerProvider.createTracker`. Don't add a matcher.
+3. **Third-party class running its own code** (Compose, Espresso, GMS, framework finalizers): add a `KnownThirdPartyViolation` with a comment naming the library + upstream issue (when public). Use `methodNameContains` when the class prefix would over-match (`android.os.StrictMode` itself does); use `fileNameContains` when classes are obfuscated and unstable (GMS Dynamite ships as `m7.*` etc.).
 
 ## Security boundaries
 
@@ -307,11 +255,11 @@ Concrete rules for input/output validation and component exposure.
 
 ### Inbound URI validation
 
-When the app receives a `Uri` via `Intent.EXTRA_STREAM` or `ACTION_SEND` (today only `AddButtonActivity`), validate before opening the stream:
+Inbound `Uri` via `Intent.EXTRA_STREAM`/`ACTION_SEND` (today only `AddButtonActivity`) — validate before opening the stream:
 
 - **Scheme allowlist:** only `content` and `file` pass; reject everything else (`http`, `javascript`, `data`).
 - **MIME type:** `ContentResolver.getType(uri)` must start with `audio/`. If null, reject.
-- **Size cap:** reject inputs over 50 MB (≈4× a 5-min MP3 at 320 kbps; rejects pathological inputs while leaving headroom). Resolve via `ContentResolver.openAssetFileDescriptor(uri, "r")?.length` or `OpenableColumns.SIZE`. Unknown size also rejects.
+- **Size cap:** reject inputs over 50 MB (≈4× a 5-min MP3 at 320 kbps). Resolve via `ContentResolver.openAssetFileDescriptor(uri, "r")?.length` or `OpenableColumns.SIZE`. Unknown size also rejects.
 - **Failure mode:** surface a typed feedback string-res to the caller (same channel as `app_feedback_generic_error_contact_support`). Never throw raw.
 
 Canonical implementation: `AddButtonFeature.saveNewButtonAsync`. Any future inbound-URI surface must call the same validator.
@@ -322,15 +270,15 @@ Canonical implementation: `AddButtonFeature.saveNewButtonAsync`. Any future inbo
 
 ### Backup hygiene
 
-Before adding any new DataStore preference file or persistent file path that could contain sensitive data (auth tokens, account identifiers, private user content), add explicit `<exclude>` entries to both `app/src/main/res/xml/app_backup_rules.xml` and `app_data_extraction_rules.xml`. Today nothing sensitive is stored — the rules `<include>` the `Music` external directory and the DataStore preference files. When that changes, the exclusion ships in the same commit as the new key.
+Before adding a DataStore preference file or persistent path with sensitive data (auth tokens, account IDs, private content), add `<exclude>` entries to both `app/src/main/res/xml/app_backup_rules.xml` and `app_data_extraction_rules.xml`. Today nothing sensitive is stored — rules `<include>` the `Music` external directory and the DataStore files. When that changes, exclusion ships in the same commit.
 
 ### Exported components default to false
 
-New `Activity`/`Service`/`Receiver` declarations in `AndroidManifest.xml` default `android:exported="false"`. Set `true` only when the component has an `<intent-filter>` for external callers; document which intents and from where (launcher, share sheet, deep link) in a comment above. The two exported activities today: `LandingActivity` (LAUNCHER + `push-me://open` deep link) and `AddButtonActivity` (system share-sheet `ACTION_SEND` with `audio/*`).
+New `Activity`/`Service`/`Receiver` in `AndroidManifest.xml` defaults `android:exported="false"`. Set `true` only with an `<intent-filter>` for external callers; document the intents in a comment above. Today's exported activities: `LandingActivity` (LAUNCHER + `push-me://open` deep link) and `AddButtonActivity` (share sheet `ACTION_SEND` with `audio/*`).
 
 ## Accessibility (WCAG 2.2 AA)
 
-All UI development and generated assets (store listing, What's New, changelogs) target **WCAG 2.2 Level AA**. Key requirements:
+All UI and generated assets (store listing, What's New, changelogs) target **WCAG 2.2 Level AA**. Key requirements:
 
 - **Contrast – text (1.4.3):** ≥ 4.5:1 for normal text; ≥ 3:1 for large text (≥ 18 sp or ≥ 14 sp bold)
 - **Contrast – non-text (1.4.11):** ≥ 3:1 for interactive UI components (icon-only buttons, input borders, focus indicators)
@@ -339,13 +287,11 @@ All UI development and generated assets (store listing, What's New, changelogs) 
 - **Touch targets (2.5.8):** minimum 24 × 24 dp; prefer 48 × 48 dp for primary actions
 - **Labels match names (2.5.3):** visible button/field labels match the accessible name used by screen readers
 
-Verify contrast when adding or changing colors. Use the [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/) or the Material Theme Builder. The brand palette in `AppTheme.kt` was designed to meet AA across all roles. **Critical role pairs are auto-verified by `AppThemeContrastTest`** — if you change the palette and a test fails, fix the theme, not the test.
+Verify contrast when changing colors ([WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/), Material Theme Builder). The `AppTheme.kt` palette meets AA across all roles. **Critical role pairs auto-verified by `AppThemeContrastTest`** — palette change + test fail means fix the theme, not the test.
 
 ## Design system
 
-Neo-Club palette (ink × acid). Single source of truth: `app/src/main/java/…/ui/theme/AppTheme.kt` (hex values + role mappings).
-
-Tokens: `Ink1000`, `Ink900`, `Ink800`, `Ink50`, `Paper`, `Acid400`, `AcidDark`, `Blood600`. See `AppTheme.kt` for hex values.
+Neo-Club palette (ink × acid). Source of truth: `AppTheme.kt` (hex values + role mappings). Tokens: `Ink1000`, `Ink900`, `Ink800`, `Ink50`, `Paper`, `Acid400`, `AcidDark`, `Blood600`.
 
 ### Semantic role → intent mapping
 
@@ -371,17 +317,17 @@ Tokens: `Ink1000`, `Ink900`, `Ink800`, `Ink50`, `Paper`, `Acid400`, `AcidDark`, 
 
 ## Product & brand context (when relevant)
 
-Product specs, brand language, and canonical naming live in the sibling backlog repo at `../push-me-backlog/`. Consult when working on user-facing strings, micro-copy, feature/level naming, gamification, or social-layer behavior:
+Sibling backlog repo `../push-me-backlog/` holds product specs, brand language, canonical naming. Consult for user-facing strings, micro-copy, feature/level naming, gamification, social-layer behavior:
 
-- [`docs/brand-dna.md`](../push-me-backlog/docs/brand-dna.md) — canonical terminology (Bomp, Bomper, Bompear, Escala Richter levels: Bompín / Bompazo / Bompardo / Bompión, Inmortal as cloud-state descriptor)
+- [`docs/brand-dna.md`](../push-me-backlog/docs/brand-dna.md) — canonical terminology (Bomp/Bomper/Bompear, Richter levels Bompín → Bompión, Inmortal cloud-state descriptor)
 - [`CLAUDE.md`](../push-me-backlog/CLAUDE.md) — Product Language glossary and spec conventions
 - [`backlog/`](../push-me-backlog/backlog/) — pending feature specs (the "why")
 
-Skip for refactors, dep bumps, build config, platform-wiring fixes. Sibling path absent → proceed with in-repo strings as authoritative and surface the gap.
+Skip for refactors, dep bumps, build config, platform-wiring fixes. Sibling path absent → in-repo strings are authoritative; surface the gap.
 
 ## Repo writing language
 
-Contributor-facing files (`README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, `CODE_OF_CONDUCT.md`, ADRs, `.github/` templates, `CLAUDE.md`, code comments, commit messages, PR descriptions, handoff notes) are written in **English**. Embedded examples of user-facing copy (❌/✓ snippets, `strings.xml` quotes) stay in their target locale to illustrate the rule faithfully. User-facing surfaces (in-app strings, store listings, push notifs, "What's New", marketing emails) follow § *Copy & localization*.
+Contributor-facing files (README, CONTRIBUTING, CHANGELOG, CODE_OF_CONDUCT, ADRs, `.github/` templates, CLAUDE.md, code comments, commit messages, PR descriptions, handoff notes) are written in **English**. Embedded examples of user-facing copy (❌/✓ snippets, `strings.xml` quotes) stay in their target locale. User-facing surfaces (in-app strings, store listings, push notifs, "What's New", marketing emails) follow § *Copy & localization*.
 
 ## Copy & localization
 
@@ -393,13 +339,13 @@ Sources of truth: `../push-me-backlog/docs/brand-dna.md` (canonical terms, anti-
 
 Hard rules:
 
-- **No calque translations; locale-aware register.** Phrases natural in the source can be wrong in the target. Match the register the locale expects: US English marketing → contractions, short sentences, imperatives, concrete nouns; Spanish-AR → voseo and warmth. Verify with a native speaker or a current idiom reference, not Google Translate. Concrete calque examples and the en-US listing post-mortem live in `CONTRIBUTING.md` § *Copy guide*.
-- **ASO awareness for store-listing copy.** Integrate high-volume queries the target market actually searches — organically, without breaching brand-DNA bans (`soundboard`, `audio sticker`, `panel`, `viralizá`, `share with friends/followers` as a CTA). Those are positioning bans, not vocabulary bans — a category descriptor like `voice notes` is fine because it names the input, not the brand position.
-- **Brand-DNA invariants.** Proper nouns Bomp / Bomper / Bompear / Bompeable NEVER translate. The manifesto closing ("Un audio de los tuyos no es un mensaje, es un abrazo que se escucha." or a locale-equivalent that preserves meaning) is invariant across surfaces and locales.
-- **Reserved-term check.** Before using any term from `brand-dna.md` or the Product Language glossary, verify it isn't reserved for a non-shipped feature or specific technical state. Reserved today: `Inmortal`/`immortal` (state descriptor for a Bompión synced via Saved Games SDK — Pro, **not shipped yet**); `Bompardo` and `Bompión` (Escala Richter levels 4 and 5, gated by share milestones — don't apply to a generic Bomp); `Bomptástico` (internal telemetry only, never in UI). ❌ "Tus Bomps son inmortales" overstates Auto Backup. ✓ "Tus Bomps quedan respaldados en tu Google Drive".
-- **Policy-contradiction check (no overclaims).** Before any absolute claim (`imborrable`, `permanent`, `forever`, `never lost`, `100% private`, `always`, `nunca se pierde`, `we never see your data`) open `privacy-policy.html` and `data-safety.html` and check the claim doesn't contradict a published statement or strip a user right. Invariants today: user can delete Bomps one-by-one or by uninstall (ARCO §05); Auto Backup is OS-controllable (PP §02); Firebase collects pseudonymous crash logs, performance, aggregated interactions (DS §01) — copy can't claim "no data ever leaves the device".
-- **Read-aloud check before ship.** Read every paragraph aloud as a native speaker. Stumbles, false friends, weird tense, "wait, what?" reactions are blockers — fix before submitting.
-- **Cross-surface consistency.** If headers use `Save. Name. Bomp.`, body copy uses the same verbs ("give it a name", not "give it a label"). Cross-reference all surfaces of a locale (title, short, full, screenshots, feature graphic, video script) before shipping.
+- **No calque; locale-aware register.** Phrases natural in source can be wrong in target. US English marketing → contractions, short sentences, imperatives, concrete nouns. Spanish-AR → voseo and warmth. Verify with a native speaker or current idiom reference, not Google Translate. Calque examples + en-US listing post-mortem: CONTRIBUTING.md § *Copy guide*.
+- **ASO awareness for store-listing copy.** Integrate high-volume target-market queries organically, without breaching brand-DNA bans (`soundboard`, `audio sticker`, `panel`, `viralizá`, `share with friends/followers` as CTA). Those are positioning bans, not vocabulary bans — `voice notes` is fine because it names the input, not the brand position.
+- **Brand-DNA invariants.** Proper nouns Bomp / Bomper / Bompear / Bompeable NEVER translate. The manifesto closing ("Un audio de los tuyos no es un mensaje, es un abrazo que se escucha." or locale-equivalent preserving meaning) is invariant across surfaces and locales.
+- **Reserved-term check.** Verify no term from `brand-dna.md` / Product Language glossary is reserved for a non-shipped feature or specific state. Reserved today: `Inmortal`/`immortal` (Saved-Games-synced Bompión — Pro, **not shipped**); `Bompardo` and `Bompión` (Escala Richter levels 4/5, gated by share milestones — not for a generic Bomp); `Bomptástico` (internal telemetry only). ❌ "Tus Bomps son inmortales" overstates Auto Backup. ✓ "Tus Bomps quedan respaldados en tu Google Drive".
+- **Policy-contradiction check (no overclaims).** Before any absolute claim (`imborrable`, `permanent`, `forever`, `never lost`, `100% private`, `always`, `nunca se pierde`, `we never see your data`) open `privacy-policy.html` and `data-safety.html` and check the claim doesn't contradict a published statement or strip a user right. Invariants: user can delete Bomps one-by-one or by uninstall (ARCO §05); Auto Backup is OS-controllable (PP §02); Firebase collects pseudonymous crash logs, performance, aggregated interactions (DS §01) — copy can't claim "no data ever leaves the device".
+- **Read-aloud check.** Read aloud as a native speaker before ship. Stumbles, false friends, weird tense block submission.
+- **Cross-surface consistency.** Headers and body copy use the same verbs ("give it a name", not "give it a label"). Cross-reference title, short, full, screenshots, feature graphic, video script before shipping.
 
 ## Store listing asset generation
 
@@ -407,37 +353,37 @@ Store listing PNGs (icon, feature graphic) render from SVG masters under `store-
 
 ## Labels and milestone
 
-Apply exactly **one type label** (`a:*` or `an:*`) plus **zero or more concern labels** (`c:*`) to every PR before merging. Do not call `gh label list` — use these tables.
+Apply exactly **one type label** (`a:*` or `an:*`) + **zero or more concern labels** (`c:*`) to every PR before merging. Don't call `gh label list` — use the tables below.
 
-For the milestone, read the `## [unreleased]` line in `CHANGELOG.md` — the version in parentheses is the milestone name (e.g. `(v2.0.0)` → milestone `v2.0.0`). Do not call `gh api repos/.../milestones`.
+For the milestone, read the `## [unreleased]` line in `CHANGELOG.md` — the version in parentheses is the milestone (e.g. `(v2.0.0)` → milestone `v2.0.0`). Don't call `gh api repos/.../milestones`.
 
-### Type — user-facing (appear in `### Added/Changed/Fixed/Removed` of the CHANGELOG)
-
-| Label | When to use |
-|---|---|
-| `a:feature` | PR that adds new user-facing functionality |
-| `a:fix` | PR that corrects a user-visible bug |
-| `an:enhancement` | PR that improves existing user-facing functionality (UX polish, copy refinement, behavior tweaks) — strictly user-facing, not a catch-all |
-
-### Type — internal (appear under `### For nerds 🤓` of the CHANGELOG, or omitted)
+### Type — user-facing (appear under `### Added/Changed/Fixed/Removed` in CHANGELOG)
 
 | Label | When to use |
 |---|---|
-| `a:refactor` | PR that restructures code without changing observable behavior |
-| `a:test` | PR for test infrastructure, flaky test fixes, new test suites or helpers |
-| `a:build` | PR that touches CI, Gradle, linters, repo tooling, or dependency bumps |
-| `a:docs` | PR for contributor-facing docs: CLAUDE.md, ADRs, README, CONTRIBUTING, `.github/` templates |
+| `a:feature` | Adds new user-facing functionality |
+| `a:fix` | Corrects a user-visible bug |
+| `an:enhancement` | Improves existing user-facing functionality (UX polish, copy, behavior) — strictly user-facing, not a catch-all |
+
+### Type — internal (appear under `### For nerds 🤓` or omitted)
+
+| Label | When to use |
+|---|---|
+| `a:refactor` | Restructures code without changing observable behavior |
+| `a:test` | Test infrastructure, flaky-test fixes, new test suites or helpers |
+| `a:build` | CI, Gradle, linters, repo tooling, dependency bumps |
+| `a:docs` | Contributor-facing docs: CLAUDE.md, ADRs, README, CONTRIBUTING, `.github/` templates |
 
 ### Concern — cross-cutting (orthogonal, stackable, also apply to issues)
 
 | Label | When to use |
 |---|---|
-| `c:accessibility` | Digital accessibility (WCAG): contrast, content descriptions, touch targets, screen reader |
+| `c:accessibility` | WCAG: contrast, content descriptions, touch targets, screen reader |
 | `c:performance` | User-perceivable performance (cold start, scroll, app size, frame budget) |
 | `c:security` | Security boundaries: input validation, exported components, backup hygiene |
 | `c:i18n` | Localization: translations, store listings per locale, locale-aware copy |
 | `c:observability` | Analytics instrumentation, Crashlytics, logging, BigQuery |
-| `c:dependencies` | Library, plugin, or Gradle wrapper version bumps (applied automatically by Dependabot together with `a:build`) |
+| `c:dependencies` | Library / plugin / Gradle-wrapper version bumps (auto-applied by Dependabot with `a:build`) |
 
 ### Issues and lifecycle
 
@@ -445,18 +391,9 @@ For the milestone, read the `## [unreleased]` line in `CHANGELOG.md` — the ver
 |---|---|
 | `a:bug` | Issue reporting something broken |
 | `a:feature-request` | Issue requesting functionality not yet implemented |
-| `stale` | Issue or PR with no recent activity — candidate for closing |
+| `stale` | No recent activity — candidate for closing |
 
-### Examples of valid combinations
-
-- WCAG contrast fix: `a:fix` + `c:accessibility`
-- New screen with localized copy: `a:feature` + `c:i18n`
-- URI validation hardening: `a:fix` + `c:security`
-- AAB size optimization: `an:enhancement` + `c:performance`
-- Dependabot bump: `a:build` + `c:dependencies` (auto-applied)
-- New Firebase Analytics event: `a:build` + `c:observability`
-- Flaky test stabilization: `a:test`
-- README rewrite: `a:docs`
+Worked examples of valid combinations: CONTRIBUTING.md § *Labels & milestone examples*.
 
 ## Third-party notices
 
@@ -464,16 +401,15 @@ For the milestone, read the `## [unreleased]` line in `CHANGELOG.md` — the ver
 
 ## Changelog
 
-`CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format:
-- Sections: `Added`, `Changed`, `Fixed`, `Removed` under `## [unreleased]`
-- Each entry is a single sentence starting with a capital letter, no trailing period
-- For dependency bumps, write one line summarising the overall bump (e.g. "Bumped all dependencies to latest stable"), not one line per library
-- As part of each commit, if the change is user-visible or architecturally significant, update `## [unreleased]` before committing
-- Never add a `Fixed` entry for a bug introduced in the same `[unreleased]` cycle. If end-users never experienced the regression, no changelog entry — git history provides the traceability
-- **User-facing first, technical under "For nerds":** within `## [unreleased]`, list user-facing changes (visible UI, labels, copy, behavior, permissions, perf the user can feel) under `### Added/Changed/Fixed/Removed`, then technical/contributor-only changes (build/CI, dep bumps, refactors, test infra, docs, analytics instrumentation) under a `### For nerds 🤓` subsection with `#### Added/Changed/Fixed/Removed` sub-headings (omit any that would be empty). Applies only to `[unreleased]` going forward; released versions stay as written.
+`CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/):
+- Sections `Added` / `Changed` / `Fixed` / `Removed` under `## [unreleased]`. Each entry: single sentence, capital, no trailing period.
+- Dependency bumps → one line for the overall bump (`"Bumped all dependencies to latest stable"`), not one per library.
+- Update `[unreleased]` per commit when the change is user-visible or architecturally significant.
+- Don't add `Fixed` for a bug introduced in the same `[unreleased]` cycle — git history is the traceability.
+- **User-facing first; technical under "For nerds":** user-facing → `### Added/Changed/Fixed/Removed`. Technical (build/CI, deps, refactors, test infra, docs, analytics) → `### For nerds 🤓` with `#### Added/Changed/Fixed/Removed` sub-headings (omit empty). `[unreleased]` only; released versions stay as written.
 
 ## Handoff notes & issue tracking
 
-GitHub Issues are open for external feature requests and bug reports. Out-of-scope work identified during development is noted in the PR description, not opened as a tracking issue.
+GitHub Issues are open for external feature requests and bug reports. Out-of-scope work found during development goes in the PR description, not as a tracking issue.
 
-`handoff/` contains session handoff documents with decisions, key file paths, and pending work. Ignored by git. Only read these when the user explicitly references them to continue a previous topic.
+`handoff/` holds session handoff documents (decisions, key paths, pending work). Gitignored. Only read these when the user references them to continue a previous topic.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ But, before going deeper I suggest you to take a look to the [opensource.guide](
 - [Error tracking](#error-tracking-)
 - [Analytics events](#analytics-events-)
 - [BigQuery export](#bigquery-export-)
+- [Labels & milestone examples](#labels--milestone-examples-)
 - [Third-party notices](#third-party-notices-)
 
 ## Local setup ⚙
@@ -60,7 +61,58 @@ The instrumented suite under `app/src/androidTest/` is **intentionally not run o
 
 ## Testing 🧪
 
-Testing rules and invariants live in `CLAUDE.md` (§ *Bug fixes — TDD workflow*, § *Features — test coverage workflow*, § *Test naming convention*, § *Activity smoke tests*, § *Pre-PR checklist*). This section covers the *operational* side: setup, run commands, and conventions you need at the keyboard.
+Testing rules and invariants live in `CLAUDE.md` (§ *Bug fixes — TDD workflow*, § *Features — test coverage workflow*, § *Test naming convention*, § *Activity smoke tests*, § *Pre-PR and pre-push checklists*). This section covers the *operational* side: setup, run commands, conventions you need at the keyboard — plus the full Pre-PR / Pre-push checklists themselves.
+
+### Bug fixes — TDD procedure
+
+The trigger and the "skip only when..." invariant live in CLAUDE.md § *Bug fixes — TDD workflow*. The full three-step procedure:
+
+1. **Write a failing test first** that reproduces the bug. Run it to confirm it fails for the right reason.
+2. **Fix the production code** with the minimum change to make it pass.
+3. **Run the full test suite** (`./gradlew test`).
+
+Skip TDD only when the bug lives exclusively in UI rendering or platform wiring that can't be exercised by unit / Robolectric tests (e.g. a pure layout glitch). Note in the PR description why TDD was skipped.
+
+For **production bugs reported by users** (not local-repro), scope frequency, affected versions, OS distribution, and recurring stack frames in Crashlytics + BigQuery first — see § *BigQuery export* below.
+
+### Features — test coverage procedure
+
+The trigger lives in CLAUDE.md § *Features — test coverage workflow*. The minimum scenario set you agree on before writing production code:
+
+1. **Happy path** — works as intended under normal conditions.
+2. **Failure modes at system boundaries** — audio I/O, MediaPlayer errors, permissions denied, Play feature delivery failures.
+3. **Smoke test** — see CLAUDE.md § *Activity smoke tests*.
+
+Implement tests **alongside** the feature, not after. Any scenario not listed before starting is out of scope for the current PR — note in the PR description.
+
+Skip a scenario only when it lives exclusively in platform wiring not exercisable by unit / Robolectric tests. Note why.
+
+### Pre-PR checklist
+
+Before opening a PR for any feature or bug fix, verify:
+
+- [ ] Happy path is covered by at least one test
+- [ ] Failure modes at system/external boundaries have tests (file I/O, MediaPlayer, permissions, network, Play feature delivery)
+- [ ] New `Activity` has a smoke test (CLAUDE.md § *Activity smoke tests*)
+- [ ] New full-screen Composable with business logic has a `createComposeRule()` smoke test
+- [ ] Composables with durable state (text input, opened overlays/sheets, sub-screens, in-flight error) have at least one `scenario.recreate()` test (CLAUDE.md § *Stateful Composables*)
+- [ ] Any skipped scenario is explicitly noted with a reason
+- [ ] Self code review: re-read every changed file as a reviewer, not author — logic gaps, missing edge cases, unclear naming
+
+Then run the **Pre-push checklist** below.
+
+### Pre-push checklist
+
+CI linters that must pass:
+
+- **KtLint** — style (part of `check`; auto-fix `ktlintFormat`)
+- **Detekt** — static analysis (config `config/detekt/detekt-config.yml`; max line length 150)
+- **Spotless** — AGPLv3 headers (part of `check`; auto-fix `spotlessApply`)
+- **Android Lint** — rules in `config/android/android-lint.xml`
+
+Run `./gradlew check -x test && ./gradlew test` before pushing — catches the same failures CI reports without waiting for a full CI run.
+
+**Functional changes also require the local UI test suite** (see § *Local UI test suite → When to run* below). If the change touches Composables, ViewModels, intents, navigation, deep links, or persistence — run the instrumented suite on an emulator before pushing. CircleCI does not execute it. Cosmetic-only changes (CHANGELOG, copy strings, README, comments) are exempt.
 
 ### Test assertions
 
@@ -83,6 +135,11 @@ For tracker substitution use `AnalyticsTrackerProvider.setForTest(FakeAnalyticsT
 ### Local UI test suite
 
 Instrumented UI/functional tests live under `app/src/androidTest/`. They drive a real emulator using Compose UI Test + Espresso + UI Automator + Espresso Accessibility Checks. CircleCI does not run them — see [ADR 0001](docs/adr/0001-local-ui-test-suite.md) for the rationale.
+
+#### When to run
+
+- After any change to a Composable, ViewModel, intent flow, navigation, deep link, or persistence layer.
+- Not required for: CHANGELOG, copy strings, README, comments, off-device tooling config.
 
 #### Setup (one-time)
 
@@ -511,6 +568,19 @@ Returns `0` early on if no crashes — that's a feature, not a bug.
 - Performance regressions across releases — easier to diff trace medians via `WITH` clauses than to flip between Console screens.
 
 The Console is still right for: real-time DebugView, alert configuration, single-issue triage. BQ is for *retrospectives* across N events / users / days.
+
+## Labels & milestone examples 🏷️
+
+The label / milestone *rules* (which label means what; how to derive the milestone from the CHANGELOG) live in CLAUDE.md § *Labels and milestone*. The combinations below illustrate the rules in practice:
+
+- WCAG contrast fix: `a:fix` + `c:accessibility`
+- New screen with localized copy: `a:feature` + `c:i18n`
+- URI validation hardening: `a:fix` + `c:security`
+- AAB size optimization: `an:enhancement` + `c:performance`
+- Dependabot bump: `a:build` + `c:dependencies` (auto-applied)
+- New Firebase Analytics event: `a:build` + `c:observability`
+- Flaky test stabilization: `a:test`
+- README rewrite: `a:docs`
 
 ## Third-party notices 📜
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ But, before going deeper I suggest you to take a look to the [opensource.guide](
 - [Logcat](#logcat-)
 - [Resources](#resources-)
 - [Signing](#signing-)
+- [Release builds](#release-builds-)
 - [Bundled audio files](#bundled-audio-files-)
 - [Store listing](#store-listing-)
 - [Copy guide](#copy-guide-)
@@ -319,6 +320,15 @@ Empty output means every detected violation matched a `KnownThirdPartyViolation`
 The following files must be located into the root dir:
 - `nahuelbarrios.keystore-appbundle.pkcs12`
 - `secure.properties`
+
+## Release builds 📦
+
+Release-only Gradle commands (need the signing files above in the project root):
+
+```bash
+./gradlew app:lintVitalRelease   # Android lint, release variant — the release lint gate
+./gradlew app:bundle             # Build the AAB for Play Store upload
+```
 
 ## Bundled audio files 🔊
 

--- a/scripts/check-adr-invariants.sh
+++ b/scripts/check-adr-invariants.sh
@@ -94,11 +94,13 @@ fi
 # ============================================================================
 # CLAUDE.md size budget — see CLAUDE.md § "What goes in this file"
 # Loaded into every Claude Code context window; performance degrades above 40K.
+# Measured in bytes (wc -c): portable and deterministic, and a conservative
+# proxy for the char budget since UTF-8 bytes >= chars (fails early, never late).
 # ============================================================================
 CLAUDE_MD_SIZE=$(wc -c < CLAUDE.md | tr -d ' ')
 CLAUDE_MD_FAIL=40000
 if [ "$CLAUDE_MD_SIZE" -gt "$CLAUDE_MD_FAIL" ]; then
-    fail "CLAUDE.md is $CLAUDE_MD_SIZE chars (hard limit: $CLAUDE_MD_FAIL). Claude Code performance degrades above 40K. Run /claude-md-audit to move reference-time content to CONTRIBUTING.md or docs/adr/."
+    fail "CLAUDE.md is $CLAUDE_MD_SIZE bytes (hard limit: $CLAUDE_MD_FAIL). Claude Code performance degrades above 40K. Run /claude-md-audit to move reference-time content to CONTRIBUTING.md or docs/adr/."
 fi
 
 # ============================================================================

--- a/scripts/check-adr-invariants.sh
+++ b/scripts/check-adr-invariants.sh
@@ -92,6 +92,16 @@ if grep -rnE --include='*.kt' '(^|[^[:alnum:]_])assert[[:space:]]*\(' $TEST_DIRS
 fi
 
 # ============================================================================
+# CLAUDE.md size budget — see CLAUDE.md § "What goes in this file"
+# Loaded into every Claude Code context window; performance degrades above 40K.
+# ============================================================================
+CLAUDE_MD_SIZE=$(wc -c < CLAUDE.md | tr -d ' ')
+CLAUDE_MD_FAIL=40000
+if [ "$CLAUDE_MD_SIZE" -gt "$CLAUDE_MD_FAIL" ]; then
+    fail "CLAUDE.md is $CLAUDE_MD_SIZE chars (hard limit: $CLAUDE_MD_FAIL). Claude Code performance degrades above 40K. Run /claude-md-audit to move reference-time content to CONTRIBUTING.md or docs/adr/."
+fi
+
+# ============================================================================
 if [ "$errors" -gt 0 ]; then
     echo
     echo "$errors ADR invariant(s) violated. See messages above for which ADR(s) to revisit." >&2


### PR DESCRIPTION
## Summary

- Three-layer system to keep `CLAUDE.md` under the 40K-char Claude Code perf cliff: (1) routing rule at the top steers future agents on what belongs here vs CONTRIBUTING.md vs an ADR, (2) `scripts/check-adr-invariants.sh` fails when `CLAUDE.md` > 40,000 chars, (3) versioned `/claude-md-audit` skill (`.claude/skills/claude-md-audit/SKILL.md`) mechanizes the audit procedure.
- First audit run trims CLAUDE.md 41,402 → 35,416 chars (-14.5%) by moving procedures, checklists, and worked examples to CONTRIBUTING.md while keeping write-time invariants in place.
- `.gitignore` carve-out (`.claude/*` + `!.claude/skills/`) so skills are versioned while keeping local state ignored.

## Code review tips

- Read CLAUDE.md § *What goes in this file* as a fresh agent — the routing rule must be unambiguous.
- `.gitignore`: verify with `git check-ignore -v .claude/settings.local.json` (ignored) vs `.claude/skills/claude-md-audit/SKILL.md` (tracked).
- `check-adr-invariants.sh`: 40000 threshold reflects Anthropic's documented perf cliff.
- No production code touched — meta/docs only.

## Already tested

- [x] `bash scripts/check-adr-invariants.sh` → passes (CLAUDE.md at 35,416)
- [x] `git check-ignore` confirms gitignore carve-out
- [x] All `CONTRIBUTING.md § *X*` and `ADR XXXX` cross-refs resolve to real headings/files
- [x] Objective code review by zero-context subagent → SHIP WITH MINOR EDITS (both addressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)