### PR TITLE
Predictive back gesture on Search, About and Manage collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Tapping Save on the new-Bomp form without a name now plays a "reject" haptic alongside the existing error message, matching the tactile feedback used elsewhere for rejected actions
 - Search empty-state hint moved away from teaching the obvious "type to filter" toward a warmer brand-voice line ("That gem of yours is in here. Go find it." / "Esa reliquia tuya está acá. Encontrala.")
 - Tapping a Bomp while it plays now pauses it (and resumes from the same position on the next tap) instead of restarting from the beginning, matching the Add Audio preview behavior. The progress bar stays at the paused position instead of snapping to zero, so a pause reads as a pause. Positions survive rotation; they are reset when a Bomp finishes naturally, is deleted, or after the app is killed
+- The back gesture now previews where it leads on the Search, About, and Manage collections screens: as you swipe back the screen slides and fades to reveal what is behind, and you can release mid-swipe to cancel and stay — honoring the system "Remove animations" setting, with the instant back kept on older devices
 
 ### For nerds 🤓
 

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/collections/ManageCollectionsFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/collections/ManageCollectionsFlowTest.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.barriosnahuel.vossosunboton.AbstractUiTest
 import com.github.barriosnahuel.vossosunboton.R
@@ -207,6 +208,20 @@ internal class ManageCollectionsFlowTest : AbstractUiTest() {
             composeRule
                 .onNodeWithText(vaultSectionLabel(), ignoreCase = true)
                 .assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun systemBackClosesManageCollections() {
+        // Guards the BackHandler → predictiveBackTransition migration for this surface: a completed
+        // system back must still pop Manage Collections back to Landing (the gesture animation is a
+        // progressive enhancement; the result — we land back on the list — is the contract).
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            openManageFromOverflow()
+            Espresso.pressBack()
+            // Overflow ⋮ is the Landing sentinel (absent on the Manage screen); its return means the
+            // PredictiveBackHandler completed and popped us back.
+            composeRule.awaitNodeWithContentDescription(overflowLabel()).assertIsDisplayed()
         }
     }
 

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/collections/ManageCollectionsFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/collections/ManageCollectionsFlowTest.kt
@@ -225,6 +225,18 @@ internal class ManageCollectionsFlowTest : AbstractUiTest() {
         }
     }
 
+    @Test
+    fun manageCollectionsHidesTheUnderlyingListFromSemantics() {
+        // Layering invariant (ADR 0011): My Sounds is composed behind Manage so predictive back can
+        // reveal it, but its semantics are cleared while Manage is open. The My Sounds overflow ⋮ is
+        // a base-layer-only sentinel — it must be absent while Manage is open, or collection names
+        // would double-match (chip row behind + Manage rows) and TalkBack would reach hidden nodes.
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            openManageFromOverflow()
+            composeRule.onNodeWithContentDescription(overflowLabel()).assertDoesNotExist()
+        }
+    }
+
     private fun openManageFromOverflow() {
         // The overflow ⋮ is an IconButton — surfaced via contentDescription, not Text.
         composeRule.awaitNodeWithContentDescription(overflowLabel()).performClick()

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenFlowTest.kt
@@ -68,6 +68,18 @@ internal class AboutScreenFlowTest : AbstractUiTest() {
     }
 
     @Test
+    fun aboutScreenHidesTheUnderlyingLandingFromSemantics() {
+        // Layering invariant (ADR 0011): Landing is composed behind About so predictive back can
+        // reveal it, but its semantics are cleared while About is open. The Landing overflow ⋮ is a
+        // base-layer-only sentinel (About has only a back arrow) — it must be absent from the tree
+        // while About is open, or TalkBack/tests would reach nodes hidden behind the opaque overlay.
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            openAbout()
+            composeRule.onNodeWithContentDescription(context.getString(R.string.app_overflow_menu)).assertDoesNotExist()
+        }
+    }
+
+    @Test
     fun playBrandingAudioButtonIsClickable() {
         ActivityScenario.launch(LandingActivity::class.java).use {
             openAbout()

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/SaveSuccessOverlay.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/SaveSuccessOverlay.kt
@@ -5,7 +5,6 @@
  */
 package com.github.barriosnahuel.vossosunboton.feature.addbutton
 
-import android.provider.Settings
 import androidx.activity.compose.BackHandler
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedVisibility
@@ -34,12 +33,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.contentDescription
@@ -47,6 +44,7 @@ import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.github.barriosnahuel.vossosunboton.ui.rememberReduceMotionEnabled
 import kotlinx.coroutines.delay
 
 /**
@@ -146,18 +144,6 @@ internal fun SaveSuccessOverlay(
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun rememberReduceMotionEnabled(): Boolean {
-    val context = LocalContext.current
-    return remember(context) {
-        Settings.Global.getFloat(
-            context.contentResolver,
-            Settings.Global.ANIMATOR_DURATION_SCALE,
-            1f,
-        ) == 0f
     }
 }
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/collections/ManageCollectionsScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/collections/ManageCollectionsScreen.kt
@@ -5,7 +5,6 @@
  */
 package com.github.barriosnahuel.vossosunboton.feature.collections
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.animation.Animatable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
@@ -73,6 +72,7 @@ import com.github.barriosnahuel.vossosunboton.model.Collection
 import com.github.barriosnahuel.vossosunboton.model.CollectionAccess
 import com.github.barriosnahuel.vossosunboton.ui.home.AppTab
 import com.github.barriosnahuel.vossosunboton.ui.home.SoundsViewModel
+import com.github.barriosnahuel.vossosunboton.ui.predictiveBackTransition
 import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
 import kotlinx.coroutines.delay
 
@@ -125,10 +125,8 @@ internal fun ManageCollectionsScreen(
     var highlightedId by rememberSaveable { mutableStateOf(focusedCollectionId) }
     var deepLinkConsumed by rememberSaveable { mutableStateOf(false) }
 
-    BackHandler { onBack() }
-
     Scaffold(
-        modifier = modifier,
+        modifier = modifier.predictiveBackTransition(onBack = onBack),
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.app_manage_collections_title)) },

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/PredictiveBackTransition.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/PredictiveBackTransition.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui
+
+import androidx.activity.compose.PredictiveBackHandler
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Material 3-style predictive back for a visually discrete surface — an overlay or a full-screen
+ * Composable. Drop-in replacement for a plain `BackHandler { onBack() }` so the back gesture previews
+ * where it leads: as the finger drags, the surface translates aside, scales down and fades (driven by
+ * the gesture `progress`, 0f→1f), revealing what sits behind it. Releasing mid-gesture cancels and the
+ * surface springs back to rest; completing the gesture runs [onBack] exactly once.
+ *
+ * Honours the system "Remove animations" setting ([rememberReduceMotionEnabled]): the visual transform
+ * is skipped and [onBack] still fires on completion, matching the OS's own instant collapse. On API < 33
+ * the platform falls back to a binary back — identical to today's behaviour, so the animation is a pure
+ * progressive enhancement with no regression on old devices.
+ *
+ * Keep a plain `BackHandler` for *back-stoppers* that must swallow the gesture (e.g. SaveSuccessOverlay
+ * while its success animation runs): those intentionally do not animate out.
+ *
+ * @param enabled mirrors `BackHandler(enabled = …)` — when false the gesture passes through to the next
+ *   handler registered up the dispatcher.
+ * @param onBack invoked once when the gesture completes (never on cancel, never per progress frame).
+ */
+@Composable
+fun Modifier.predictiveBackTransition(
+    enabled: Boolean = true,
+    onBack: () -> Unit,
+): Modifier {
+    val reduceMotion = rememberReduceMotionEnabled()
+    // Held outside the graphicsLayer block and read only inside it, so each gesture frame invalidates
+    // the layer in the draw phase without recomposing this modifier — the performant predictive path.
+    val progress = remember { mutableFloatStateOf(0f) }
+
+    PredictiveBackHandler(enabled = enabled) { events ->
+        try {
+            events.collect { event -> progress.floatValue = event.progress }
+            // Reached only when the flow completes without cancellation: the gesture went through.
+            onBack()
+            progress.floatValue = 0f
+        } catch (cancellation: CancellationException) {
+            // Gesture released before completion, or the surface left composition mid-drag: reset to
+            // rest, then rethrow so structured cancellation is honoured (idiomatic predictive-back).
+            progress.floatValue = 0f
+            throw cancellation
+        }
+    }
+
+    return if (reduceMotion) {
+        this
+    } else {
+        graphicsLayer {
+            val fraction = progress.floatValue
+            // Material 3 caps the horizontal drift so the surface stays partly on-screen all gesture.
+            translationX = size.width * MAX_TRANSLATION_FRACTION * fraction
+            val scale = 1f - fraction * SCALE_REDUCTION
+            scaleX = scale
+            scaleY = scale
+            alpha = 1f - fraction * ALPHA_REDUCTION
+        }
+    }
+}
+
+private const val MAX_TRANSLATION_FRACTION = 0.35f
+private const val SCALE_REDUCTION = 0.05f
+private const val ALPHA_REDUCTION = 0.5f

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/ReduceMotion.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/ReduceMotion.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui
+
+import android.provider.Settings
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * True when the system "Remove animations" accessibility setting is on
+ * (`Settings.Global.ANIMATOR_DURATION_SCALE == 0`). Surfaces that drive their own motion — the
+ * SaveSuccessOverlay entry spring, the [predictiveBackTransition] gesture — read this to degrade to a
+ * static, instantaneous equivalent, matching what the OS does to its own system transitions.
+ *
+ * Read once per composition (`remember(context)`): the setting only changes via a trip to system
+ * Settings, which tears down and recreates the Activity, so there is no need to observe it live.
+ */
+@Composable
+fun rememberReduceMotionEnabled(): Boolean {
+    val context = LocalContext.current
+    return remember(context) {
+        Settings.Global.getFloat(
+            context.contentResolver,
+            Settings.Global.ANIMATOR_DURATION_SCALE,
+            1f,
+        ) == 0f
+    }
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreen.kt
@@ -14,7 +14,6 @@ import android.content.pm.PackageManager
 import android.media.AudioAttributes
 import android.media.SoundPool
 import android.net.Uri
-import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Image
@@ -79,6 +78,7 @@ import com.github.barriosnahuel.vossosunboton.commons.android.analytics.Analytic
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.ui.AppIcons
+import com.github.barriosnahuel.vossosunboton.ui.predictiveBackTransition
 import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
 import com.github.barriosnahuel.vossosunboton.util.withDeviceHl
 import kotlinx.coroutines.launch
@@ -125,9 +125,8 @@ fun AboutScreen(onBack: () -> Unit) {
         onDispose { soundPool.release() }
     }
 
-    BackHandler { onBack() }
-
     Scaffold(
+        modifier = Modifier.predictiveBackTransition(onBack = onBack),
         topBar = {
             TopAppBar(
                 title = {},

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -61,6 +61,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsEvent
@@ -141,41 +142,55 @@ fun LandingScreen(viewModel: SoundsViewModel) {
     val collectionsByAudio by viewModel.audioCollectionsIndex.collectAsState()
     val privateCollections = remember(collections) { collections.filter { it.isPrivate } }
 
+    // My Sounds is the always-composed base layer; About / Manage Collections render as opaque
+    // full-screen overlays stacked on top of it (the same layering SearchOverlay uses below).
+    // Keeping the list composed behind is what lets predictiveBackTransition reveal the live
+    // My Sounds as the user swipes those screens away — an exclusive `when` (the prior shape)
+    // exposed the bare window background instead. The overlays' Scaffold Surface is opaque: it
+    // blocks touch propagation and covers the list at rest, so there is no visual or input change
+    // until a back gesture is in progress. When the nav3 migration (backlog 08) lands, About/Manage
+    // become real destinations and this manual layering is removed.
+    //
+    // While a sub-screen is open the occluded list is cleared from the semantics tree, so TalkBack
+    // and UI tests neither reach nor double-match nodes hidden behind the opaque overlay (e.g. a
+    // collection name shown both in the chip row and in the Manage list). Drawing is untouched, so
+    // the gesture still reveals the live list visually.
+    val subScreenOpen = isAboutVisible || manageRequest != null
+    ScaffoldedLanding(
+        modifier = if (subScreenOpen) Modifier.clearAndSetSemantics {} else Modifier,
+        viewModel = viewModel,
+        sounds = sounds,
+        selectedTab = selectedTab,
+        hasBundledSounds = hasBundledSounds,
+        playbackProgress = playbackProgress,
+        pausedProgress = pausedProgress,
+        soundDurations = soundDurations,
+        snackbarHostState = snackbarHostState,
+        listState = listState,
+        coroutineScope = coroutineScope,
+        context = context,
+        tabBackStack = tabBackStack,
+        collections = collections,
+        activeFilter = activeFilter,
+        publicCollections = publicCollections,
+        collectionsByAudio = collectionsByAudio,
+        privateCollections = privateCollections,
+        onAboutClick = { isAboutVisible = true },
+        onManageCollectionsClick = { manageRequest = ManageRequest.Generic },
+        onActiveFilterEditClick = { collectionId ->
+            manageRequest = ManageRequest.Focused(collectionId)
+        },
+    )
+
+    // Exactly one sub-screen overlays the list at a time (About wins over Manage, preserving the
+    // prior priority); neither branch removes the base layer.
     when {
-        isAboutVisible -> {
-            AboutScreen(onBack = { isAboutVisible = false })
-        }
-        manageRequest != null -> {
+        isAboutVisible -> AboutScreen(onBack = { isAboutVisible = false })
+        manageRequest != null ->
             com.github.barriosnahuel.vossosunboton.feature.collections.ManageCollectionsScreen(
                 viewModel = viewModel,
                 focusedCollectionId = (manageRequest as? ManageRequest.Focused)?.collectionId,
                 onBack = { manageRequest = null },
-            )
-        }
-        else ->
-            ScaffoldedLanding(
-                viewModel = viewModel,
-                sounds = sounds,
-                selectedTab = selectedTab,
-                hasBundledSounds = hasBundledSounds,
-                playbackProgress = playbackProgress,
-                pausedProgress = pausedProgress,
-                soundDurations = soundDurations,
-                snackbarHostState = snackbarHostState,
-                listState = listState,
-                coroutineScope = coroutineScope,
-                context = context,
-                tabBackStack = tabBackStack,
-                collections = collections,
-                activeFilter = activeFilter,
-                publicCollections = publicCollections,
-                collectionsByAudio = collectionsByAudio,
-                privateCollections = privateCollections,
-                onAboutClick = { isAboutVisible = true },
-                onManageCollectionsClick = { manageRequest = ManageRequest.Generic },
-                onActiveFilterEditClick = { collectionId ->
-                    manageRequest = ManageRequest.Focused(collectionId)
-                },
             )
     }
 
@@ -275,6 +290,7 @@ private fun SearchOverlayHost(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ScaffoldedLanding(
+    modifier: Modifier = Modifier,
     viewModel: SoundsViewModel,
     sounds: List<Sound>,
     selectedTab: AppTab,
@@ -297,6 +313,7 @@ private fun ScaffoldedLanding(
     onActiveFilterEditClick: (String) -> Unit,
 ) {
     Scaffold(
+        modifier = modifier,
         topBar = {
             AppTopBar(
                 onAboutClick = onAboutClick,

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlay.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlay.kt
@@ -5,7 +5,6 @@
  */
 package com.github.barriosnahuel.vossosunboton.ui.home
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -59,6 +58,7 @@ import androidx.compose.ui.unit.dp
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.github.barriosnahuel.vossosunboton.ui.predictiveBackTransition
 import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
 
 private sealed class SearchDisplayState {
@@ -90,8 +90,6 @@ fun SearchOverlay(
     showVaultUnlockCta: Boolean = false,
     onUnlockVault: () -> Unit = {},
 ) {
-    BackHandler { onClose() }
-
     val displayState =
         when {
             query.isBlank() -> SearchDisplayState.Initial
@@ -104,6 +102,7 @@ fun SearchOverlay(
         modifier =
             Modifier
                 .fillMaxSize()
+                .predictiveBackTransition(onBack = onClose)
                 .background(Color.Black.copy(alpha = 0.6f)),
     ) {
         Surface(

--- a/docs/adr/0011-predictive-back-navigation.md
+++ b/docs/adr/0011-predictive-back-navigation.md
@@ -1,0 +1,77 @@
+# ADR 0011 — Predictive back for in-app navigation surfaces
+
+- **Status:** Accepted (with explicit revisit criteria)
+- **Date:** 2026-05-21
+- **Supersedes:** —
+
+## Context
+
+`targetSdk` 37 opts the app into the `OnBackInvokedDispatcher` by default (the OS
+enabled the opt-in from API 35), so the back gesture can be a continuous,
+cancelable *preview* — Material 3 predictive back — instead of a binary close.
+Android's manual API is `PredictiveBackHandler`, which delivers a
+`Flow<BackEventCompat>` with `progress` (0f→1f). References:
+
+- https://developer.android.com/develop/ui/compose/system/predictive-back
+- https://developer.android.com/develop/ui/compose/system/predictive-back-progress
+
+The app has **no `NavHost` today**: every surface is an `Activity` or a
+manually-managed root Composable, swapped by a flag/state in `LandingScreen`
+(`isAboutVisible`, `manageRequest`, `isSearchVisible`). The Jetpack Navigation 3
+migration — which would give predictive back *between destinations* for free —
+is a separate, much larger effort (`../push-me-backlog/backlog/08-...nav3`),
+deliberately scheduled **after** this work. Predictive back is wired manually in
+the meantime (backlog `03-predictive-back-navigation`).
+
+## Decision
+
+1. **New visually-discrete navigation surfaces** (overlays, full-screen
+   Composables reached by a manual flag/state) use
+   `Modifier.predictiveBackTransition` (`ui/PredictiveBackTransition.kt`) instead
+   of a plain `BackHandler`. It runs `onBack` **only on gesture completion**,
+   drives a `graphicsLayer` (translate + scale-down + fade) from `progress`, and
+   degrades to an instant close when the system "Remove animations" setting is on
+   (`rememberReduceMotionEnabled`). On API < 33 it falls back to a binary back —
+   no regression.
+
+2. **Navigation must be built so the gesture can reveal what is behind.** For the
+   preview to show the destination, that destination has to be **composed behind**
+   the surface being dismissed (*layering*): render the base screen always + the
+   surface as an **opaque overlay** on top (as `SearchOverlay`, `AboutScreen` and
+   `ManageCollectionsScreen` do in `LandingScreen`). An exclusive `when` that
+   *removes* the base from composition makes the gesture reveal the bare window
+   background (near-black) — that is the bug fixed in PR #1171. While an overlay
+   is open, **clear the occluded base's semantics** (`Modifier.clearAndSetSemantics {}`)
+   so TalkBack and UI tests neither reach nor double-match nodes hidden behind it
+   (drawing is untouched, so the reveal still works visually).
+
+3. **Back-swallowers keep a plain `BackHandler`.** A surface whose contract is to
+   *consume* the back (e.g. `SaveSuccessOverlay` while its success animation runs)
+   must not animate out — `BackHandler { /* swallow */ }` stays correct.
+
+4. **The `LandingScreen` tab-pop stays a binary `BackHandler`.** Driving it with
+   the gesture needs an `AnimatedContent` mediating tab content that the current
+   `when`-based body does not have; adding it is out of scope here.
+
+This is a **documented convention, not a CI-grep invariant** — `BackHandler` is
+legitimately used by swallowers, so a blanket grep guard would over-match.
+
+## Revisit criteria
+
+When the **Navigation 3 migration (backlog 08)** lands, predictive back between
+destinations becomes automatic. At that point the manual
+`predictiveBackTransition`, the layering, the `clearAndSetSemantics` occlusion,
+and the per-surface handlers in `SearchOverlay` / `AboutScreen` /
+`ManageCollectionsScreen` are simplified or removed. Re-evaluate this ADR then.
+
+## Consequences
+
+- New full-screen / overlay navigation surfaces inherit a consistent,
+  OS-native-feeling back gesture from day one.
+- The base screen stays composed (and its state retained) behind an open
+  sub-screen — slightly more work, but it is occluded and its semantics are
+  cleared, so there is no visual, input, or a11y change at rest.
+- Result-level coverage (back closes the surface; the occluded base is absent
+  from the semantics tree) lives in the local instrumented suite (ADR 0001),
+  which runs with animations disabled — exercising the reduce-motion branch.
+  The gesture animation itself is verified on-device, not in automated tests.


### PR DESCRIPTION
### Summary

Polish to the back gesture so it feels native. Today, swiping back on the Search overlay, the About screen, or Manage collections snaps the screen shut instantly.

1. Open Search (or About, or Manage collections)
2. Start swiping back from the screen edge

**before:** the screen closes the instant you start — back is all-or-nothing, no way to peek and cancel.
**after:** the screen follows your finger (slides aside, scales down, fades) to reveal the live screen behind it; release past the threshold to go back, or let go early to stay. Honors the system "Remove animations" setting; the instant back is kept on Android < 13.

### Technical detail

`BackHandler { onBack() }` → `PredictiveBackHandler` behind a reusable `Modifier.predictiveBackTransition` (drives a `graphicsLayer` from the gesture `progress`; `onBack` fires only on completion; resets + rethrows on cancel). Shared `rememberReduceMotionEnabled` extracted from `SaveSuccessOverlay`. Applied to SearchOverlay, AboutScreen, ManageCollectionsScreen (the 4th surface, added after the spec was written). Reference: [Compose predictive back](https://developer.android.com/develop/ui/compose/system/predictive-back) + [Access progress manually](https://developer.android.com/develop/ui/compose/system/predictive-back-progress).

**Layering (fixes the reveal).** About/Manage used to sit in an exclusive `when` with My Sounds, so the gesture revealed the bare window background (near-black). They now render as opaque overlays over an always-composed My Sounds base — the same layering SearchOverlay uses — so the gesture reveals the live list. While a sub-screen is open the occluded list is cleared from the semantics tree (`clearAndSetSemantics`) so TalkBack/UI tests don't reach or double-match nodes behind the overlay; drawing is untouched. (Caught in on-device review.)

**Convention documented** in [ADR 0011](docs/adr/0011-predictive-back-navigation.md): new visually-discrete nav surfaces use `predictiveBackTransition` and must be composed behind so the gesture reveals them; back-swallowers keep plain `BackHandler`; revisit when nav3 (backlog 08) lands. No CLAUDE.md pointer added — the file is at 39.7K/40K (CI hard limit); it awaits a `/claude-md-audit` pass.

**Deliberately not changed:** LandingScreen tab-pop stays a plain `BackHandler` (needs a tab-content `AnimatedContent` the code lacks → deferred to nav3); SaveSuccessOverlay keeps `BackHandler { swallow }` (spec).

### Code review tips

- `predictiveBackTransition` is the blast radius (3 surfaces). `progress` is read **only** inside the `graphicsLayer {}` block (deferred draw read) → no per-frame recomposition; keep it there.
- **Layering in `LandingScreen`:** My Sounds is now always composed under About/Manage. The overlays' Scaffold `Surface` is opaque (blocks touch + covers the list at rest), and `clearAndSetSemantics` hides the occluded subtree — without it, collection names double-match in the Manage flow tests. The tab-pop `BackHandler`'s `enabled` guard already accounts for About/Manage being open.
- **Tests** (result-level, per spec § 6): back-closes-surface — `SearchOverlayTest.systemBackClosesOverlay`, `AboutScreenFlowTest.systemBackReturnsToLanding`, `ManageCollectionsFlowTest.systemBackClosesManageCollections`. New **layering guards** assert the occluded base is absent from the semantics tree while a sub-screen is open (`aboutScreenHidesTheUnderlyingLandingFromSemantics`, `manageCollectionsHidesTheUnderlyingListFromSemantics`). The reduce-motion branch is exercised by the systemBack tests (the suite runs with animations disabled, ADR 0001). The gesture animation itself is verified on-device.
- **Flaky suite, unrelated to this diff:** the full instrumented suite intermittently failed on `headerIsHiddenWhileVaultIsLocked` and `saveWithBlankNameShowsRequiredError` on isolated cold-boot runs (different unrelated tests each time, with fully-green runs in between; neither touches this diff). Matches the documented ADR 0001 emulator-degradation signature.

### Already tested
- `:app:assembleDebug`, `./gradlew check -x test`, `./gradlew test`: green
- Instrumented (cold boot): full suite green 100/100 after the layering change; the affected flow classes (About / Manage / Search), including the two new layering guards, green on targeted cold-boot runs
- On-device (Pixel 8): predictive back verified on Search, About and Manage — the gesture reveals the live screen behind, no black window
