### PR TITLE
feat(vault): collapse the create-collection FAB while scrolling

### DIFF
--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultScreen.kt
@@ -323,6 +323,11 @@ private fun VaultBody(
                     .align(Alignment.BottomEnd)
                     .padding(Spacing.LG)
                     .semantics { contentDescription = fabContentDescription },
+            // Collapse to icon-only while the list is actively scrolling (less content covered),
+            // expand back to icon+text once it settles — the Material 3 ExtendedFAB idiom. The
+            // accessible name is unaffected: contentDescription lives on the modifier above, not the
+            // text slot, so it persists across both states.
+            expanded = !listState.isScrollInProgress,
             containerColor = MaterialTheme.colorScheme.primaryContainer,
             contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
             icon = {


### PR DESCRIPTION
### Summary

1. User opens the Vault tab
2. Scrolls through their private audios

**before:** the "Nuevo Baúl" button sits full-width (icon **+** label) over the list the whole time, covering more of the content as you scroll past it.
**after:** the button shrinks to just the **+** while you're scrolling and grows back to **+ Nuevo Baúl** the moment you stop — less of the list hidden mid-scroll, and the create action is still one tap away.

### Technical detail

Adds `expanded = !listState.isScrollInProgress` to the existing `ExtendedFloatingActionButton` in `VaultScreen.kt` (`VaultBody`). The `listState` was already threaded into `VaultBody`, so this is a one-line behavior addition — the Material 3 ExtendedFAB idiom for shrink-on-scroll. `VAULT_FAB_CLEARANCE` is untouched: the collapsed footprint is ≤ the expanded one, so the reserved bottom padding still prevents the last-row occlusion it was added for. The accessible name is unchanged because `contentDescription` lives on the FAB's `Modifier`, not the `text` slot, so it persists across both states.

No CHANGELOG entry: this polishes the still-unreleased Collections & Vault feature (same `[unreleased]` cycle), so it folds into that entry rather than fragmenting it.

### Code review tips

- **Recomposition scope:** `listState.isScrollInProgress` is read in `VaultBody`'s composition, so `VaultBody` recomposes on scroll start/stop (~2× per fling). Negligible today — the expensive child (`SoundsList`) is a separate composable that doesn't re-layout from this boolean — but worth watching if `VaultBody` grows heavier inline work.
- **Test gap (deliberate):** nothing asserts the expand/collapse — Compose UI Test can't easily check mid-fling state, and this is the "opcional, follow-up" task; locking it belongs to the pending instrumented-scroll-test work. `VaultFabClearanceTest` and `VaultTabFlowTest` are unaffected (their 3-audio / ZRP states don't scroll, and the FAB's content description is unchanged).

### Already tested

- instrumented: `VaultFabClearanceTest` + `VaultTabFlowTest` corridos local vía cold-boot wrapper, 4/4 verdes.
