### PR TITLE
fix(addbutton): refresh screen on new intent so share never opens stale rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Optimized app size by filtering AAB locales to `en` and `es` only via AGP 9 `androidResources.localeFilters`; transitive dependencies (Material, AndroidX, Firebase, Play Services) no longer ship ~80 unused translations in the bundle
 - Restored ripple contrast on the empty Home in light mode so the illustration reads clearly from the first launch
 - Audio preview no longer bleeds into the success confirmation when you save a new Bomp (or save a rename) while the preview is playing — the audio now stops the moment the confirmation appears
+- Sharing an audio into Bomp while a rename was left open in the background no longer drops you back into that unsaved rename screen with the wrong audio's data; the share now correctly opens the new-Bomp form for the incoming audio (anything you had typed in the unsaved rename is discarded since it was never saved)
 
 
 ### Changed

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivity.kt
@@ -26,7 +26,19 @@ class AddButtonActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge(statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT))
         super.onCreate(savedInstanceState)
+        handleIntent(intent)
+    }
 
+    // singleTask + a new ACTION_SEND from a share sheet arrives here while an Edit
+    // flow is still alive: the most recent user intent wins, the previous in-progress
+    // state is discarded by reading the new intent and recomposing setContent.
+    public override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        handleIntent(intent)
+    }
+
+    private fun handleIntent(intent: Intent) {
         val editSound: Sound? =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 intent.getParcelableExtra(LandingActivity.EXTRA_EDIT_SOUND, Sound::class.java)

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivityIntentDispatchTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivityIntentDispatchTest.kt
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.addbutton
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.FakeAnalyticsTracker
+import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.github.barriosnahuel.vossosunboton.testSound
+import com.github.barriosnahuel.vossosunboton.ui.home.LandingActivity
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.robolectric.Robolectric
+import org.robolectric.android.controller.ActivityController
+import org.robolectric.annotation.Config
+
+/**
+ * Activity-level contract for [AddButtonActivity]: a fresh [Intent] (initial via `onCreate` or
+ * a subsequent `onNewIntent` while the task is alive) always replaces the current screen. Guards
+ * against the regression where a share from another app, arriving while the user had a rename
+ * (Edit mode) open without saving, would surface the abandoned Edit screen with the previous
+ * Sound's data instead of starting a fresh Create flow for the incoming audio.
+ *
+ * Uses [Robolectric.buildActivity] (not `ActivityScenario`) because the production fix mutates
+ * `Activity.getIntent()` via `setIntent(...)` inside `onNewIntent`. `ActivityScenario` matches
+ * lifecycle callbacks against the launching intent to track which Activity it controls, and
+ * silently drops events once the live intent diverges — `scenario.close()` then waits forever
+ * for a DESTROYED transition that no longer reaches it. The lower-level controller has no such
+ * coupling and lets us drive the lifecycle deterministically.
+ */
+@Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+internal class AddButtonActivityIntentDispatchTest : AbstractRobolectricTest() {
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    private lateinit var fake: FakeAnalyticsTracker
+    private lateinit var feature: FakeAddButtonFeature
+    private var controller: ActivityController<AddButtonActivity>? = null
+
+    @Before
+    fun setUp() {
+        fake = FakeAnalyticsTracker()
+        AnalyticsTrackerProvider.setForTest(fake)
+        feature = FakeAddButtonFeature()
+        AddButtonFeatureProvider.setForTest(feature)
+    }
+
+    @After
+    fun tearDown() {
+        controller?.let { runCatching { it.pause().stop().destroy() } }
+        controller = null
+        AnalyticsTrackerProvider.setForTest(null)
+        AddButtonFeatureProvider.setForTest(null)
+    }
+
+    @Test
+    fun `AddButtonActivity reaches RESUMED without crashing for an incoming share`() {
+        val activity = launch(shareIntent(SAMPLE_URI))
+        assertThat(activity.lifecycle.currentState).isEqualTo(Lifecycle.State.RESUMED)
+    }
+
+    @Test
+    fun `share intent arriving while Edit is open replaces the screen with a fresh Create flow`() {
+        // Reproduces the bug: user opens Edit (rename), goes Home without saving, then a share
+        // from WhatsApp arrives. singleTask routes the new intent to the live instance via
+        // onNewIntent — the contract is that the new ACTION_SEND ALWAYS wins, the abandoned
+        // Edit state is discarded, and Activity.getIntent() now points at the share.
+        val activity = launch(editIntent())
+        assertThat(fake.screens.map { it.name }).contains(CanonicalScreenName.EDIT_SOUND)
+
+        controller!!.newIntent(shareIntent(SAMPLE_URI))
+
+        val addScreen =
+            fake.screens.lastOrNull { it.name == CanonicalScreenName.ADD_SOUND }
+                ?: error("onNewIntent did not log ADD_SOUND. Recorded: ${fake.screens.map { it.name }}")
+        assertThat(addScreen.extras["source"]).isEqualTo(AddButtonActivity.SOURCE_SHARE)
+        assertThat(activity.intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java))
+            .isEqualTo(SAMPLE_URI)
+        assertThat(activity.intent.getParcelableExtra(LandingActivity.EXTRA_EDIT_SOUND, Sound::class.java))
+            .isNull()
+        // The user transited Edit → Create; assert relative order, not absolute indices,
+        // because other screen_view emissions from the surrounding Compose tree are allowed.
+        val editIndex = fake.screens.indexOfFirst { it.name == CanonicalScreenName.EDIT_SOUND }
+        val createIndex = fake.screens.indexOfLast { it.name == CanonicalScreenName.ADD_SOUND }
+        assertThat(editIndex).isLessThan(createIndex)
+    }
+
+    @Test
+    fun `share intent arriving while a previous Create is open re-emits screen_view for the new audio`() {
+        // Symmetric scenario: two consecutive shares without finishing the first. Each share is
+        // a fresh user intent, so analytics must record both and Activity.getIntent() must
+        // reflect the most recent URI — otherwise a "stuck on first share" bug could hide later.
+        val activity = launch(shareIntent(SAMPLE_URI))
+        assertThat(fake.screens.count { it.name == CanonicalScreenName.ADD_SOUND }).isEqualTo(1)
+
+        controller!!.newIntent(shareIntent(OTHER_URI))
+
+        assertThat(fake.screens.count { it.name == CanonicalScreenName.ADD_SOUND }).isEqualTo(2)
+        assertThat(activity.intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java))
+            .isEqualTo(OTHER_URI)
+    }
+
+    @Test
+    fun `Edit intent arriving while a Create share is open replaces the screen with Edit`() {
+        // The fix is launchMode-agnostic: any new intent dispatched to the live instance refreshes
+        // mode. Covers the (rarer) path where the user is in Create from a share and the host app
+        // re-enters Edit via singleTask routing (e.g. internal navigation while the task is alive).
+        val activity = launch(shareIntent(SAMPLE_URI))
+        assertThat(fake.screens.map { it.name }).contains(CanonicalScreenName.ADD_SOUND)
+
+        controller!!.newIntent(editIntent())
+
+        assertThat(fake.screens.map { it.name }).contains(CanonicalScreenName.EDIT_SOUND)
+        assertThat(activity.intent.getParcelableExtra(LandingActivity.EXTRA_EDIT_SOUND, Sound::class.java))
+            .isNotNull()
+    }
+
+    @Test
+    fun `malformed onNewIntent finishes the Activity even when a valid mode was alive`() {
+        // Option A guard: the most recent intent always wins, including a malformed one. Without
+        // this, a buggy share-receiver caller could leave the user stuck on a stale Edit screen
+        // with no way to get to the rest of the app. Toast + finish is consistent with onCreate.
+        val activity = launch(editIntent())
+        val malformed = Intent(context, AddButtonActivity::class.java)
+
+        controller!!.newIntent(malformed)
+
+        assertThat(activity.isFinishing).isTrue()
+    }
+
+    /**
+     * Build, attach and resume an [AddButtonActivity] with [intent]. Stashed in `controller` so
+     * `@After` can drive it to DESTROYED, releasing the Looper-shared resources between tests.
+     */
+    private fun launch(intent: Intent): AddButtonActivity {
+        val newController = Robolectric.buildActivity(AddButtonActivity::class.java, intent)
+        controller = newController
+        return newController
+            .create()
+            .start()
+            .resume()
+            .get()
+    }
+
+    private fun shareIntent(uri: Uri): Intent =
+        Intent(context, AddButtonActivity::class.java).apply {
+            action = Intent.ACTION_SEND
+            type = "audio/*"
+            putExtra(Intent.EXTRA_STREAM, uri)
+        }
+
+    private fun editIntent(): Intent =
+        Intent(context, AddButtonActivity::class.java).apply {
+            putExtra(LandingActivity.EXTRA_EDIT_SOUND, testSound(EXISTING_NAME, file = "existing.mp3"))
+        }
+
+    /**
+     * Test double for [AddButtonFeature]. Same pattern as `AddButtonScreenAnalyticsTest` — returns
+     * already-completed deferreds so the Compose tree does not race with the test.
+     */
+    private class FakeAddButtonFeature : AddButtonFeature {
+        override fun saveNewButtonAsync(
+            context: Context,
+            name: String,
+            uri: String,
+        ): Deferred<Int> = CompletableDeferred(0)
+
+        override fun renameButtonAsync(
+            context: Context,
+            sound: Sound,
+            newName: String,
+        ): Deferred<Unit> = CompletableDeferred(Unit)
+    }
+
+    private companion object {
+        val SAMPLE_URI: Uri = Uri.parse("content://test/audio.mp3")
+        val OTHER_URI: Uri = Uri.parse("content://test/other.mp3")
+        const val EXISTING_NAME = "Existing sound"
+    }
+}


### PR DESCRIPTION
### Summary

1. User taps rename on an audio in Bomp, lands on the rename screen
2. Types a name but presses Home (no save)
3. Opens WhatsApp, shares another audio into Bomp
4. *Currently:* lands back on the unsaved rename screen with the previous audio's preloaded data — the new share is silently dropped, the user can't reach the "new Bomp" form without abandoning the app and re-sharing
5. *After this PR:* the share opens a fresh new-Bomp form for the incoming audio; the unsaved rename text is discarded (it was never saved anyway). The most recent user intent always wins — aligned with how mature share-receivers (Drive, Keep, Telegram) handle the same collision

### Technical detail

`AddButtonActivity` is `singleTask` + `exported="true"` and serves both internal Edit (via `EXTRA_EDIT_SOUND` from Landing) and external Create (via `ACTION_SEND` + `EXTRA_STREAM` from share sheet). It was missing `onNewIntent`, so when a new intent arrived on the live instance the UI never refreshed. Extracted the `onCreate` dispatch into `handleIntent(intent)` and added `onNewIntent` that calls `super` → `setIntent(intent)` → `handleIntent(intent)`. Same dispatch for both entries.

### Code review tips

- `onNewIntent` widened to `public` because the parent override is `protected` and the Robolectric test drives it from outside the class. Surface unchanged for Android (the Activity is already exported).
- Test uses `Robolectric.buildActivity` rather than `ActivityScenario`: `setIntent` diverges `Activity.getIntent()` from the launching intent, and `ActivityScenario` matches lifecycle callbacks against the launching intent — close hangs forever when they diverge.
- Malformed `onNewIntent` (no extras) toast+finish keeps the Option A contract under all paths; locked in by a dedicated test.

### Already tested

- unit: `AddButtonActivityIntentDispatchTest` 5/5 local + the rest of `./gradlew test` green
- lint/detekt/spotless: `./gradlew check -x test` green local
- instrumented: `./scripts/run-instrumented-tests.sh` green local (62 run, 0 failed, 2 pre-existing skips) — CI does not run this suite