### PR TITLE
fix(test): use overflow-menu sentinel for About back-nav tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Analytics event `sound_add_abandoned_after_error` fires when the user leaves the Add Button screen with an unresolved save error (lifecycle-driven via `ON_STOP` and explicit Snackbar dismiss); best-effort — process death drops the signal
 - Enforce ADR 0005 audio engine invariant via `check-adr-invariants.sh` and the CircleCI `adr-invariants` job — fails the build if a `MediaPlayer()` constructor appears in `src/main` outside `PlayerControllerImpl.kt`
 
+#### Fixed
+- `AboutScreenFlowTest` back-navigation tests now use the always-present overflow-menu icon as the Landing sentinel instead of the Search FAB, which #1143 gated behind a minimum sound count
+
 #### Removed
 - Dead post-save plumbing: `EXTRA_BUTTON_SAVED` / `EXTRA_BUTTON_RENAMED` / `EXTRA_BUTTON_NAME` Intent extras, `SoundsViewModel.buttonSavedEvent` / `buttonRenamedEvent` channels and their `onButtonSaved` / `onButtonRenamed` setters, the `LandingScreen` `LaunchedEffect`s that consumed them, and `AddButtonActivity.navigateBackSaved` / `navigateBackRenamed`
 

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenFlowTest.kt
@@ -53,8 +53,8 @@ internal class AboutScreenFlowTest : AbstractUiTest() {
         ActivityScenario.launch(LandingActivity::class.java).use {
             openAbout()
             composeRule.onNodeWithContentDescription(backLabel()).performClick()
-            // Search FAB on Landing is back in view.
-            composeRule.awaitNodeWithContentDescription(context.getString(R.string.app_search)).assertIsDisplayed()
+            // Overflow menu is the Landing sentinel (absent on About); the Search FAB is unusable here since #1143 gates it on sound count.
+            composeRule.awaitNodeWithContentDescription(context.getString(R.string.app_overflow_menu)).assertIsDisplayed()
         }
     }
 
@@ -63,7 +63,7 @@ internal class AboutScreenFlowTest : AbstractUiTest() {
         ActivityScenario.launch(LandingActivity::class.java).use {
             openAbout()
             Espresso.pressBack()
-            composeRule.awaitNodeWithContentDescription(context.getString(R.string.app_search)).assertIsDisplayed()
+            composeRule.awaitNodeWithContentDescription(context.getString(R.string.app_overflow_menu)).assertIsDisplayed()
         }
     }
 


### PR DESCRIPTION
### Summary
- Surfaced during a flake investigation: `AboutScreenFlowTest.backArrowReturnsToLanding` and `systemBackReturnsToLanding` fail deterministically on `develop`.
- Root cause: #1143 gated the Search FAB behind a 7-sound minimum (`SEARCH_FAB_MIN_SOUNDS`). It updated `HomeTabFlowTest` and `SearchOverlayTest` but missed `AboutScreenFlowTest`, which seeds zero custom sounds and used the FAB `contentDescription` as a "we're back on Landing" sentinel — so the FAB never renders and the assertion times out.
- Fix: swap the sentinel to the overflow-menu icon (`R.string.app_overflow_menu`) — unconditionally present on Landing, absent on About's back-only top bar. Not an app bug; the FAB gate is #1143's intended feature, so no production code is touched.

### Code review tips
- The two tests still prove back-navigation leaves About and returns to Landing — the overflow menu is exclusive to the Landing top bar, so the assertion is not weakened.
- `openAbout()` already clicks `app_overflow_menu` to *enter* About, so reusing it as the "back on Landing" sentinel is consistent within the file.
- `R.string.app_search` is no longer referenced in this file; no import cleanup needed (`R` is still used throughout).
- TDD note: the "red" state is pre-existing — both tests already fail deterministically on `develop` (confirmed by two isolated runs). The job here is to make them green without weakening the assertion.

### Already tested
- [x] `./gradlew :app:detekt :app:ktlintCheck spotlessCheck` — BUILD SUCCESSFUL
- [ ] Isolated `AboutScreenFlowTest` run on emulator — **blocked**: the emulator crashes the instrumentation process with a Firebase Crashlytics `LeakedClosableViolation` (third-party OkHttp `GzipSource` finalizer leak) before reaching the two target tests. Retried; same environmental crash. Draft until a clean device run confirms green.
