### PR TITLE
Fix Bomps reappearing after deleting several in a row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Restored ripple contrast on the empty Home in light mode so the illustration reads clearly from the first launch
 - Audio preview no longer bleeds into the success confirmation when you save a new Bomp (or save a rename) while the preview is playing — the audio now stops the moment the confirmation appears
 - Sharing an audio into Bomp while a rename was left open in the background no longer drops you back into that unsaved rename screen with the wrong audio's data; the share now correctly opens the new-Bomp form for the incoming audio (anything you had typed in the unsaved rename is discarded since it was never saved)
+- Deleting several Bomps in a row (in My Sounds or the Vault) now removes all of them; previously only the most recent deletion stuck and the rest reappeared when the last undo snackbar faded or the list reloaded
 
 
 ### Changed

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -780,6 +780,14 @@ class SoundsViewModel(
             recomputeSearchResults()
             recomputeVaultAudios()
         }
+        // A new deletion supersedes the previous undo window (that snackbar is already gone), so
+        // commit the previous pending deletion now. Without this, rapid back-to-back deletes overwrite
+        // the single pending slot and only the LAST one is ever persisted; the earlier sounds are
+        // dropped from the in-memory list but left on disk, and the next repo re-emit resurrects them
+        // (the "delete several Bomps → they reappear when the last snackbar fades" bug).
+        if (_deletedSoundEvent.value != null) {
+            confirmDelete()
+        }
         _deletedSoundEvent.value = DeletedSoundEvent(resolvedSound.copy(isPlaying = false), sourcePosition)
         if (isWelcome) {
             _welcomeStickerVisible.value = false
@@ -1129,11 +1137,16 @@ class SoundsViewModel(
             val deletedSound = _deletedSoundEvent.value?.sound
             val deletedId = deletedSound?.id
             val welcomeIsPendingDismissal = deletedSound != null && isWelcomeSticker(deletedSound)
+            // Exclude the pending soft-deletion so a repo re-emit during the undo window can't
+            // resurrect it in the cache-derived views (search, Vault). `_sounds` already filters
+            // `deletedId` below; this keeps `allSoundsCache` consistent with it. `filterNot` over a
+            // possibly-null id is a no-op when nothing is pending (ids are never null).
+            val undeleted = allSounds.filterNot { it.id == deletedId }
             allSoundsCache.value =
                 if (playingId == null) {
-                    allSounds
+                    undeleted
                 } else {
-                    allSounds.map { if (it.id == playingId) it.copy(isPlaying = true) else it }
+                    undeleted.map { if (it.id == playingId) it.copy(isPlaying = true) else it }
                 }
             recomputeSearchResults()
             recomputeVaultAudios()

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
@@ -10,6 +10,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
+import com.github.barriosnahuel.vossosunboton.commons.file.getFile
 import com.github.barriosnahuel.vossosunboton.feature.collections.MySoundsFilterStore
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
 import com.github.barriosnahuel.vossosunboton.feature.share.ShareFeature
@@ -442,6 +443,91 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
         viewModel.selectTab(AppTab.MY_SOUNDS)
 
         assertThat(viewModel.sounds.value.none { it.name == sound.name }).isTrue()
+    }
+
+    @Test
+    fun `deleting several sounds in a row persists every deletion, not just the last`() {
+        // Regression: each delete shows an undo snackbar; a new delete replaces the previous one
+        // (cancelling its LaunchedEffect) before the previous deletion is confirmed. With a single
+        // pending-deletion slot, only the LAST deletion was ever persisted — the earlier ones were
+        // dropped from the in-memory list but left on disk, so the next repo re-emit (triggered when
+        // the last deletion is finally confirmed) repopulated them and they reappeared. The user
+        // saw: delete 4-5 in a row → empty Vault → last snackbar fades → the deleted Bomps return.
+        val context = ApplicationProvider.getApplicationContext<android.app.Application>()
+        val repo = SoundsRepository(context)
+        val files = listOf("one.mp3", "two.mp3", "three.mp3")
+        runBlocking {
+            files.forEach { name ->
+                // `repo.delete` only removes a sound from the store when its backing file is actually
+                // deleted from disk, so the persistence assertion below needs real files to delete.
+                getFile(context, name).apply {
+                    parentFile?.mkdirs()
+                    createNewFile()
+                }
+                repo.save(testSound(name.removeSuffix(".mp3"), file = name))
+            }
+        }
+        val viewModel = givenAViewModel()
+        val names = setOf("one", "two", "three")
+        val toDelete = viewModel.sounds.value.filter { it.name in names }
+        assertThat(toDelete).hasSize(names.size)
+
+        // Rapid deletes — no undo, no per-delete confirm between them.
+        toDelete.forEach { viewModel.deleteSound(it) }
+        // Only the last deletion's snackbar survives to be dismissed.
+        viewModel.confirmDelete()
+
+        runBlocking {
+            // Every deletion must reach persistence (the async DataStore writes settle slightly after
+            // the calls return). With the bug, "one"/"two" never get a confirm and stay on disk
+            // forever, so the poll times out and the assertion still sees them — exactly what the
+            // repo re-emit would resurrect on screen.
+            val persisted =
+                withTimeoutOrNull(3_000) {
+                    var remaining = repo.sounds.first().filter { it.name in names }
+                    while (remaining.isNotEmpty()) {
+                        kotlinx.coroutines.delay(20)
+                        remaining = repo.sounds.first().filter { it.name in names }
+                    }
+                    remaining
+                } ?: repo.sounds.first().filter { it.name in names }
+            assertThat(persisted).isEmpty()
+        }
+    }
+
+    @Test
+    fun `a concurrent repo write while a delete is pending does not resurrect the sound`() {
+        // Companion to the fix above. fix #1's flush persists the previous deletion, and that write
+        // fires the reactive `repo.sounds` collector, which re-runs loadSounds. loadSounds must keep
+        // the pending soft-deletion out of `allSoundsCache` (rebuilt from persistence, which still
+        // holds the pending sound) — otherwise the just-dismissed sound resurfaces in the views that
+        // read the cache (search, Vault). This drives that real re-emit path via a concurrent write.
+        val context = ApplicationProvider.getApplicationContext<android.app.Application>()
+        runBlocking { SoundsRepository(context).save(testSound("solo", file = "solo.mp3")) }
+        val viewModel =
+            SoundsViewModel(
+                context,
+                ioDispatcher = UnconfinedTestDispatcher(),
+                searchDebounceMs = 0L,
+            )
+        createdViewModels += viewModel
+        runBlocking {
+            viewModel.isInitialLoadComplete.first { it }
+            kotlinx.coroutines.delay(50)
+        }
+        val sound = viewModel.sounds.value.single { it.name == "solo" }
+
+        viewModel.deleteSound(sound)
+        // A concurrent repo write fires the reactive collector → loadSounds rebuilds the cache from
+        // persistence (which still has `solo`, its delete being unconfirmed).
+        runBlocking {
+            SoundsRepository(context).save(testSound("other", file = "other.mp3"))
+            kotlinx.coroutines.delay(200)
+        }
+        viewModel.showSearch()
+        viewModel.onSearchQueryChange("solo")
+
+        assertThat(viewModel.searchResults.value.none { it.name == "solo" }).isTrue()
     }
 
     @Test


### PR DESCRIPTION
### Summary

1. Open My Sounds (or the Vault) with several Bomps
2. Delete 4-5 of them in a row, faster than the undo snackbars fade

**before:** the list empties as expected, but when the last undo snackbar fades the deleted Bomps come back. Only the most recent deletion actually stuck — the earlier ones were dropped from the screen but never removed, so the next list reload (the snackbar fading, a tab switch, or reopening the app) resurrected them.
**after:** every deletion sticks; the list stays empty.

### Technical detail

`SoundsViewModel` tracked a single pending-deletion slot (`_deletedSoundEvent`). A new delete overwrote it before the previous one was confirmed (the previous undo `LaunchedEffect` was cancelled when its snackbar was replaced), so only the last deletion ever reached `confirmDelete` → `repo.delete`. The earlier sounds stayed on disk, and the reactive `repo.sounds` collector (which re-runs `loadSounds` on every write) — or a cold start — repopulated `allSoundsCache` from persistence and they reappeared.

- **`deleteSound`** now commits the previous pending deletion when a new one arrives (only the most recent stays undoable — the standard snackbar-undo contract).
- **`loadSounds`** filters the pending `deletedId` out of `allSoundsCache` (via `filterNot`, no extra branch — keeps the method under the detekt complexity threshold) so the re-emit that the commit triggers can't repopulate the just-deleted sound in the cache-derived views (search, Vault). `_sounds` already filtered it; this makes the cache consistent.

This is the shared delete flow, so it fixes both My Sounds and the Vault (where it was reported).

### Code review tips

- The flush in `deleteSound` calls the existing `confirmDelete()` for the previous pending, so welcome-sticker / bundled cases route through its existing `when`. The new event is set immediately after.
- TDD: two tests, each verified red→green by reverting its fix — `deleting several sounds in a row persists every deletion, not just the last` (guards the flush) and `a concurrent repo write while a delete is pending does not resurrect the sound` (guards the `allSoundsCache` filter via the real reactive-collector re-emit path).

### Already tested
- `:app:assembleDebug`, `./gradlew check -x test`, `./gradlew test`: green (incl. the 2 new TDD tests)
- Instrumented (cold boot): full suite green
