### PR TITLE
Migrate off material-icons-core to bundled Material Symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 #### Changed
 - CircleCI PR workflow parallelizes `lint`, `test`, and `bundle` after the cheap linters (`detekt`, `ktlint`, `spotless`) instead of serializing them; `lint` job drops the redundant `app:lintRelease` re-invocation and `app:lintVitalRelease` (a fatal-only filter over the same checks); `bundle` job drops `bundleDebug` (the debug AAB was never consumed in CI). Critical path drops from ~14m39s to an estimated ~6-7min without losing coverage
+- Replaced the unmaintained `androidx.compose.material:material-icons-core` dependency with bundled Material Symbols vector drawables loaded via `painterResource`: the 15 icons in use become `app_ic_*` drawables (filled/outlined matched to the originals, `autoMirrored` preserved for the back arrow and chevron); `AppIcons` local vectors are untouched
 
 #### Removed
 - Dead post-save plumbing: `EXTRA_BUTTON_SAVED` / `EXTRA_BUTTON_RENAMED` / `EXTRA_BUTTON_NAME` Intent extras, `SoundsViewModel.buttonSavedEvent` / `buttonRenamedEvent` channels and their `onButtonSaved` / `onButtonRenamed` setters, the `LandingScreen` `LaunchedEffect`s that consumed them, and `AddButtonActivity.navigateBackSaved` / `navigateBackRenamed`

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -115,7 +115,6 @@ dependencies {
     implementation libs.compose.ui
     implementation libs.compose.ui.tooling.preview
     implementation libs.compose.material3
-    implementation libs.compose.material.icons.core
     implementation libs.androidx.activity.compose
     implementation libs.androidx.core.splashscreen
     implementation libs.lifecycle.viewmodel.compose

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
@@ -4,7 +4,6 @@
  * See LICENSE in the project root for full license information.
  */
 package com.github.barriosnahuel.vossosunboton.feature.addbutton
-
 import android.content.Context
 import android.net.Uri
 import androidx.annotation.StringRes
@@ -24,9 +23,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -61,6 +57,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
@@ -635,7 +632,7 @@ private fun SaveButton(
                         horizontalArrangement = Arrangement.Center,
                     ) {
                         Icon(
-                            imageVector = Icons.Default.Check,
+                            painter = painterResource(R.drawable.app_ic_check),
                             contentDescription = null,
                             modifier = Modifier.size(20.dp),
                         )
@@ -734,7 +731,7 @@ private fun AddButtonTopBar(
         navigationIcon = {
             IconButton(onClick = onNavigateUp) {
                 Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    painter = painterResource(R.drawable.app_ic_arrow_back),
                     contentDescription = null,
                 )
             }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AssignToCollectionsSection.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AssignToCollectionsSection.kt
@@ -4,7 +4,6 @@
  * See LICENSE in the project root for full license information.
  */
 package com.github.barriosnahuel.vossosunboton.feature.addbutton
-
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
@@ -13,8 +12,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
@@ -25,6 +22,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.github.barriosnahuel.vossosunboton.R
@@ -173,7 +171,7 @@ private fun PrivateBlock(
 ) {
     Row(verticalAlignment = Alignment.CenterVertically) {
         Icon(
-            imageVector = Icons.Default.Lock,
+            painter = painterResource(R.drawable.app_ic_lock),
             contentDescription = null,
             modifier = Modifier.size(16.dp),
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -223,7 +221,7 @@ private fun PrivateBlock(
                 label = { Text(displayName) },
                 leadingIcon = {
                     Icon(
-                        imageVector = Icons.Default.Lock,
+                        painter = painterResource(R.drawable.app_ic_lock),
                         contentDescription = null,
                         modifier = Modifier.size(14.dp),
                     )

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AudioPreview.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AudioPreview.kt
@@ -4,7 +4,6 @@
  * See LICENSE in the project root for full license information.
  */
 package com.github.barriosnahuel.vossosunboton.feature.addbutton
-
 import android.content.Context
 import android.media.MediaMetadataRetriever
 import android.net.Uri
@@ -18,8 +17,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FilledIconButton
@@ -39,6 +36,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -171,7 +170,14 @@ internal fun AudioPreview(
                                 ),
                         ) {
                             Icon(
-                                imageVector = if (isPlaying) AppIcons.Pause else Icons.Default.PlayArrow,
+                                painter =
+                                    if (isPlaying) {
+                                        rememberVectorPainter(
+                                            AppIcons.Pause,
+                                        )
+                                    } else {
+                                        painterResource(R.drawable.app_ic_play_arrow)
+                                    },
                                 contentDescription = stringResource(R.string.app_addbutton_preview_audio),
                             )
                         }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/DuplicateNameHint.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/DuplicateNameHint.kt
@@ -4,7 +4,6 @@
  * See LICENSE in the project root for full license information.
  */
 package com.github.barriosnahuel.vossosunboton.feature.addbutton
-
 import android.content.Context
 import android.net.Uri
 import androidx.compose.foundation.layout.Column
@@ -13,8 +12,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -26,6 +23,8 @@ import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.liveRegion
@@ -192,7 +191,7 @@ internal fun DuplicateNameHint(
             modifier = Modifier.size(48.dp),
         ) {
             Icon(
-                imageVector = if (isPlayingThisMatch) AppIcons.Stop else Icons.Default.PlayArrow,
+                painter = if (isPlayingThisMatch) rememberVectorPainter(AppIcons.Stop) else painterResource(R.drawable.app_ic_play_arrow),
                 contentDescription =
                     stringResource(
                         if (isPlayingThisMatch) {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/SaveSuccessOverlay.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/SaveSuccessOverlay.kt
@@ -4,7 +4,6 @@
  * See LICENSE in the project root for full license information.
  */
 package com.github.barriosnahuel.vossosunboton.feature.addbutton
-
 import androidx.activity.compose.BackHandler
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedVisibility
@@ -24,8 +23,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -37,6 +34,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.contentDescription
@@ -44,6 +42,7 @@ import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.ui.rememberReduceMotionEnabled
 import kotlinx.coroutines.delay
 
@@ -126,7 +125,7 @@ internal fun SaveSuccessOverlay(
                     verticalArrangement = Arrangement.Center,
                 ) {
                     Icon(
-                        imageVector = Icons.Default.Check,
+                        painter = painterResource(R.drawable.app_ic_check),
                         contentDescription = null,
                         modifier = Modifier.size(CHECK_ICON_DP.dp),
                     )

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/collections/ActiveFilterHeader.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/collections/ActiveFilterHeader.kt
@@ -4,15 +4,12 @@
  * See LICENSE in the project root for full license information.
  */
 package com.github.barriosnahuel.vossosunboton.feature.collections
-
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -20,6 +17,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
@@ -107,7 +105,7 @@ internal fun ActiveFilterHeader(
                     stringResource(R.string.app_active_filter_header_edit_description, displayName!!)
                 IconButton(onClick = onEditClick) {
                     Icon(
-                        imageVector = Icons.Outlined.Edit,
+                        painter = painterResource(R.drawable.app_ic_edit_outlined),
                         contentDescription = description,
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/collections/ManageCollectionsScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/collections/ManageCollectionsScreen.kt
@@ -4,7 +4,6 @@
  * See LICENSE in the project root for full license information.
  */
 package com.github.barriosnahuel.vossosunboton.feature.collections
-
 import androidx.compose.animation.Animatable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
@@ -22,14 +21,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.Lock
-import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -57,6 +48,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -133,7 +125,7 @@ internal fun ManageCollectionsScreen(
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            painter = painterResource(R.drawable.app_ic_arrow_back),
                             contentDescription = stringResource(R.string.app_manage_collections_back),
                         )
                     }
@@ -314,7 +306,7 @@ private fun SectionCreateButton(
         modifier = Modifier.padding(horizontal = Spacing.SM),
     ) {
         Icon(
-            imageVector = Icons.Outlined.Add,
+            painter = painterResource(R.drawable.app_ic_add),
             contentDescription = null,
             modifier = Modifier.size(18.dp),
         )
@@ -419,7 +411,7 @@ private fun ManageRowOverflow(
     androidx.compose.foundation.layout.Box {
         IconButton(onClick = { menuExpanded = true }) {
             Icon(
-                imageVector = Icons.Default.MoreVert,
+                painter = painterResource(R.drawable.app_ic_more_vert),
                 contentDescription = description,
             )
         }
@@ -433,7 +425,7 @@ private fun ManageRowOverflow(
             // refused at the repo layer, so they should not appear in the menu.
             DropdownMenuItem(
                 text = { Text(stringResource(R.string.app_manage_collections_overflow_view)) },
-                leadingIcon = { Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null) },
+                leadingIcon = { Icon(painterResource(R.drawable.app_ic_keyboard_arrow_right), contentDescription = null) },
                 onClick = {
                     menuExpanded = false
                     onViewClick()
@@ -442,7 +434,7 @@ private fun ManageRowOverflow(
             if (!isSystem) {
                 DropdownMenuItem(
                     text = { Text(stringResource(R.string.app_vault_card_overflow_rename)) },
-                    leadingIcon = { Icon(Icons.Default.Edit, contentDescription = null) },
+                    leadingIcon = { Icon(painterResource(R.drawable.app_ic_edit), contentDescription = null) },
                     onClick = {
                         menuExpanded = false
                         onRenameClick()
@@ -450,7 +442,7 @@ private fun ManageRowOverflow(
                 )
                 DropdownMenuItem(
                     text = { Text(stringResource(R.string.app_vault_card_overflow_delete)) },
-                    leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
+                    leadingIcon = { Icon(painterResource(R.drawable.app_ic_delete), contentDescription = null) },
                     onClick = {
                         menuExpanded = false
                         onDeleteClick()
@@ -481,7 +473,7 @@ private fun VaultLockedCard(onUnlock: () -> Unit) {
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(
-                    imageVector = Icons.Default.Lock,
+                    painter = painterResource(R.drawable.app_ic_lock),
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultScreen.kt
@@ -4,7 +4,6 @@
  * See LICENSE in the project root for full license information.
  */
 package com.github.barriosnahuel.vossosunboton.feature.vault
-
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -17,9 +16,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExtendedFloatingActionButton
@@ -35,6 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -197,7 +194,7 @@ private fun UnlockGate(
         verticalArrangement = Arrangement.Center,
     ) {
         Icon(
-            imageVector = Icons.Default.Lock,
+            painter = painterResource(R.drawable.app_ic_lock),
             contentDescription = null,
             tint = MaterialTheme.colorScheme.primary,
             modifier = Modifier.size(56.dp),
@@ -226,7 +223,7 @@ private fun UnlockGate(
                 ),
         ) {
             Icon(
-                imageVector = Icons.Default.Lock,
+                painter = painterResource(R.drawable.app_ic_lock),
                 contentDescription = null,
                 modifier = Modifier.size(18.dp),
             )
@@ -443,7 +440,7 @@ private fun PolaroidPlaceholder() {
     ) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Icon(
-                imageVector = Icons.Default.Favorite,
+                painter = painterResource(R.drawable.app_ic_favorite),
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
                 modifier = Modifier.size(56.dp),

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreen.kt
@@ -32,9 +32,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -133,7 +130,7 @@ fun AboutScreen(onBack: () -> Unit) {
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            painter = painterResource(R.drawable.app_ic_arrow_back),
                             contentDescription = stringResource(R.string.app_about_back),
                         )
                     }
@@ -352,7 +349,7 @@ private fun CreditsSection(creditEntries: List<CreditEntry>) {
             style = MaterialTheme.typography.titleMedium,
         )
         Icon(
-            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            painter = painterResource(R.drawable.app_ic_keyboard_arrow_right),
             contentDescription = null,
             modifier = Modifier.rotate(arrowRotation),
         )

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -6,7 +6,6 @@
 @file:Suppress("TooManyFunctions")
 
 package com.github.barriosnahuel.vossosunboton.ui.home
-
 import android.content.Context
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
@@ -24,11 +23,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.Lock
-import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -60,6 +54,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
@@ -346,7 +341,7 @@ private fun ScaffoldedLanding(
                     contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
                 ) {
                     Icon(
-                        imageVector = Icons.Default.Search,
+                        painter = painterResource(R.drawable.app_ic_search),
                         contentDescription = stringResource(R.string.app_search),
                     )
                 }
@@ -474,7 +469,7 @@ private fun AppTopBar(
         actions = {
             IconButton(onClick = { isMenuExpanded = true }) {
                 Icon(
-                    imageVector = Icons.Default.MoreVert,
+                    painter = painterResource(R.drawable.app_ic_more_vert),
                     contentDescription = stringResource(R.string.app_overflow_menu),
                 )
             }
@@ -526,7 +521,12 @@ private fun AppBottomBar(
             colors = itemColors,
             selected = selectedTab == AppTab.MY_SOUNDS,
             onClick = { onTabSelected(AppTab.MY_SOUNDS) },
-            icon = { Icon(Icons.Default.Home, contentDescription = stringResource(R.string.app_navigation_menu_item_my_sounds)) },
+            icon = {
+                Icon(
+                    painterResource(R.drawable.app_ic_home),
+                    contentDescription = stringResource(R.string.app_navigation_menu_item_my_sounds),
+                )
+            },
             label = { Text(stringResource(R.string.app_navigation_menu_item_my_sounds)) },
         )
         NavigationBarItem(
@@ -535,7 +535,7 @@ private fun AppBottomBar(
             onClick = { onTabSelected(AppTab.VAULT) },
             icon = {
                 Icon(
-                    imageVector = Icons.Default.Lock,
+                    painter = painterResource(R.drawable.app_ic_lock),
                     contentDescription = stringResource(R.string.app_navigation_menu_item_vault),
                 )
             },

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlay.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlay.kt
@@ -4,7 +4,6 @@
  * See LICENSE in the project root for full license information.
  */
 package com.github.barriosnahuel.vossosunboton.ui.home
-
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -26,10 +25,6 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -51,6 +46,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
@@ -115,7 +111,7 @@ fun SearchOverlay(
                     navigationIcon = {
                         IconButton(onClick = onClose) {
                             Icon(
-                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                painter = painterResource(R.drawable.app_ic_arrow_back),
                                 contentDescription = stringResource(R.string.app_search_close),
                             )
                         }
@@ -221,7 +217,7 @@ private fun VaultUnlockCta(
             ) {
                 TextButton(onClick = onUnlock) {
                     Icon(
-                        imageVector = Icons.Default.Lock,
+                        painter = painterResource(R.drawable.app_ic_lock),
                         contentDescription = null,
                         modifier = Modifier.size(18.dp),
                     )
@@ -282,7 +278,7 @@ private fun SearchField(
             if (query.isNotBlank()) {
                 IconButton(onClick = { onQueryChange("") }) {
                     Icon(
-                        imageVector = Icons.Default.Close,
+                        painter = painterResource(R.drawable.app_ic_close),
                         contentDescription = stringResource(R.string.app_search_clear),
                     )
                 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
@@ -4,7 +4,6 @@
  * See LICENSE in the project root for full license information.
  */
 package com.github.barriosnahuel.vossosunboton.ui.home
-
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
@@ -18,11 +17,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
@@ -52,10 +46,12 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -286,7 +282,7 @@ private fun SwipeActionBackground(
         } else {
             MaterialTheme.colorScheme.onErrorContainer
         }
-    val icon = if (isPinAction) AppIcons.PushPin else Icons.Default.Delete
+    val icon = if (isPinAction) rememberVectorPainter(AppIcons.PushPin) else painterResource(R.drawable.app_ic_delete)
     val alignment = if (isPinAction) Alignment.CenterStart else Alignment.CenterEnd
     Box(
         modifier =
@@ -296,7 +292,7 @@ private fun SwipeActionBackground(
                 .padding(horizontal = Spacing.LG),
         contentAlignment = alignment,
     ) {
-        Icon(imageVector = icon, contentDescription = null, tint = iconTint)
+        Icon(painter = icon, contentDescription = null, tint = iconTint)
     }
 }
 
@@ -397,7 +393,14 @@ private fun SoundCard(
                             ),
                     ) {
                         Icon(
-                            imageVector = if (sound.isPlaying) AppIcons.Pause else Icons.Default.PlayArrow,
+                            painter =
+                                if (sound.isPlaying) {
+                                    rememberVectorPainter(
+                                        AppIcons.Pause,
+                                    )
+                                } else {
+                                    painterResource(R.drawable.app_ic_play_arrow)
+                                },
                             contentDescription = stringResource(if (sound.isPlaying) R.string.app_pause else R.string.app_play),
                         )
                     }
@@ -529,7 +532,7 @@ private fun SoundCardHeader(
         if (shareEnabled) {
             IconButton(onClick = onShareClick) {
                 Icon(
-                    imageVector = Icons.Default.Share,
+                    painter = painterResource(R.drawable.app_ic_share),
                     contentDescription = stringResource(R.string.app_share_chooser_title),
                 )
             }
@@ -553,7 +556,7 @@ private fun SoundCardHeader(
                     if (onEditClick != null) {
                         DropdownMenuItem(
                             text = { Text(stringResource(R.string.app_edit)) },
-                            leadingIcon = { Icon(Icons.Default.Edit, contentDescription = null) },
+                            leadingIcon = { Icon(painterResource(R.drawable.app_ic_edit), contentDescription = null) },
                             onClick = {
                                 onMenuDismiss()
                                 onEditClick()
@@ -563,7 +566,7 @@ private fun SoundCardHeader(
                     if (onDeleteClick != null) {
                         DropdownMenuItem(
                             text = { Text(stringResource(R.string.app_delete)) },
-                            leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
+                            leadingIcon = { Icon(painterResource(R.drawable.app_ic_delete), contentDescription = null) },
                             onClick = {
                                 onMenuDismiss()
                                 onDeleteClick()

--- a/app/src/main/res/drawable/app_ic_add.xml
+++ b/app/src/main/res/drawable/app_ic_add.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M440-440H200v-80h240v-240h80v240h240v80H520v240h-80v-240Z" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/app_ic_arrow_back.xml
+++ b/app/src/main/res/drawable/app_ic_arrow_back.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:autoMirrored="true">
+    <group android:translateY="960">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="m313-440 224 224-57 56-320-320 320-320 57 56-224 224h487v80H313Z" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/app_ic_check.xml
+++ b/app/src/main/res/drawable/app_ic_check.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M382-240 154-468l57-57 171 171 367-367 57 57-424 424Z" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/app_ic_close.xml
+++ b/app/src/main/res/drawable/app_ic_close.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="m256-200-56-56 224-224-224-224 56-56 224 224 224-224 56 56-224 224 224 224-56 56-224-224-224 224Z" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/app_ic_delete.xml
+++ b/app/src/main/res/drawable/app_ic_delete.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M280-120q-33 0-56.5-23.5T200-200v-520h-40v-80h200v-40h240v40h200v80h-40v520q0 33-23.5 56.5T680-120H280Zm80-160h80v-360h-80v360Zm160 0h80v-360h-80v360Z" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/app_ic_edit.xml
+++ b/app/src/main/res/drawable/app_ic_edit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M120-120v-170l528-527q12-11 26.5-17t30.5-6q16 0 31 6t26 18l55 56q12 11 17.5 26t5.5 30q0 16-5.5 30.5T817-647L290-120H120Zm584-528 56-56-56-56-56 56 56 56Z" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/app_ic_edit_outlined.xml
+++ b/app/src/main/res/drawable/app_ic_edit_outlined.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M200-200h57l391-391-57-57-391 391v57Zm-80 80v-170l528-527q12-11 26.5-17t30.5-6q16 0 31 6t26 18l55 56q12 11 17.5 26t5.5 30q0 16-5.5 30.5T817-647L290-120H120Zm640-584-56-56 56 56Zm-141 85-28-29 57 57-29-28Z" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/app_ic_favorite.xml
+++ b/app/src/main/res/drawable/app_ic_favorite.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="m480-120-58-52q-101-91-167-157T150-447.5Q111-500 95.5-544T80-634q0-94 63-157t157-63q52 0 99 22t81 62q34-40 81-62t99-22q94 0 157 63t63 157q0 46-15.5 90T810-447.5Q771-395 705-329T538-172l-58 52Z" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/app_ic_home.xml
+++ b/app/src/main/res/drawable/app_ic_home.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M160-120v-480l320-240 320 240v480H560v-280H400v280H160Z" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/app_ic_keyboard_arrow_right.xml
+++ b/app/src/main/res/drawable/app_ic_keyboard_arrow_right.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:autoMirrored="true">
+    <group android:translateY="960">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M504-480 320-664l56-56 240 240-240 240-56-56 184-184Z" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/app_ic_lock.xml
+++ b/app/src/main/res/drawable/app_ic_lock.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M240-80q-33 0-56.5-23.5T160-160v-400q0-33 23.5-56.5T240-640h40v-80q0-83 58.5-141.5T480-920q83 0 141.5 58.5T680-720v80h40q33 0 56.5 23.5T800-560v400q0 33-23.5 56.5T720-80H240Zm240-200q33 0 56.5-23.5T560-360q0-33-23.5-56.5T480-440q-33 0-56.5 23.5T400-360q0 33 23.5 56.5T480-280ZM360-640h240v-80q0-50-35-85t-85-35q-50 0-85 35t-35 85v80Z" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/app_ic_more_vert.xml
+++ b/app/src/main/res/drawable/app_ic_more_vert.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M480-160q-33 0-56.5-23.5T400-240q0-33 23.5-56.5T480-320q33 0 56.5 23.5T560-240q0 33-23.5 56.5T480-160Zm0-240q-33 0-56.5-23.5T400-480q0-33 23.5-56.5T480-560q33 0 56.5 23.5T560-480q0 33-23.5 56.5T480-400Zm0-240q-33 0-56.5-23.5T400-720q0-33 23.5-56.5T480-800q33 0 56.5 23.5T560-720q0 33-23.5 56.5T480-640Z" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/app_ic_play_arrow.xml
+++ b/app/src/main/res/drawable/app_ic_play_arrow.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M320-200v-560l440 280-440 280Z" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/app_ic_search.xml
+++ b/app/src/main/res/drawable/app_ic_search.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M784-120 532-372q-30 24-69 38t-83 14q-109 0-184.5-75.5T120-580q0-109 75.5-184.5T380-840q109 0 184.5 75.5T640-580q0 44-14 83t-38 69l252 252-56 56ZM380-400q75 0 127.5-52.5T560-580q0-75-52.5-127.5T380-760q-75 0-127.5 52.5T200-580q0 75 52.5 127.5T380-400Z" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/app_ic_share.xml
+++ b/app/src/main/res/drawable/app_ic_share.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M720-80q-50 0-85-35t-35-85q0-7 1-14.5t3-13.5L322-392q-17 15-38 23.5t-44 8.5q-50 0-85-35t-35-85q0-50 35-85t85-35q23 0 44 8.5t38 23.5l282-164q-2-6-3-13.5t-1-14.5q0-50 35-85t85-35q50 0 85 35t35 85q0 50-35 85t-85 35q-23 0-44-8.5T638-672L356-508q2 6 3 13.5t1 14.5q0 7-1 14.5t-3 13.5l282 164q17-15 38-23.5t44-8.5q50 0 85 35t35 85q0 50-35 85t-85 35Z" />
+    </group>
+</vector>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,7 +64,6 @@ compose-ui-tooling-preview        = { module = "androidx.compose.ui:ui-tooling-p
 compose-ui-tooling                = { module = "androidx.compose.ui:ui-tooling" }
 compose-ui-test-manifest          = { module = "androidx.compose.ui:ui-test-manifest" }
 compose-material3                 = { module = "androidx.compose.material3:material3" }
-compose-material-icons-core        = { module = "androidx.compose.material:material-icons-core" }
 compose-ui-test-junit4            = { module = "androidx.compose.ui:ui-test-junit4" }
 
 # ---------- Lifecycle ----------


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change. Icons keep the same glyphs, sizes and content descriptions; the only perceivable difference is a slightly more modern Material Symbols stroke. Removes a dependency Google no longer maintains and has dropped from the latest Material 3, before a future BOM bump can break the build.

### Technical detail

Replaces `androidx.compose.material:material-icons-core` with **15 bundled Material Symbols vector drawables** (`app_ic_*`) loaded via `painterResource`. Every `Icon(imageVector = Icons.X.Y)` → `Icon(painter = painterResource(R.drawable.app_ic_y))` across 13 files. Drawables generated from Material Symbols SVGs (filled to match `Icons.Default.*`, outlined for `Icons.Outlined.*`); the `viewBox="0 -960 960 960"` is handled with a `<group android:translateY="960">`, and `autoMirrored="true"` is preserved for `arrow_back` + `keyboard_arrow_right` (RTL).

`AppIcons` local ImageVectors (Add, Pause, Stop, PushPin, VolumeUp, ViewComfyAlt) were never part of material-icons-core and stay as-is; mixed `if/else` icon toggles (play/pause/stop, pin/delete) wrap the AppIcons branch in `rememberVectorPainter` so both branches resolve to `Painter`. Dependency + alias removed from `build.gradle` and `libs.versions.toml`. (The third-party notices file has no material-icons entry to remove.)

Branched on top of #1171 (which touches the same UI files for predictive back) so it merges clean — spec 25 flagged the overlap and asked to keep them in separate PRs.

### Code review tips

- Drawable conversion is the novel bit: spot-check that `app_ic_*.xml` carry `<group android:translateY="960">` (the -960 viewBox shift) and that `arrow_back`/`keyboard_arrow_right` have `autoMirrored="true"`.
- `rememberVectorPainter` conditionals (`SoundItem`, `DuplicateNameHint`, `AudioPreview`): both branches are `Painter`; toggle/click wiring unchanged.
- Completeness: `grep -rn "androidx.compose.material.icons" app/src/main` → 0; remaining `Icons.` refs are all `AppIcons`.
- **Pre-existing flaky unit test** `SoundsViewModelSearchTest > searchResults recomputes when VaultSessionState flips to open mid-search` (from PR 1170, a `runTest` timing test, unrelated to this diff) can flake the `test` CI job — re-run if it does; worth stabilizing in a separate PR.

### Already tested
- `:app:assembleDebug`, `./gradlew check -x test`, `./gradlew test`, ADR-invariants + security-test-count guards: green
- Instrumented (cold boot): full suite green (tests locate icons by `contentDescription`, which is unchanged)
- On-device (emulator): icons render upright and correct — home (share/play/home/lock/more_vert) and About (back arrow + chevron, autoMirrored)
