### PR TITLE
test(home): join VM scopes in LandingScreenAnalyticsTest @After

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - New CLAUDE.md § *Stateful Composables — `rememberSaveable` is the default for durable state* documents the rule, references `SaveOutcomeSaver` as the Saver template, and adds a Pre-PR checklist line requiring `scenario.recreate()` tests for screens with durable state
 - `AboutScreenFlowTest` back-navigation tests now use the always-present overflow-menu icon as the Landing sentinel instead of the Search FAB, which #1143 gated behind a minimum sound count
 - `FakeAnalyticsTracker.firedFlags` is now backed by a `ConcurrentHashMap` (via `Collections.newSetFromMap`) so its `add` mirrors production `DataStoreFirstFlagStore.consumeFirstTime` (atomic per-key); fixes a flaky `SoundsViewModelAnalyticsTest > loadSounds does not re-emit milestone_sounds_3 once already fired[33]` where two concurrent IO-dispatched coroutines could both observe the flag as absent on the plain `mutableSetOf()` and double-emit the milestone
+- `LandingScreenAnalyticsTest` now joins each `SoundsViewModel`'s scope in `@After` (same pattern as the other four `ui/home` test classes since PR #1130); the missing cleanup let its leaked `repo.sounds.drop(1)` collectors outlive the class and re-emit `milestone_sounds_3` into a later test's `FakeAnalyticsTracker`, surfacing as the residual flake in `SoundsViewModelAnalyticsTest > loadSounds does not re-emit milestone_sounds_3 once already fired[33]` after the `firedFlags` thread-safety fix
 
 ## \[v2.0.0] - 2026-05-07
 

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenAnalyticsTest.kt
@@ -37,6 +37,7 @@ internal class LandingScreenAnalyticsTest : AbstractRobolectricTest() {
     val composeTestRule = createComposeRule()
 
     private lateinit var fake: FakeAnalyticsTracker
+    private val createdViewModels = mutableListOf<SoundsViewModel>()
 
     @Before
     fun setUp() {
@@ -48,6 +49,11 @@ internal class LandingScreenAnalyticsTest : AbstractRobolectricTest() {
 
     @After
     fun tearDown() {
+        // Join every VM scope so the reactive `repo.sounds` collector each VM starts in `init`
+        // cannot outlive this class and re-fire `milestone_sounds_3` (or other one-shot events)
+        // into a later test's `FakeAnalyticsTracker` — see ViewModelTestCleanup.kt.
+        createdViewModels.cancelAndJoinAll()
+        createdViewModels.clear()
         AnalyticsTrackerProvider.setForTest(null)
         unmockkAll()
     }
@@ -126,9 +132,13 @@ internal class LandingScreenAnalyticsTest : AbstractRobolectricTest() {
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    private fun givenAViewModel(): SoundsViewModel =
-        SoundsViewModel(
-            ApplicationProvider.getApplicationContext(),
-            ioDispatcher = UnconfinedTestDispatcher(),
-        )
+    private fun givenAViewModel(): SoundsViewModel {
+        val vm =
+            SoundsViewModel(
+                ApplicationProvider.getApplicationContext(),
+                ioDispatcher = UnconfinedTestDispatcher(),
+            )
+        createdViewModels += vm
+        return vm
+    }
 }


### PR DESCRIPTION
### Summary
Internal — no user-visible behavior change.

Closes the last cross-class state leak driving the flaky `SoundsViewModelAnalyticsTest > loadSounds does not re-emit milestone_sounds_3 once already fired[33]` (and the sibling `playOrStop increments lifetime_plays user property monotonically[33]` it occasionally took down). PR #1130 added `cancelAndJoinAll()` cleanup to four `ui/home` test classes; the fifth — `LandingScreenAnalyticsTest` — kept building `SoundsViewModel` instances without joining their scope, so its `repo.sounds.drop(1)` collectors stayed parked on the singleton `bompsStore` and polluted later classes.

### Technical detail
- Adopts the canonical `createdViewModels = mutableListOf<SoundsViewModel>()` + `cancelAndJoinAll() / clear()` pattern shared by `LandingScreenTest`, `SoundsViewModelTest`, `SoundsViewModelSearchTest`, `SoundsViewModelAnalyticsTest`. `givenAViewModel()` appends each VM to the list before returning.
- The leaked collector re-runs `loadSounds` on a later test's `clearForTest()` / `save(...)` emissions; with the leak gone, the only writers to the new test's `fake` are its own VMs.

### Code review tips
- `cancelAndJoinAll()` MUST run before `AnalyticsTrackerProvider.setForTest(null)` — any final emission during unwind has to land on the test fake, not a real Firebase tracker. Matches the order in the four canonical siblings.
- composeTestRule's RuleChain wraps @Before/@After, so VM cancellation runs before compose teardown — same proven order as `LandingScreenTest`.

### Already tested
- unit: 10× back-to-back `./gradlew :app:testDebugUnitTest --rerun-tasks`, 10/10 green; pre-fix the same loop hit one `[33]` flake in 5 iterations.