### PR TITLE
test(collections): await asserted property, not a proxy, in bucket tests

### DIFF
--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelAnalyticsTest.kt
@@ -323,6 +323,26 @@ internal class SoundsViewModelAnalyticsTest : AbstractRobolectricTest() {
         }
     }
 
+    /**
+     * Polls [fake] every 25 ms until user property [name] equals [expected], 5-second cap. Use this
+     * instead of awaiting a *proxy* (the collections StateFlow, the toggle event) when the assertion
+     * reads a bucket user property: the collections observer sets `_collections.value` BEFORE it runs
+     * `syncAudioBuckets` (which writes the bucket properties) in the same pass, so a test awaiting the
+     * collection update can resume — under `UnconfinedTestDispatcher` — and race ahead of the property
+     * write. Awaiting the asserted value itself closes that gap (CLAUDE.md § JVM tests).
+     */
+    private suspend fun awaitUserProperty(
+        fake: FakeAnalyticsTracker,
+        name: String,
+        expected: String,
+    ) {
+        withTimeout(5_000L) {
+            while (fake.userProperties[name] != expected) {
+                delay(25L)
+            }
+        }
+    }
+
     @Test
     fun `welcome_sticker_shown is logged once on first VM init when flag is active`() {
         givenAViewModel()
@@ -632,8 +652,10 @@ internal class SoundsViewModelAnalyticsTest : AbstractRobolectricTest() {
         runBlocking { viewModel.collections.first { col -> col.any { it.id == created.id } } }
 
         viewModel.toggleAudioInCollection(sound.id, created.id)
-        runBlocking { awaitAnalyticsEvent(fake, "collection_audio_toggle") }
-        runBlocking { viewModel.collections.first { col -> col.first { it.id == created.id }.audioIds.contains(sound.id) } }
+        // Await the asserted property itself, not a proxy: `syncAudioBuckets` writes it AFTER the
+        // `_collections` emit in the same observer pass, so awaiting the collection update would
+        // race ahead of the write under UnconfinedTestDispatcher.
+        runBlocking { awaitUserProperty(fake, AnalyticsUserProperty.CURRENT_VAULT_CUSTOM, "1") }
 
         assertThat(fake.userProperties[AnalyticsUserProperty.CURRENT_VAULT_CUSTOM]).isEqualTo("1")
         assertThat(fake.userProperties[AnalyticsUserProperty.CURRENT_VAULT_DEFAULT]).isEqualTo("0")
@@ -653,8 +675,10 @@ internal class SoundsViewModelAnalyticsTest : AbstractRobolectricTest() {
         val baul = viewModel.collections.value.first { it.isSystem }
 
         viewModel.toggleAudioInCollection(sound.id, baul.id)
-        runBlocking { awaitAnalyticsEvent(fake, "collection_audio_toggle") }
-        runBlocking { viewModel.collections.first { col -> col.first { it.id == baul.id }.audioIds.contains(sound.id) } }
+        // Await the asserted property itself, not a proxy: `syncAudioBuckets` writes it AFTER the
+        // `_collections` emit in the same observer pass, so awaiting the collection update would
+        // race ahead of the write under UnconfinedTestDispatcher.
+        runBlocking { awaitUserProperty(fake, AnalyticsUserProperty.CURRENT_VAULT_DEFAULT, "1") }
 
         assertThat(fake.userProperties[AnalyticsUserProperty.CURRENT_VAULT_DEFAULT]).isEqualTo("1")
         assertThat(fake.userProperties[AnalyticsUserProperty.CURRENT_VAULT_CUSTOM]).isEqualTo("0")
@@ -683,8 +707,10 @@ internal class SoundsViewModelAnalyticsTest : AbstractRobolectricTest() {
         runBlocking { viewModel.collections.first { col -> col.any { it.id == created.id } } }
 
         viewModel.toggleAudioInCollection(filed.id, created.id)
-        runBlocking { awaitAnalyticsEvent(fake, "collection_audio_toggle") }
-        runBlocking { viewModel.collections.first { col -> col.first { it.id == created.id }.audioIds.contains(filed.id) } }
+        // Await the asserted property itself, not a proxy: `syncAudioBuckets` writes it AFTER the
+        // `_collections` emit in the same observer pass, so awaiting the collection update would
+        // race ahead of the write under UnconfinedTestDispatcher.
+        runBlocking { awaitUserProperty(fake, AnalyticsUserProperty.CURRENT_PUBLIC_CUSTOM, "1") }
 
         assertThat(fake.userProperties[AnalyticsUserProperty.CURRENT_PUBLIC_CUSTOM]).isEqualTo("1")
         assertThat(fake.userProperties[AnalyticsUserProperty.CURRENT_PUBLIC_DEFAULT]).isEqualTo("1")


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change.

Stops `SoundsViewModelAnalyticsTest`'s three Collections-&-Vault bucket tests from intermittently failing CI (seen on API[23]), which was tripping unrelated PRs and eroding trust in a green run. This is the deeper instance of the flaky pattern first addressed in the Collections & Vault PR.

### Technical detail

The `current_*_default` / `current_*_custom` assertions awaited the collections `StateFlow` as a *proxy* for the bucket user-property writes. But the collections observer sets `_collections.value` **before** it calls `syncAudioBuckets` (which writes the properties) in the same pass (`SoundsViewModel.kt:325` vs `:345`) — so under `UnconfinedTestDispatcher` the test's collector resumes on the collection emit and can reach the assertion before the property is written.

New `awaitUserProperty(fake, name, expected)` helper polls the fake until the asserted value lands (mirrors `awaitAnalyticsEvent`); applied to all three bucket tests (vault_default, vault_custom, public), since they share the identical shape. Reinforces the CLAUDE.md "await every async input" invariant — this is the case it didn't yet cover (awaiting a proxy that updates *before* the target in the same coroutine).

### Code review tips

- The proxy `collections.first { contains }` await **and** the `awaitAnalyticsEvent("collection_audio_toggle")` checkpoint are replaced by the single `awaitUserProperty` gate — both were redundant once we wait on the asserted value.
- `awaitUserProperty` waits on each test's **primary** bucket (e.g. `CURRENT_VAULT_DEFAULT="1"`); the complementary `="0"` assertion is then safe because `syncAudioBuckets` writes all four bucket properties in one call — once one is correct, they all are.

### Already tested

- unit: `SoundsViewModelAnalyticsTest` run **10× locally, 10/10 green** (`--rerun-tasks`) — flake validation beyond CI's single run.
