### PR TITLE
chore(test): cold-boot the emulator before each instrumented run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 #### Added
 - Analytics event `sound_add_abandoned_after_error` fires when the user leaves the Add Button screen with an unresolved save error (lifecycle-driven via `ON_STOP` and explicit Snackbar dismiss); best-effort — process death drops the signal
 - Enforce ADR 0005 audio engine invariant via `check-adr-invariants.sh` and the CircleCI `adr-invariants` job — fails the build if a `MediaPlayer()` constructor appears in `src/main` outside `PlayerControllerImpl.kt`
+- Added `scripts/run-instrumented-tests.sh`, a wrapper that cold-boots the test emulator (wiped userdata, pinned serial) before each `connectedDebugAndroidTest` run — a warm AVD degrades across back-to-back runs (`system_server` watchdog ANRs) and produces misleading `ComposeTimeout`/`Process crashed` flakes; ADR 0001 and CONTRIBUTING now document the cold-boot requirement
 
 #### Removed
 - Dead post-save plumbing: `EXTRA_BUTTON_SAVED` / `EXTRA_BUTTON_RENAMED` / `EXTRA_BUTTON_NAME` Intent extras, `SoundsViewModel.buttonSavedEvent` / `buttonRenamedEvent` channels and their `onButtonSaved` / `onButtonRenamed` setters, the `LandingScreen` `LaunchedEffect`s that consumed them, and `AddButtonActivity.navigateBackSaved` / `navigateBackRenamed`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,10 @@ Mock singleton factories (e.g. `PlayerControllerFactory`) that would crash under
 
 Instrumented UI/functional tests live under `app/src/androidTest/`. CircleCI intentionally does not run them — see [ADR 0001](docs/adr/0001-local-ui-test-suite.md). Setup, run commands, and report paths live in CONTRIBUTING.md § *Testing → Local UI test suite*.
 
+### How to run — always via the wrapper
+
+Run the suite with `./scripts/run-instrumented-tests.sh` (extra args pass through to Gradle; `RUNS=N` repeats the cold-boot+run cycle N times). **Never invoke `./gradlew :app:connectedDebugAndroidTest` directly against an already-running emulator** — a warm AVD degrades across back-to-back runs (`system_server` watchdog ANRs, hundreds of skipped frames), and the failures masquerade as per-test flakes (`ComposeTimeoutException`, `ComposeNotIdleException`) or escalate to `Process crashed`. The wrapper cold-boots the AVD with wiped userdata and pins the emulator serial before each run. Rationale + the misdiagnosis trap: [ADR 0001 § *Cold boot per run*](docs/adr/0001-local-ui-test-suite.md). If the suite flakes, re-run via the wrapper before assuming a test or production bug.
+
 ### When to run
 
 - After any change to a Composable, ViewModel, intent flow, navigation, deep link, or persistence layer.
@@ -249,7 +253,7 @@ CI linters that must pass:
 
 Run `./gradlew check -x test && ./gradlew test` before pushing — catches the same failures CI reports without waiting for a full CI run.
 
-**Functional changes also require the local UI test suite** (§ *Local UI test suite*). If the change touches Composables, ViewModels, intents, navigation, deep links, or persistence — run the instrumented suite on an emulator before pushing. CircleCI does not execute it. Cosmetic-only changes (CHANGELOG, copy strings, README, comments) are exempt.
+**Functional changes also require the local UI test suite** (§ *Local UI test suite*). If the change touches Composables, ViewModels, intents, navigation, deep links, or persistence — run `./scripts/run-instrumented-tests.sh` before pushing (it cold-boots the emulator; never run the Gradle task directly against a warm AVD). CircleCI does not execute it. Cosmetic-only changes (CHANGELOG, copy strings, README, comments) are exempt.
 
 ## Analytics events
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,20 +94,27 @@ Instrumented UI/functional tests live under `app/src/androidTest/`. They drive a
 #### Run the full suite
 
 ```bash
-# 1. Boot the emulator (background)
-emulator -avd Android_14_API_34 -no-snapshot-save -no-boot-anim &
-adb wait-for-device shell 'while [[ $(getprop sys.boot_completed) != 1 ]]; do sleep 1; done'
+./scripts/run-instrumented-tests.sh
+```
 
-# 2. Run all instrumented tests (UTP installs + runs natively)
-./gradlew app:connectedDebugAndroidTest
+The wrapper cold-boots the AVD with wiped userdata, waits for it, then runs `./gradlew :app:connectedDebugAndroidTest` against that emulator only (it pins the serial, so a physical device attached at the same time is ignored).
+
+**Always go through the wrapper — do not run `./gradlew :app:connectedDebugAndroidTest` against an already-running emulator.** A warm emulator degrades across back-to-back runs (`system_server` watchdog ANRs, hundreds of skipped frames), which surfaces as `ComposeTimeoutException` / `ComposeNotIdleException` flakes or an outright `Process crashed`. A cold boot resets that — a clean run finishes in ~3 min; a degraded one takes 15+ min or never completes. Rationale: [ADR 0001 § *Cold boot per run*](docs/adr/0001-local-ui-test-suite.md).
+
+To hunt flakes, run several cold-booted passes in a row:
+
+```bash
+RUNS=3 ./scripts/run-instrumented-tests.sh
 ```
 
 HTML report: `app/build/reports/androidTests/connected/debug/index.html`. Raw XML: `app/build/outputs/androidTest-results/connected/debug/`.
 
 #### Run a single test class
 
+Any extra arguments are passed straight through to Gradle:
+
 ```bash
-./gradlew app:connectedDebugAndroidTest \
+./scripts/run-instrumented-tests.sh \
   -Pandroid.testInstrumentationRunnerArguments.class=com.github.barriosnahuel.vossosunboton.ui.home.SearchOverlayTest
 ```
 

--- a/docs/adr/0001-local-ui-test-suite.md
+++ b/docs/adr/0001-local-ui-test-suite.md
@@ -81,11 +81,35 @@ Adopt **Option D**, isolated under `app/src/androidTest/`:
 
 - Gradle source set already excluded from `./gradlew test` and `./gradlew check`.
 - Not invoked by `.circleci/config.yml` (the `test` job runs `./gradlew test` only).
-- A single command runs the suite: `./gradlew app:connectedDebugAndroidTest`.
-- Operator workflow: run `./scripts/setup-test-emulator.sh` once to create the AVD, boot
-  the emulator, then `./gradlew app:connectedDebugAndroidTest` for each pass.
+- A single command runs the suite: `./scripts/run-instrumented-tests.sh` (wraps
+  `./gradlew :app:connectedDebugAndroidTest`).
+- Operator workflow: run `./scripts/setup-test-emulator.sh` once to create the AVD, then
+  `./scripts/run-instrumented-tests.sh` for each pass. The wrapper cold-boots the AVD with
+  wiped userdata before every run — see *Cold boot per run* below — and pins the emulator
+  serial so the run never spills onto a physical device that happens to be attached.
 - Each screen test file owns its accessibility assertions. There is no
   `AccessibilitySweepTest` collector — a11y is part of the feature, not a separate concern.
+
+### Cold boot per run
+
+The suite must run on a freshly cold-booted emulator, not a warm one. A long-lived AVD
+degrades across back-to-back runs: `system_server`'s `InputManagerService` watchdog
+eventually ANRs, `Choreographer` skips hundreds of frames, and the instrumentation loses
+contact with the app process. The symptoms are misleading — they look like per-test flakes
+(`ComposeTimeoutException`, `ComposeNotIdleException`) or escalate to `Process crashed` and
+the run failing to start at all — but the root cause is accumulated emulator state, not the
+tests or the app (a single run from a clean cold boot finishes ~5× faster and green; the
+same tests pass on physical devices). `./scripts/run-instrumented-tests.sh` enforces this:
+it kills the AVD, relaunches it with `-no-snapshot -wipe-data`, waits for boot, then runs
+the suite — repeating the cold boot before each pass when `RUNS` > 1. Do **not** invoke
+`./gradlew :app:connectedDebugAndroidTest` directly against an already-running emulator.
+
+The wrapper resets *guest* (emulator) state — it cannot reset *host* state. The emulator is
+a VM, and a saturated host (high load average from other heavy work, or from running the
+suite dozens of times back-to-back) makes even a freshly booted guest janky enough to flake
+timing-sensitive tests. If a cold-booted run is still slow or flaky, check the host load
+before suspecting a test: close other heavy work and re-run, rather than chasing a
+non-existent test bug.
 
 ### History note: dynamic feature workaround (removed)
 
@@ -99,9 +123,11 @@ to bypass UTP's reinstall.
 
 That whole workaround was deleted when `:feature_addbutton` was promoted into
 `:app` (creating buttons is core to the product, not a freemium add-on). The
-suite is now plain `./gradlew app:connectedDebugAndroidTest` with the standard
-HTML/XML report. Reintroduce something similar if a dynamic feature returns
-for genuinely on-demand functionality.
+suite is now the standard `:app:connectedDebugAndroidTest` Gradle task with the
+standard HTML/XML report — `./scripts/run-instrumented-tests.sh` only wraps it
+with emulator lifecycle management (see *Cold boot per run*), it does not touch
+the build or install path. Reintroduce a bundletool-style workaround only if a
+dynamic feature returns for genuinely on-demand functionality.
 
 ## Consequences
 
@@ -117,6 +143,9 @@ for genuinely on-demand functionality.
 
 - Requires an emulator to run the suite. Developers without one need to run
   `./scripts/setup-test-emulator.sh` once (~5 minutes including system image download).
+- Each run pays a cold-boot cost (~30–60 s) because the wrapper wipes userdata and reboots
+  the AVD. This is deliberate: a warm run is faster to *start* but unreliable to *finish*
+  (see *Cold boot per run*), and a clean run completes the whole suite in ~3 min anyway.
 - Compose-driven interactions don't auto-trigger ATF — explicit semantics assertions are
   required per screen test. This is documented in `AbstractUiTest`'s KDoc and enforced by
   PR review (the per-screen test is supposed to include a11y bullets in the test plan).

--- a/scripts/run-instrumented-tests.sh
+++ b/scripts/run-instrumented-tests.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# Runs the local instrumented UI test suite on a freshly cold-booted emulator.
+#
+# Why a wrapper instead of `./gradlew :app:connectedDebugAndroidTest` directly:
+# the suite (ADR 0001) is run repeatedly on a long-lived AVD, and a *warm*
+# emulator degrades across back-to-back runs. system_server's
+# InputManagerService watchdog eventually ANRs, Choreographer skips hundreds of
+# frames, and the instrumentation loses contact with the app process — surfacing
+# as ComposeTimeout / ComposeNotIdle flakes, "Process crashed", or the run
+# failing to start at all. A cold boot with wiped userdata resets that state: a
+# clean run finishes in ~3 min, a degraded one takes 15+ min or never completes.
+# This wrapper guarantees every run starts from that clean state.
+#
+# It also pins the emulator serial (-port 5554) and exports ANDROID_SERIAL, so
+# `connectedDebugAndroidTest` targets the emulator only — never a physical
+# device that happens to be plugged in (Gradle would otherwise run on all
+# connected devices in parallel and corrupt the run).
+#
+# Usage:
+#   ./scripts/run-instrumented-tests.sh
+#       one clean run, full suite
+#   ./scripts/run-instrumented-tests.sh \
+#       -Pandroid.testInstrumentationRunnerArguments.class=com.github.barriosnahuel.vossosunboton.ui.home.SearchOverlayTest
+#       single class — any extra args are passed through to Gradle
+#   RUNS=3 ./scripts/run-instrumented-tests.sh
+#       three runs, each preceded by its own cold boot (use to hunt flakes)
+#
+# Environment overrides: AVD_NAME, RUNS, EMULATOR_PORT, BOOT_TIMEOUT_SECONDS.
+#
+# Requires the Android SDK CLI on PATH (emulator, adb) and the AVD created by
+# ./scripts/setup-test-emulator.sh.
+#
+set -euo pipefail
+
+AVD_NAME="${AVD_NAME:-Android_14_API_34}"
+RUNS="${RUNS:-1}"
+EMULATOR_PORT="${EMULATOR_PORT:-5554}"
+BOOT_TIMEOUT_SECONDS="${BOOT_TIMEOUT_SECONDS:-300}"
+EMULATOR_SERIAL="emulator-${EMULATOR_PORT}"
+
+# Auto-discover the Android SDK and prepend its tool dirs to PATH (mirrors
+# scripts/setup-test-emulator.sh) so the script works with only cmdline-tools on PATH.
+SDK_ROOT="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-$HOME/Library/Android/sdk}}"
+if [ -d "$SDK_ROOT" ]; then
+  PATH="$SDK_ROOT/platform-tools:$SDK_ROOT/emulator:$PATH"
+fi
+
+for cmd in emulator adb; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "✘ '$cmd' not found on PATH (looked under $SDK_ROOT). Run ./scripts/setup-test-emulator.sh first." >&2
+    exit 1
+  fi
+done
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+EMULATOR_LOG="${TMPDIR:-/tmp}/push-me-instrumented-emulator.log"
+
+# Kills any running emulator instance backing $AVD_NAME and blocks until its
+# serial is fully gone from `adb devices`. `adb emu kill` is asynchronous — the
+# process keeps holding its console/adb port for a moment after the call
+# returns — so reusing the port immediately makes the fresh `emulator -port`
+# collide with the dying instance (adb then attaches to the ghost and the boot
+# poll never completes). A different AVD the developer happens to be running is
+# left untouched.
+kill_existing_emulator() {
+  local serial name killed=0
+  for serial in $(adb devices | awk '/^emulator-/{print $1}'); do
+    name="$(adb -s "$serial" emu avd name 2>/dev/null | head -1 | tr -d '\r')"
+    if [ "$name" = "$AVD_NAME" ]; then
+      echo "→ Killing running emulator $serial ($AVD_NAME)"
+      adb -s "$serial" emu kill >/dev/null 2>&1 || true
+      killed=1
+    fi
+  done
+  [ "$killed" -eq 0 ] && return 0
+
+  local waited=0
+  while adb devices | grep -qE "^${EMULATOR_SERIAL}[[:space:]]"; do
+    if [ "$waited" -ge 60 ]; then
+      echo "✘ $EMULATOR_SERIAL still present 60s after 'adb emu kill' — kill it manually" >&2
+      exit 1
+    fi
+    sleep 2
+    waited=$((waited + 2))
+  done
+}
+
+# Cold-boots $AVD_NAME on $EMULATOR_PORT with wiped userdata and blocks until the
+# device reports sys.boot_completed.
+cold_boot_emulator() {
+  echo "→ Cold-booting $AVD_NAME on port $EMULATOR_PORT (-no-snapshot -wipe-data)"
+  # -no-snapshot  : ignore any saved snapshot and don't save one on exit — boot from scratch
+  # -wipe-data    : reset userdata, the part that accumulates the cruft this wrapper exists to avoid
+  # -no-boot-anim : shave a few seconds off the boot
+  # stdout/stderr -> $EMULATOR_LOG so a failed boot is diagnosable instead of silent.
+  nohup emulator -avd "$AVD_NAME" -port "$EMULATOR_PORT" \
+    -no-snapshot -wipe-data -no-boot-anim >"$EMULATOR_LOG" 2>&1 &
+
+  ANDROID_SERIAL="$EMULATOR_SERIAL" adb wait-for-device
+  local waited=0
+  until [ "$(ANDROID_SERIAL="$EMULATOR_SERIAL" adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" = "1" ]; do
+    if [ "$waited" -ge "$BOOT_TIMEOUT_SECONDS" ]; then
+      echo "✘ $AVD_NAME did not finish booting within ${BOOT_TIMEOUT_SECONDS}s" >&2
+      echo "  emulator log: $EMULATOR_LOG" >&2
+      tail -20 "$EMULATOR_LOG" >&2 2>/dev/null || true
+      exit 1
+    fi
+    sleep 2
+    waited=$((waited + 2))
+  done
+  echo "✔ $AVD_NAME booted ($EMULATOR_SERIAL)"
+}
+
+overall_status=0
+for run in $(seq 1 "$RUNS"); do
+  if [ "$RUNS" -gt 1 ]; then
+    echo ""
+    echo "================ instrumented run ${run} / ${RUNS} ================"
+  fi
+  kill_existing_emulator
+  cold_boot_emulator
+
+  echo "→ ANDROID_SERIAL=$EMULATOR_SERIAL ./gradlew :app:connectedDebugAndroidTest $*"
+  if (cd "$REPO_ROOT" && ANDROID_SERIAL="$EMULATOR_SERIAL" ./gradlew :app:connectedDebugAndroidTest "$@"); then
+    echo "✔ run ${run}/${RUNS} passed"
+  else
+    echo "✘ run ${run}/${RUNS} failed — report: app/build/reports/androidTests/connected/debug/index.html" >&2
+    overall_status=1
+  fi
+done
+
+if [ "$RUNS" -gt 1 ]; then
+  echo ""
+  if [ "$overall_status" -eq 0 ]; then
+    echo "✔ all ${RUNS} runs passed"
+  else
+    echo "✘ at least one of ${RUNS} runs failed"
+  fi
+fi
+
+exit "$overall_status"

--- a/scripts/setup-test-emulator.sh
+++ b/scripts/setup-test-emulator.sh
@@ -57,10 +57,11 @@ echo "no" | avdmanager create avd \
 cat <<EOF
 ✔ AVD '${AVD_NAME}' ready.
 
-Launch it before running the UI test suite:
-  emulator -avd ${AVD_NAME} -no-snapshot-save -no-boot-anim &
-  adb wait-for-device shell 'while [[ \$(getprop sys.boot_completed) != 1 ]]; do sleep 1; done'
+Run the UI test suite with the wrapper — it cold-boots the AVD (wiped userdata)
+before every run, which the suite needs to stay reliable:
+  ./scripts/run-instrumented-tests.sh
 
-Then run the suite:
-  ./gradlew app:connectedDebugAndroidTest
+A warm emulator degrades across back-to-back runs; do not invoke
+'./gradlew :app:connectedDebugAndroidTest' against an already-running instance.
+See ./scripts/run-instrumented-tests.sh and docs/adr/0001-local-ui-test-suite.md.
 EOF


### PR DESCRIPTION
### Summary
- The local instrumented suite (ADR 0001) is run repeatedly against a long-lived AVD. A *warm* emulator degrades across back-to-back runs — `system_server` watchdog ANRs, hundreds of skipped frames — and the instrumentation loses contact with the app process.
- The failures masquerade as per-test flakes (`ComposeTimeoutException` / `ComposeNotIdleException`) or escalate to `Process crashed`. Root cause is accumulated *emulator* state, not the tests or the app: a clean cold-booted run is ~5× faster and the same tests pass on physical devices.
- Adds `scripts/run-instrumented-tests.sh` — kills + cold-boots the AVD (`-no-snapshot -wipe-data`), waits for boot, runs `:app:connectedDebugAndroidTest` with the serial pinned. `RUNS=N` repeats the cycle. ADR 0001, CONTRIBUTING, CLAUDE.md and `setup-test-emulator.sh` now route through it.

### Code review tips
- `run-instrumented-tests.sh` is the only executable change. `kill_existing_emulator` waits for the serial to leave `adb devices` before reusing the port — `adb emu kill` is async, so skipping the wait makes the fresh `-port` boot collide with the dying instance (the boot poll then hangs on a ghost device).
- Pins `-port 5554` + `ANDROID_SERIAL` so the run never spills onto a physical device attached at the same time (`connectedDebugAndroidTest` otherwise runs on every connected device in parallel).
- No production code, no Kotlin, no `.circleci/config.yml` change — ADR 0001's local-only invariant holds (`check-adr-invariants.sh` passes).

### Already tested
- `bash -n scripts/run-instrumented-tests.sh` and `scripts/check-adr-invariants.sh` — pass.
- `RUNS=2 ./scripts/run-instrumented-tests.sh`: both passes cold-booted cleanly (kill → wait-for-serial-gone → reboot). Run 1 completed all 51 tests with only the 2 deterministic `AboutScreenFlowTest` back-nav failures (a pre-existing #1143 regression, fixed in #1145) and zero environmental flakes — warm runs previously crashed at test 30 or never started. Run 2 showed residual flakiness from host saturation (load avg ~12 after a multi-hour emulator marathon) — out of a test wrapper's scope, documented in ADR 0001.

### Related
- #1145 fixes the 2 `AboutScreenFlowTest` back-nav failures surfaced (and correctly isolated) by this wrapper.