### PR TITLE
test(home): join ViewModel scopes in @After to fix flaky milestone test

### DIFF
--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
-import androidx.lifecycle.viewModelScope
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
@@ -20,7 +19,6 @@ import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -46,9 +44,11 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
 
     @After
     fun tearDown() {
-        // Cancel each VM's `viewModelScope` to stop the reactive `repo.sounds` collector added
-        // in the post-PR-#1130 fix; otherwise it survives the test boundary.
-        createdViewModels.forEach { it.viewModelScope.cancel() }
+        // Deterministically stop the reactive `repo.sounds` collector each VM starts in `init`
+        // (post-PR-#1130 fix). A bare `cancel()` is fire-and-forget: the collector can outlive the
+        // test, parked on the process-singleton DataStore. `cancelAndJoinAll()` joins until it
+        // unwinds — see ViewModelTestCleanup.kt.
+        createdViewModels.cancelAndJoinAll()
         createdViewModels.clear()
         unmockkAll()
     }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelAnalyticsTest.kt
@@ -22,10 +22,10 @@ import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.withTimeout
@@ -53,12 +53,13 @@ internal class SoundsViewModelAnalyticsTest : AbstractRobolectricTest() {
 
     @After
     fun tearDown() {
-        // Cancel each VM's `viewModelScope` so the reactive `repo.sounds` collector added in the
-        // post-PR-#1130 fix doesn't survive past the test boundary. Without this cleanup, the
-        // next test's `clearForTest()` would emit through the old VM's collector, fire
-        // `loadSounds` against the old VM's `_searchQuery`, and leak `search_zero_results`
-        // events into the new test's `fake`.
-        createdViewModels.forEach { it.viewModelScope.cancel() }
+        // Deterministically stop the reactive `repo.sounds` collector each VM starts in `init`
+        // (post-PR-#1130 fix). A bare `cancel()` is fire-and-forget: the collector can outlive the
+        // test, parked on the process-singleton DataStore, and the next test's `clearForTest()` /
+        // `save(...)` writes emit through it — leaking events (`milestone_sounds_3`,
+        // `search_zero_results`) into the new test's `fake`. `cancelAndJoinAll()` joins until it
+        // unwinds — see ViewModelTestCleanup.kt.
+        createdViewModels.cancelAndJoinAll()
         createdViewModels.clear()
         AnalyticsTrackerProvider.setForTest(null)
         unmockkAll()
@@ -209,6 +210,33 @@ internal class SoundsViewModelAnalyticsTest : AbstractRobolectricTest() {
 
         givenAViewModel()
 
+        fake.assertNotEmitted("milestone_sounds_3")
+    }
+
+    @Test
+    fun `cancelAndJoinAll fully stops a ViewModel repo collector so it cannot pollute a later test`() {
+        // Build a VM, then tear it down the way @After does — but assert the contract a bare
+        // `viewModelScope.cancel()` does NOT give: the scope's Job is actually completed.
+        val vm = givenAViewModel()
+        createdViewModels.remove(vm) // this test owns the teardown; keep @After from double-cancelling
+
+        listOf(vm).cancelAndJoinAll()
+
+        // Deterministic regression anchor: `cancelAndJoin` waits for the full unwind, so the Job
+        // is completed. The old fire-and-forget `cancel()` left the `repo.sounds` collector parked
+        // on the singleton DataStore with the Job lingering in "cancelling".
+        val job = vm.viewModelScope.coroutineContext.job
+        assertThat(job.isActive).isFalse()
+        assertThat(job.isCompleted).isTrue()
+
+        // Behavioural check: a torn-down VM's collector must not react to later DataStore writes.
+        // Without the join, these `save(...)` calls would emit through the leaked collector and
+        // re-fire `milestone_sounds_3` into the (freshly reset) tracker.
+        fake.reset()
+        runBlocking {
+            val repo = SoundsRepository(ApplicationProvider.getApplicationContext())
+            repeat(3) { idx -> repo.save(Sound("leak-$idx", "leak-$idx.mp3")) }
+        }
         fake.assertNotEmitted("milestone_sounds_3")
     }
 

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelSearchTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelSearchTest.kt
@@ -5,7 +5,6 @@
  */
 package com.github.barriosnahuel.vossosunboton.ui.home
 
-import androidx.lifecycle.viewModelScope
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
 import com.github.barriosnahuel.vossosunboton.model.Sound
@@ -14,7 +13,6 @@ import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.After
@@ -32,10 +30,12 @@ internal class SoundsViewModelSearchTest : AbstractRobolectricTest() {
 
     @After
     fun tearDown() {
-        // Cancel each VM's `viewModelScope` to stop the reactive `repo.sounds` collector added
-        // in the post-PR-#1130 fix; otherwise it survives the test boundary and pollutes the
-        // next test by re-running `loadSounds` against stale in-memory state.
-        createdViewModels.forEach { it.viewModelScope.cancel() }
+        // Deterministically stop the reactive `repo.sounds` collector each VM starts in `init`
+        // (post-PR-#1130 fix). A bare `cancel()` is fire-and-forget: the collector can outlive the
+        // test, parked on the process-singleton DataStore, and pollute the next test by re-running
+        // `loadSounds` against stale state. `cancelAndJoinAll()` joins until it unwinds — see
+        // ViewModelTestCleanup.kt.
+        createdViewModels.cancelAndJoinAll()
         createdViewModels.clear()
         unmockkAll()
     }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
@@ -6,7 +6,6 @@
 package com.github.barriosnahuel.vossosunboton.ui.home
 
 import android.content.Intent
-import androidx.lifecycle.viewModelScope
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.R
@@ -26,7 +25,6 @@ import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -54,10 +52,12 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
 
     @After
     fun tearDown() {
-        // Cancel each VM's `viewModelScope` so the reactive `repo.sounds` collector added in the
-        // post-PR-#1130 fix doesn't survive past the test boundary and pollute the next test
-        // (e.g. firing `loadSounds` against the prior VM's stale `_searchQuery`).
-        createdViewModels.forEach { it.viewModelScope.cancel() }
+        // Deterministically stop the reactive `repo.sounds` collector each VM starts in `init`
+        // (post-PR-#1130 fix). A bare `cancel()` is fire-and-forget: the collector can outlive the
+        // test, parked on the process-singleton DataStore, and pollute the next test (e.g. firing
+        // `loadSounds` against the prior VM's stale `_searchQuery`). `cancelAndJoinAll()` joins
+        // until it unwinds — see ViewModelTestCleanup.kt.
+        createdViewModels.cancelAndJoinAll()
         createdViewModels.clear()
         unmockkAll()
     }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/ViewModelTestCleanup.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/ViewModelTestCleanup.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home
+
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.job
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Deterministically tears down every [SoundsViewModel] a test built: cancels each
+ * `viewModelScope` and **joins** until its child coroutines fully unwind.
+ *
+ * A bare `viewModelScope.cancel()` is fire-and-forget — it flips the scope's `Job` to
+ * "cancelling" and returns without waiting. The `repo.sounds.drop(1).collect { loadSounds() }`
+ * collector each VM starts in `init` (post-PR-#1130 fix) then stays parked on the
+ * process-singleton `bompsStore` DataStore and can outlive the test: the next test's
+ * `clearForTest()` / `save(...)` writes emit through it, re-running `loadSounds` and leaking
+ * analytics events (e.g. `milestone_sounds_3`, `search_zero_results`) into the next test's
+ * `FakeAnalyticsTracker`. `cancelAndJoin()` waits for the collector to actually stop, closing
+ * that cross-test race.
+ *
+ * Shared by the four `ui/home` test classes that build a `SoundsViewModel`.
+ */
+internal fun List<SoundsViewModel>.cancelAndJoinAll() {
+    runBlocking {
+        forEach {
+            it.viewModelScope.coroutineContext.job
+                .cancelAndJoin()
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- Fixes the flaky `SoundsViewModelAnalyticsTest > loadSounds does not re-emit milestone_sounds_3 ...[33]` that intermittently failed CI with `IllegalStateException`.
- Root cause: the reactive `repo.sounds.drop(1).collect { loadSounds() }` collector added in 50686cc outlived its test. `viewModelScope.cancel()` in `@After` is fire-and-forget, so the collector stayed parked on the **process-singleton** `bompsStore` DataStore and reacted to the *next* test's `save(...)` writes, re-emitting `milestone_sounds_3` into the next test's `FakeAnalyticsTracker`.
- New `cancelAndJoinAll()` helper (`ViewModelTestCleanup.kt`) joins until each VM's coroutines fully unwind; wired into the `@After` of the 4 `ui/home` classes that build a `SoundsViewModel`.

### Code review tips
- `ViewModelTestCleanup.kt` is the actual fix — `cancelAndJoin()` (awaited) vs the old fire-and-forget `cancel()`.
- The new regression test is deterministically green with the fix; verified it flakes **red on `[33]`** against the old helper — matching the exact CI symptom.
- No CHANGELOG entry: the regression was introduced in the same `[unreleased]` cycle (50686cc) and no end-user experienced it.

### Already tested
- [x] `./gradlew check -x test` + full `./gradlew test` (638 tests, 0 failures) rebased on latest `develop`
- [x] Previously-flaky class stress-run 27× consecutively → all green
- [x] `scripts/check-adr-invariants.sh` → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)