### PR TITLE
fix(addbutton): stop preview audio when save success morph appears

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Rotating the device while the License sheet is open in About no longer collapses the sheet; the sheet stays open
 - Optimized app size by filtering AAB locales to `en` and `es` only via AGP 9 `androidResources.localeFilters`; transitive dependencies (Material, AndroidX, Firebase, Play Services) no longer ship ~80 unused translations in the bundle
 - Restored ripple contrast on the empty Home in light mode so the illustration reads clearly from the first launch
+- Audio preview no longer bleeds into the success confirmation when you save a new Bomp (or save a rename) while the preview is playing — the audio now stops the moment the confirmation appears
 
 
 ### Changed

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
@@ -155,6 +155,7 @@ fun AddButtonScreen(
                 is AddButtonMode.Create -> {
                     val feedbackId = feature.saveNewButtonAsync(context, trimmedName, m.uri.toString()).await()
                     if (feedbackId == R.string.app_addbutton_feedback_saved_ok) {
+                        stopActivePreviewPlayback()
                         trackSoundAdd(context, trimmedName, tracker)
                         saveOutcome = SaveOutcome.Success(trimmedName)
                     } else {
@@ -181,6 +182,7 @@ fun AddButtonScreen(
                 }
                 is AddButtonMode.Edit -> {
                     feature.renameButtonAsync(context, m.sound, trimmedName).await()
+                    stopActivePreviewPlayback()
                     trackSoundEdit(trimmedName, m.sound.name, tracker)
                     saveOutcome = SaveOutcome.Success(trimmedName)
                 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AudioPreview.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AudioPreview.kt
@@ -52,6 +52,21 @@ import com.github.barriosnahuel.vossosunboton.ui.home.formatRelativeDate
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
+/**
+ * Stops in-flight URI-bound preview playback. Used by `AudioPreview`'s `DisposableEffect.onDispose`
+ * and by `AddButtonScreen.save()` when transitioning to the success morph — without the latter the
+ * only stop is the disposal path, which fires when the Activity tears down ~600 ms later, leaving
+ * audio bleeding through the confirmation overlay. Guarded on a non-null URI to leave Sound-bound
+ * playback owned by other surfaces (Home/Explore — reported via the listener, not [playbackState];
+ * see ADR 0007) untouched.
+ */
+internal fun stopActivePreviewPlayback() {
+    val controller = PlayerControllerFactory.instance
+    if (controller.playbackState.value?.uri != null) {
+        controller.stopPlayingSound()
+    }
+}
+
 @Composable
 internal fun AudioPreview(
     context: Context,

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenPlaybackTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenPlaybackTest.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.addbutton
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.FakeAnalyticsTracker
+import com.github.barriosnahuel.vossosunboton.feature.playback.PlaybackState
+import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerController
+import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
+import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.github.barriosnahuel.vossosunboton.testSound
+import com.github.barriosnahuel.vossosunboton.ui.home.LandingActivity
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.robolectric.annotation.Config
+
+/**
+ * Guards the contract that the moment `save()` flips to [SaveOutcome.Success] — i.e. the success
+ * morph starts — any in-flight preview playback is explicitly stopped. Without this the only stop
+ * is AudioPreview's `DisposableEffect.onDispose`, which fires when the Activity tears down ~600 ms
+ * later (overlay hold + `finish()`), so audio keeps bleeding into the confirmation moment.
+ */
+@Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+internal class AddButtonScreenPlaybackTest : AbstractRobolectricTest() {
+    @get:Rule
+    val composeTestRule = createEmptyComposeRule()
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    private val playbackStateFlow = MutableStateFlow<PlaybackState?>(null)
+    private lateinit var fakeController: PlayerController
+    private lateinit var originalController: PlayerController
+
+    @Before
+    fun setUp() {
+        AnalyticsTrackerProvider.setForTest(FakeAnalyticsTracker())
+        AddButtonFeatureProvider.setForTest(AlwaysSucceedFeature())
+        originalController = PlayerControllerFactory.instance
+        fakeController =
+            mockk(relaxed = true) {
+                every { playbackState } returns playbackStateFlow
+            }
+        PlayerControllerFactory.instance = fakeController
+    }
+
+    @After
+    fun tearDown() {
+        PlayerControllerFactory.instance = originalController
+        AnalyticsTrackerProvider.setForTest(null)
+        AddButtonFeatureProvider.setForTest(null)
+    }
+
+    @Test
+    fun `Create flow stops preview playback when save transitions to the success morph`() {
+        // Simulate the user mid-preview: the URI-bound playbackState matches the share-incoming Uri.
+        playbackStateFlow.value =
+            PlaybackState(uri = SAMPLE_URI, positionMs = 250, durationMs = 5_000, isPlaying = true)
+
+        ActivityScenario.launch<AddButtonActivity>(createIntent()).use {
+            composeTestRule.waitForIdle()
+            composeTestRule.onNode(hasSetTextAction()).performTextInput(NEW_NAME)
+            // Pause the clock so we can observe the post-save state BEFORE the overlay's auto-finish
+            // (~600 ms) tears down the Activity — without this the AudioPreview DisposableEffect could
+            // also call stopPlayingSound() during teardown and the assertion would not isolate the fix.
+            composeTestRule.mainClock.autoAdvance = false
+            composeTestRule.onNodeWithText(context.getString(R.string.app_addbutton_save)).performClick()
+            // Advance just enough for save() to flip to Success — well under the 600 ms hold.
+            composeTestRule.mainClock.advanceTimeBy(CLOCK_STEP_MS)
+
+            verify(exactly = 1) { fakeController.stopPlayingSound() }
+
+            composeTestRule.mainClock.autoAdvance = true
+        }
+    }
+
+    @Test
+    fun `Edit flow stops preview playback when save transitions to the success morph`() {
+        playbackStateFlow.value =
+            PlaybackState(uri = EXISTING_URI, positionMs = 100, durationMs = 3_000, isPlaying = true)
+
+        ActivityScenario.launch<AddButtonActivity>(editIntent()).use {
+            composeTestRule.waitForIdle()
+            composeTestRule.mainClock.autoAdvance = false
+            composeTestRule
+                .onNodeWithText(context.getString(R.string.app_addbutton_save_changes))
+                .performClick()
+            composeTestRule.mainClock.advanceTimeBy(CLOCK_STEP_MS)
+
+            verify(exactly = 1) { fakeController.stopPlayingSound() }
+
+            composeTestRule.mainClock.autoAdvance = true
+        }
+    }
+
+    @Test
+    fun `Create flow does not stop preview when save fails so the user can retry without losing the audio`() {
+        // Failure path stays on the form (snackbar with Retry). If the preview were pre-empted on
+        // failure the user would have to re-tap play to verify the audio before retrying — which
+        // is the exact UX trap the success-path fix is meant to avoid carrying over to errors.
+        playbackStateFlow.value =
+            PlaybackState(uri = SAMPLE_URI, positionMs = 200, durationMs = 4_000, isPlaying = true)
+        AddButtonFeatureProvider.setForTest(
+            object : AddButtonFeature {
+                override fun saveNewButtonAsync(
+                    context: Context,
+                    name: String,
+                    uri: String,
+                ): Deferred<Int> = CompletableDeferred(R.string.app_addbutton_feedback_save_failed)
+
+                override fun renameButtonAsync(
+                    context: Context,
+                    sound: Sound,
+                    newName: String,
+                ): Deferred<Unit> = CompletableDeferred(Unit)
+            },
+        )
+
+        ActivityScenario.launch<AddButtonActivity>(createIntent()).use {
+            composeTestRule.waitForIdle()
+            composeTestRule.onNode(hasSetTextAction()).performTextInput(NEW_NAME)
+            composeTestRule.mainClock.autoAdvance = false
+            composeTestRule.onNodeWithText(context.getString(R.string.app_addbutton_save)).performClick()
+            composeTestRule.mainClock.advanceTimeBy(CLOCK_STEP_MS)
+
+            verify(exactly = 0) { fakeController.stopPlayingSound() }
+
+            composeTestRule.mainClock.autoAdvance = true
+        }
+    }
+
+    @Test
+    fun `save does not preempt playback when nothing is playing`() {
+        // Idle controller: no preview was running. The fix must not pre-empt anything that isn't
+        // ours — guards against future regressions where a global stop would interfere with an
+        // unrelated playback owned by another surface.
+        playbackStateFlow.value = null
+
+        ActivityScenario.launch<AddButtonActivity>(createIntent()).use {
+            composeTestRule.waitForIdle()
+            composeTestRule.onNode(hasSetTextAction()).performTextInput(NEW_NAME)
+            composeTestRule.mainClock.autoAdvance = false
+            composeTestRule.onNodeWithText(context.getString(R.string.app_addbutton_save)).performClick()
+            composeTestRule.mainClock.advanceTimeBy(CLOCK_STEP_MS)
+
+            verify(exactly = 0) { fakeController.stopPlayingSound() }
+
+            composeTestRule.mainClock.autoAdvance = true
+        }
+    }
+
+    private fun createIntent(): Intent =
+        Intent(context, AddButtonActivity::class.java).apply {
+            action = Intent.ACTION_SEND
+            type = "audio/*"
+            putExtra(Intent.EXTRA_STREAM, SAMPLE_URI)
+        }
+
+    private fun editIntent(): Intent =
+        Intent(context, AddButtonActivity::class.java).apply {
+            putExtra(LandingActivity.EXTRA_EDIT_SOUND, testSound(EXISTING_NAME, file = "existing.mp3"))
+        }
+
+    private class AlwaysSucceedFeature : AddButtonFeature {
+        override fun saveNewButtonAsync(
+            context: Context,
+            name: String,
+            uri: String,
+        ): Deferred<Int> = CompletableDeferred(R.string.app_addbutton_feedback_saved_ok)
+
+        override fun renameButtonAsync(
+            context: Context,
+            sound: Sound,
+            newName: String,
+        ): Deferred<Unit> = CompletableDeferred(Unit)
+    }
+
+    private companion object {
+        val SAMPLE_URI: Uri = Uri.parse("content://test/audio.mp3")
+        val EXISTING_URI: Uri = Uri.parse("file:///tmp/existing.mp3")
+        const val NEW_NAME = "Test sound"
+        const val EXISTING_NAME = "Existing sound"
+        const val CLOCK_STEP_MS = 100L
+    }
+}


### PR DESCRIPTION
### Summary
- Adding a new audio (or renaming one), hitting **Save** while the preview is playing left the audio audible for the full ~600ms success-morph hold. The only stop was `AudioPreview`'s `DisposableEffect.onDispose`, which fires on Activity teardown — not on the morph transition.
- `AddButtonScreen.save()` now calls a new helper `stopActivePreviewPlayback()` at the exact moment it flips `saveOutcome = SaveOutcome.Success(...)` (Create branch after `saveNewButtonAsync` returns `saved_ok`; Edit branch after `renameButtonAsync` returns). The helper lives in `AudioPreview.kt` (preview-playback domain owner) and guards on `playbackState.value?.uri != null` to match the canonical onDispose pattern — Sound-bound playback owned by Home/Explore (ADR 0007) is never touched.
- TDD: added `AddButtonScreenPlaybackTest` with 4 Robolectric cases — Create stops, Edit stops, save **failure does not stop** (user must keep the audio to retry-with-listen), idle no-op.

### Code review tips
- Trade-off: helper lives in `AudioPreview.kt`, not `AddButtonScreen.kt`, because adding a top-level fun in the latter pushes `TooManyFunctions` past 10/11 and a local fun pushes `CyclomaticComplexMethod` past 15. `AudioPreview.kt` is the canonical owner of preview-playback side effects anyway (it already calls `stopPlayingSound()` in `DisposableEffect.onDispose`), so the move is structurally cleaner.
- The fix relies on the ADR 0007 invariant that `playbackState` is null for Sound-bound playback. If a future refactor unifies Sound/Uri reporting through `playbackState`, this helper would start pre-empting Home/Explore. KDoc cites the ADR — keep that link maintained.
- Tests use `composeTestRule.mainClock.autoAdvance = false` to *isolate* the new save-path stop from the AudioPreview disposal-path stop. With the clock frozen, the overlay's `delay(600)` never resolves, the Activity never reaches `finish()`, and `AudioPreview.onDispose` never fires — so `verify(exactly = 1) { stopPlayingSound() }` proves the new call alone happened. Pattern mirrors existing `AddButtonScreenAnalyticsTest`'s recreate test.
- Save-failure case (snackbar with Retry) deliberately does **not** call the helper, so the user can still verify the audio before re-tapping save. Test guards this regression.
- Flaky pre-existing: `SoundsViewModelAnalyticsTest > welcome_sticker_shown ...` failed once in a full-suite run, then 3/3 green in isolation and 1/1 green on full re-run — test-pollution flake unrelated to this PR.

### Already tested
- [x] `./gradlew check` (detekt + ktlint + spotless + Android Lint) green
- [x] `./gradlew test` full unit suite green on re-run; new `AddButtonScreenPlaybackTest` 4/4 green
- [x] Instrumented suite (`./scripts/run-instrumented-tests.sh`) green on cold-booted `Android_14_API_34` AVD: 61 tests, 0 failed (10 skipped pre-existing) in 6m19s
- [x] Manual smoke on Pixel 8 (debug build, real Firebase): playing the preview then tapping Save now stops the audio at the moment the success morph appears
