### PR TITLE
feat(home): hide Search FAB until sound list reaches N=7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 
 ### Changed
+- The Search action is now hidden until you have enough Bomps for it to be useful, so a fresh install isn't cluttered with a control that can't find anything
 - Shortened the welcome-dismissal snackbar from 10 s to 4 s so the feedback no longer lingers; user-deleted sounds keep the longer Undo window
 - Saving a new Bomp or renaming an existing one now confirms with a brand "voice bubble" overlay that briefly fills the screen with the Bomp's name (inflates with a spring, holds, slides out — metaphor for "your Bomp is on its way") and returns the user to wherever they came from, instead of a long snackbar that lingered after the form. Honors the system "Remove animations" setting with an equivalent static confirmation
 - The "name your Bomp" field now opens with focus and the keyboard ready, saving one tap

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/HomeTabFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/HomeTabFlowTest.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
@@ -138,14 +140,17 @@ internal class HomeTabFlowTest : AbstractUiTest() {
 
     @Test
     fun homeScreenExposesA11yContentDescriptionsForKeyControls() {
-        TestData.seedCustomSounds(context, count = 1)
+        // 7 mirrors SEARCH_FAB_MIN_SOUNDS in LandingScreen.kt — below that, the Search FAB is
+        // hidden by design, so seeding fewer items would make the searchLabel() assertion fail.
+        // Per-sound controls (play/share/pin) match once per row, so the assertions use onFirst().
+        TestData.seedCustomSounds(context, count = 7)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             composeRule.awaitNodeWithContentDescription(searchLabel()).assertHasClickAction()
             composeRule.awaitNodeWithContentDescription(overflowLabel()).assertHasClickAction()
-            composeRule.awaitNodeWithContentDescription(playLabel()).assertHasClickAction()
-            composeRule.awaitNodeWithContentDescription(shareLabel()).assertHasClickAction()
-            composeRule.awaitNodeWithContentDescription(pinLabel()).assertHasClickAction()
+            composeRule.onAllNodesWithContentDescription(playLabel()).onFirst().assertHasClickAction()
+            composeRule.onAllNodesWithContentDescription(shareLabel()).onFirst().assertHasClickAction()
+            composeRule.onAllNodesWithContentDescription(pinLabel()).onFirst().assertHasClickAction()
         }
     }
 

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlayTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlayTest.kt
@@ -30,7 +30,7 @@ import org.junit.runner.RunWith
 internal class SearchOverlayTest : AbstractUiTest() {
     @Test
     fun fabOpensSearchOverlay() {
-        TestData.seedCustomSounds(context, count = 1)
+        TestData.seedCustomSounds(context, count = SOUNDS_FOR_VISIBLE_FAB)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
@@ -41,7 +41,7 @@ internal class SearchOverlayTest : AbstractUiTest() {
 
     @Test
     fun typingQueryFiltersResultsToMatchingSound() {
-        TestData.seedCustomSounds(context, count = 3)
+        TestData.seedCustomSounds(context, count = SOUNDS_FOR_VISIBLE_FAB)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
@@ -59,7 +59,7 @@ internal class SearchOverlayTest : AbstractUiTest() {
 
     @Test
     fun queryWithNoMatchShowsZeroResultsMessage() {
-        TestData.seedCustomSounds(context, count = 1)
+        TestData.seedCustomSounds(context, count = SOUNDS_FOR_VISIBLE_FAB)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
@@ -70,7 +70,7 @@ internal class SearchOverlayTest : AbstractUiTest() {
 
     @Test
     fun trailingClearIconClearsQueryWithoutClosingOverlay() {
-        TestData.seedCustomSounds(context, count = 1)
+        TestData.seedCustomSounds(context, count = SOUNDS_FOR_VISIBLE_FAB)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
@@ -86,7 +86,7 @@ internal class SearchOverlayTest : AbstractUiTest() {
 
     @Test
     fun backArrowClosesOverlay() {
-        TestData.seedCustomSounds(context, count = 1)
+        TestData.seedCustomSounds(context, count = SOUNDS_FOR_VISIBLE_FAB)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
@@ -100,7 +100,7 @@ internal class SearchOverlayTest : AbstractUiTest() {
 
     @Test
     fun systemBackClosesOverlay() {
-        TestData.seedCustomSounds(context, count = 1)
+        TestData.seedCustomSounds(context, count = SOUNDS_FOR_VISIBLE_FAB)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
@@ -116,7 +116,7 @@ internal class SearchOverlayTest : AbstractUiTest() {
 
     @Test
     fun searchOverlayExposesA11yContentDescriptions() {
-        TestData.seedCustomSounds(context, count = 1)
+        TestData.seedCustomSounds(context, count = SOUNDS_FOR_VISIBLE_FAB)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
@@ -135,4 +135,10 @@ internal class SearchOverlayTest : AbstractUiTest() {
     private fun closeSearchLabel() = context.getString(R.string.app_search_close)
 
     private fun clearSearchLabel() = context.getString(R.string.app_search_clear)
+
+    private companion object {
+        // Matches SEARCH_FAB_MIN_SOUNDS in LandingScreen.kt — the FAB stays hidden below this
+        // threshold, so any test that needs to tap it must seed at least this many sounds.
+        const val SOUNDS_FOR_VISIBLE_FAB = 7
+    }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -142,15 +142,17 @@ fun LandingScreen(viewModel: SoundsViewModel) {
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         floatingActionButton = {
-            FloatingActionButton(
-                onClick = { viewModel.showSearch() },
-                containerColor = MaterialTheme.colorScheme.primaryContainer,
-                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Search,
-                    contentDescription = stringResource(R.string.app_search),
-                )
+            if (sounds.size >= SEARCH_FAB_MIN_SOUNDS) {
+                FloatingActionButton(
+                    onClick = { viewModel.showSearch() },
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Search,
+                        contentDescription = stringResource(R.string.app_search),
+                    )
+                }
             }
         },
     ) { innerPadding ->
@@ -339,6 +341,12 @@ private fun AppBottomBar(
         )
     }
 }
+
+// 7 is the lower bound of the UX-research "ambiguous band" (7–15 items) where search starts to
+// out-perform scanning on mobile. Below 7, IME open + typing cost > scan time (NN/g "search vs.
+// browse", Baymard on mobile filter thresholds). We anchor at the lower bound because Bomp names
+// are short (fast to scan) and the dominant search task is find-specific, not browse-to-discover.
+private const val SEARCH_FAB_MIN_SOUNDS = 7
 
 private const val DELETE_ANIMATION_DURATION_MS = 300
 private val WELCOME_BORDER_WIDTH = 1.5.dp

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
@@ -8,11 +8,13 @@ package com.github.barriosnahuel.vossosunboton.ui.home
 import android.os.Build
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.lifecycle.viewModelScope
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
+import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
 import io.mockk.every
 import io.mockk.mockkObject
@@ -73,6 +75,39 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
         composeTestRule.onNodeWithText("Explore").assertIsDisplayed()
     }
 
+    @Test
+    fun `Search FAB is hidden when sound list is empty`() {
+        val viewModel = givenAViewModel()
+        viewModel.injectSounds(emptyList())
+
+        composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithContentDescription("Search").assertDoesNotExist()
+    }
+
+    @Test
+    fun `Search FAB is hidden when sound list has 6 items`() {
+        val viewModel = givenAViewModel()
+        viewModel.injectSounds(stubSounds(count = 6))
+
+        composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithContentDescription("Search").assertDoesNotExist()
+    }
+
+    @Test
+    fun `Search FAB is shown when sound list has 7 items`() {
+        val viewModel = givenAViewModel()
+        viewModel.injectSounds(stubSounds(count = 7))
+
+        composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithContentDescription("Search").assertIsDisplayed()
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun givenAViewModel(): SoundsViewModel {
         val vm =
@@ -95,4 +130,14 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
             // Safe: _hasBundledSounds is always MutableStateFlow<Boolean> — type parameter erased at runtime
             .let { (it.get(this) as MutableStateFlow<Boolean>).value = value }
     }
+
+    private fun SoundsViewModel.injectSounds(value: List<Sound>) {
+        SoundsViewModel::class.java
+            .getDeclaredField("_sounds")
+            .also { it.isAccessible = true }
+            // Safe: _sounds is always MutableStateFlow<List<Sound>> — type parameter erased at runtime
+            .let { (it.get(this) as MutableStateFlow<List<Sound>>).value = value }
+    }
+
+    private fun stubSounds(count: Int): List<Sound> = List(count) { Sound(name = "stub-$it", file = "/tmp/stub-$it.mp3") }
 }


### PR DESCRIPTION
### Summary

- Hides the Search FAB on Home when `sounds.size < 7`, so a fresh install (where there is nothing useful to search) is not cluttered by a control that cannot do its job.
- Threshold rationale lives next to the constant: below 7, opening the IME + typing on mobile is slower than scanning the list. Anchored at the lower bound of the 7–15 "ambiguous band" because Bomp names are short and find-specific is the dominant search task (NN/g, Baymard).
- Applies to both Home tabs (`MY_SOUNDS` and `EXPLORE_SOUNDS`) — the count comes from whichever list is currently visible, so Explore keeps Search available once enough bundled audios are present.

### Code review tips

- `LandingScreen.kt:144` — the FAB is now wrapped in a conditional. The constant `SEARCH_FAB_MIN_SOUNDS` lives in the same file with the research citation as a comment; if the number changes, update both the source and the duplicate guard in `SearchOverlayTest.SOUNDS_FOR_VISIBLE_FAB` / the count in `HomeTabFlowTest.homeScreenExposesA11yContentDescriptionsForKeyControls`.
- Instrumented tests that tap the FAB previously seeded a single sound — they now seed 7. The a11y test was rewritten to use `onAllNodesWithContentDescription(...).onFirst()` for per-sound controls (play/share/pin) because those labels now match once per row.

### Already tested

- [x] `./gradlew check -x test` — all linters green
- [x] `./gradlew test` — unit suite green, includes 3 new boundary tests (0, 6, 7 sounds)
- [x] `:app:connectedDebugAndroidTest` on emulator: `SearchOverlayTest` (7/7) and `HomeTabFlowTest#homeScreenExposesA11yContentDescriptionsForKeyControls` (1/1)
- [x] `HomeTabFlowTest#tapPlaySwapsPlayIconToPause` fails on this emulator both on this branch and on `develop` with no changes — pre-existing flake unrelated to this PR