### PR TITLE
test: de-flake milestone_sounds_3 re-emit + rename clash with FAILED marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Search overlay's auto-focus now mirrors the Add Button pattern: `withFrameNanos` wait + `runCatching { requestFocus() }` with `Tracker.track` on failure (static wrapper title, breadcrumb `searchoverlay.field=search`), so a first-frame focus break on the search input is no longer silent
 - New CLAUDE.md § *Stateful Composables — `rememberSaveable` is the default for durable state* documents the rule, references `SaveOutcomeSaver` as the Saver template, and adds a Pre-PR checklist line requiring `scenario.recreate()` tests for screens with durable state
 - `AboutScreenFlowTest` back-navigation tests now use the always-present overflow-menu icon as the Landing sentinel instead of the Search FAB, which #1143 gated behind a minimum sound count
+- `FakeAnalyticsTracker.firedFlags` is now backed by a `ConcurrentHashMap` (via `Collections.newSetFromMap`) so its `add` mirrors production `DataStoreFirstFlagStore.consumeFirstTime` (atomic per-key); fixes a flaky `SoundsViewModelAnalyticsTest > loadSounds does not re-emit milestone_sounds_3 once already fired[33]` where two concurrent IO-dispatched coroutines could both observe the flag as absent on the plain `mutableSetOf()` and double-emit the milestone
 
 ## \[v2.0.0] - 2026-05-07
 

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeatureTest.kt
@@ -138,7 +138,7 @@ internal class ShareFeatureTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `prepareShareIntent returns Failure copy_failed when bundled copy throws IOException`() {
+    fun `prepareShareIntent returns Failure with copy-error feedback when bundled copy throws IOException`() {
         val sound = givenASoundWithResourceId()
         val realContext = ApplicationProvider.getApplicationContext<Context>()
         val mockedContext = spyk<Context>(realContext)

--- a/commons_android/src/testFixtures/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/FakeAnalyticsTracker.kt
+++ b/commons_android/src/testFixtures/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/FakeAnalyticsTracker.kt
@@ -6,19 +6,31 @@
 package com.github.barriosnahuel.vossosunboton.commons.android.analytics
 
 import android.os.Bundle
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Test double that records every emission so call-site tests can assert what the wrapper would have sent to Firebase.
  *
  * Distributed via the `java-test-fixtures` configuration of `:commons_android` so any module can consume it via
  * `testImplementation testFixtures(project(":commons_android"))`.
+ *
+ * Thread-safety: tests in this codebase create `SoundsViewModel` instances that launch coroutines on
+ * `Dispatchers.IO` (the production default); a single test can also have multiple ViewModels alive at
+ * once. [firedFlags] therefore mirrors production's [DataStoreFirstFlagStore] semantics — backed by a
+ * [ConcurrentHashMap] so `add` is atomic, leaving exactly one concurrent caller observing "not yet
+ * fired" per flag and preventing a double-emit of `first_*` / `milestone_*` events.
+ * `Collections.newSetFromMap` (API 9+) wraps the map without requiring `ConcurrentHashMap.newKeySet`
+ * (API 24+). The other recorders stay plain — they are written from the same coroutines but only
+ * read by the test thread after the ViewModel has reached a quiescent state, so the JMM visibility
+ * cost of synchronized collections is not worth paying.
  */
 class FakeAnalyticsTracker : AnalyticsTracker {
     val events: MutableList<RecordedEvent> = mutableListOf()
     val screens: MutableList<RecordedScreen> = mutableListOf()
     val userProperties: MutableMap<String, String> = mutableMapOf()
     val counters: MutableMap<String, Long> = mutableMapOf()
-    val firedFlags: MutableSet<String> = mutableSetOf()
+    val firedFlags: MutableSet<String> = Collections.newSetFromMap(ConcurrentHashMap())
 
     override fun log(event: AnalyticsEvent) {
         events += RecordedEvent(event.name, event.params().toReadableMap())


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change.

- Removes flakiness from `SoundsViewModelAnalyticsTest > loadSounds does not re-emit milestone_sounds_3 once already fired`, observed failing on SDK 33 with `IllegalStateException` at the `assertNotEmitted` line.
- Renames a sibling test to drop the literal `failed` substring so cmd+F for "failed" in CI test reports no longer collides with the `FAILED` status marker.

Protects: the `markFiredOnce` contract (one emit per install per flag) so analytics dashboards stay clean, and removes a log-search collision that slowed triage.

### Technical detail

1. `FakeAnalyticsTracker.firedFlags` was `mutableSetOf()` (`LinkedHashSet`). Two `SoundsViewModel` instances alive in the same test could race on `firedFlags.add("milestone_sounds_3")` from coroutines on `Dispatchers.IO` — both observe the flag absent on the non-thread-safe set and both return `true`, double-emitting. Production `DataStoreFirstFlagStore.consumeFirstTime` uses `ConcurrentHashMap.putIfAbsent` precisely to satisfy "exactly one concurrent caller sees true" (KDoc). The fake now backs `firedFlags` with `Collections.newSetFromMap(ConcurrentHashMap())` — `add` is atomic per key and stays API 23-compatible (`ConcurrentHashMap.newKeySet` would need API 24).

2. `ShareFeatureTest > prepareShareIntent returns Failure copy_failed when bundled copy throws IOException` renamed to `... Failure with copy-error feedback when bundled copy throws IOException`; body unchanged.

### Code review tips

- Fix is in `:commons_android` test fixtures (`java-test-fixtures`), inherited by every consumer module. `firedFlags: MutableSet<String>` public type unchanged → no call-site updates needed.
- `Collections.newSetFromMap` semantics: `set.add(e)` delegates to `map.put(e, TRUE)` which is atomic on `ConcurrentHashMap`; for a key never removed, this is equivalent to `putIfAbsent`.

### Already tested

- 30 sequential runs of `:app:testDebugUnitTest --tests "...SoundsViewModelAnalyticsTest" --rerun-tasks`, all PASS (prior to the fix the same test would fail 1-in-N on SDK 33).
- `./gradlew check` clean (full local verification including detekt, ktlint, spotless, Android Lint, all unit tests).