### PR TITLE
feat(vault): screen-lock setup shortcut on unprotected devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 ### Added
 - New **Vault** tab in the bottom navigation, grouping your private collections behind your fingerprint or screen lock. The "Baúl" lives there by default and you can create more private collections for specific people, moments, or memories. Audios tagged to a private collection only play from there, in an immersive listen view with no share button
+- On devices with no screen lock set, the Vault stays usable and its unlock screen now offers a one-tap shortcut to Android's screen-lock setup so you can protect it
 - Public **collections** for organizing your Bomps by context (Family, Work, Recipes…). A filter chip row at the top of My Sounds lets you narrow the list to one collection at a time — the last chip you used persists across cold starts
 - New "Assign to collections" section in New Bomp and Rename Bomp. Public collections show up as multi-select chips; private collections appear behind a "Show private collections (requires unlock)" CTA that asks for your fingerprint before revealing them
 - Terms of Service link in the About screen's "Legal & Privacy" section, opening the published page with `?hl=` matched to the device locale (es-AR, es-419, es-ES, en, pt-BR)

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultTabFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultTabFlowTest.kt
@@ -35,6 +35,8 @@ import org.junit.runner.RunWith
  * - `unlockingVaultRevealsInspirationalZeroResultState`: same flow as above but pre-seeds the
  *   session state so we land directly on the ZRP body. Belt + suspenders for the empty-state
  *   message; failing it means either the chip row, the FAB, or the ZRP text changed unexpectedly.
+ * - `unprotectedDeviceGateOffersScreenLockShortcut`: on the (unprotected) AVD the gate must surface
+ *   the secondary "set up screen lock" shortcut, since the system Settings resolves the deep link.
  */
 @RunWith(AndroidJUnit4::class)
 internal class VaultTabFlowTest : AbstractUiTest() {
@@ -50,6 +52,18 @@ internal class VaultTabFlowTest : AbstractUiTest() {
         ActivityScenario.launch(LandingActivity::class.java).use {
             composeRule.awaitNodeWithText(vaultLabel()).performClick()
             composeRule.awaitNodeWithText(unlockCta()).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun unprotectedDeviceGateOffersScreenLockShortcut() {
+        // The CI AVD cold-boots with no screen lock, so the gate takes its unprotected branch and the
+        // system Settings resolves ACTION_SET_NEW_PASSWORD — both conditions for the secondary
+        // "set up screen lock" shortcut. Asserts the real device-resolution path the Robolectric test
+        // can only simulate.
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            composeRule.awaitNodeWithText(vaultLabel()).performClick()
+            composeRule.awaitNodeWithText(setupScreenLockCta()).assertIsDisplayed()
         }
     }
 
@@ -70,6 +84,8 @@ internal class VaultTabFlowTest : AbstractUiTest() {
     private fun vaultLabel() = context.getString(R.string.app_navigation_menu_item_vault)
 
     private fun unlockCta() = context.getString(R.string.app_vault_unlock_cta)
+
+    private fun setupScreenLockCta() = context.getString(R.string.app_vault_unprotected_setup_screenlock_cta)
 
     private fun zrpHeadlineLead() = context.getString(R.string.app_vault_zrp_headline_lead)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,19 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!--
+        Package visibility (Android 11+ / API 30+): declaring the SET_NEW_PASSWORD intent makes the
+        system Settings activity that handles it visible to resolveActivity(), so the Vault's "set up
+        screen lock" shortcut (ScreenLockSettings) can verify the deep link resolves before offering
+        it. Without this, resolveActivity() returns null on API 30+ and the affordance never appears.
+        https://developer.android.com/training/package-visibility
+    -->
+    <queries>
+        <intent>
+            <action android:name="android.app.action.SET_NEW_PASSWORD" />
+        </intent>
+    </queries>
+
     <application
         android:name=".MainApplication"
         android:allowBackup="true"

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultScreen.kt
@@ -20,10 +20,14 @@ import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -37,6 +41,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsEvent
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsSource
@@ -45,6 +52,7 @@ import com.github.barriosnahuel.vossosunboton.feature.collections.MySoundsFilter
 import com.github.barriosnahuel.vossosunboton.feature.vault.security.BiometricGate
 import com.github.barriosnahuel.vossosunboton.feature.vault.security.BiometricGateResult
 import com.github.barriosnahuel.vossosunboton.feature.vault.security.BiometricGateStatus
+import com.github.barriosnahuel.vossosunboton.feature.vault.security.ScreenLockSettings
 import com.github.barriosnahuel.vossosunboton.feature.vault.security.VaultSessionState
 import com.github.barriosnahuel.vossosunboton.model.Collection
 import com.github.barriosnahuel.vossosunboton.model.CollectionAccess
@@ -78,7 +86,24 @@ fun VaultScreen(
     val context = LocalContext.current
     val activity = remember(context) { context.findFragmentActivity() }
     val gate = remember(activity) { activity?.let { BiometricGate(it) } }
-    val status = remember(gate) { gate?.status() ?: BiometricGateStatus.UNAVAILABLE }
+    // Re-read the gate status on every ON_RESUME (not just first composition): when the user taps the
+    // "set up screen lock" shortcut, leaves to Settings, enrolls a lock and returns, the snapshot must
+    // flip from unprotected to AVAILABLE so the warning + shortcut disappear instead of going stale.
+    var status by remember(gate) { mutableStateOf(gate?.status() ?: BiometricGateStatus.UNAVAILABLE) }
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner, gate) {
+        val observer =
+            LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_RESUME) {
+                    status = gate?.status() ?: BiometricGateStatus.UNAVAILABLE
+                }
+            }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+    // The set-screen-lock intent's resolvability does not change at runtime, so cache it once. The
+    // status snapshot above is what flips the affordance off once a lock exists.
+    val screenLockShortcutAvailable = remember(context) { ScreenLockSettings.isAvailable(context) }
     val vaultOpen by VaultSessionState.flow.collectAsState()
     val tracker = remember(context) { AnalyticsTrackerProvider.get(context.applicationContext) }
     val unprotectedWarning = stringResource(R.string.app_vault_unprotected_warning_chip)
@@ -103,6 +128,7 @@ fun VaultScreen(
                 UnlockGate(
                     status = status,
                     unprotectedWarning = unprotectedWarning,
+                    showScreenLockShortcut = screenLockShortcutAvailable,
                     onUnlock = {
                         requestUnlock(
                             context = context,
@@ -112,6 +138,7 @@ fun VaultScreen(
                             source = AnalyticsSource.VAULT_TAB,
                         )
                     },
+                    onSetUpScreenLock = { ScreenLockSettings.open(context) },
                 )
             else ->
                 VaultBody(
@@ -180,7 +207,9 @@ internal fun bumpVaultUnlockCounter(tracker: com.github.barriosnahuel.vossosunbo
 private fun UnlockGate(
     status: BiometricGateStatus,
     unprotectedWarning: String,
+    showScreenLockShortcut: Boolean,
     onUnlock: () -> Unit,
+    onSetUpScreenLock: () -> Unit,
 ) {
     Column(
         modifier =
@@ -235,6 +264,23 @@ private fun UnlockGate(
                 color = MaterialTheme.colorScheme.error,
                 textAlign = TextAlign.Center,
             )
+            // Secondary remediation affordance: a text-tier button (ADR 0010 — `primary` inherited,
+            // never an outlined/tonal tier) that deep-links straight to the system set-screen-lock
+            // flow. Only rendered when the intent actually resolves on this device, so it can never
+            // be a dead button. Below the primary "unlock" CTA on purpose — it's the fallback path,
+            // not the main action.
+            if (showScreenLockShortcut) {
+                Spacer(modifier = Modifier.height(Spacing.SM))
+                TextButton(onClick = onSetUpScreenLock) {
+                    Icon(
+                        painter = painterResource(R.drawable.app_ic_lock),
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Spacer(modifier = Modifier.size(Spacing.XS))
+                    Text(stringResource(R.string.app_vault_unprotected_setup_screenlock_cta))
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/security/ScreenLockSettings.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/security/ScreenLockSettings.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.vault.security
+
+import android.app.admin.DevicePolicyManager
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
+
+/**
+ * One-tap shortcut to the system "set up a screen lock" flow, surfaced only when the Vault is
+ * unprotected because the device has neither a biometric nor a device credential enrolled (spec § 6
+ * edge case "dispositivo sin PIN"). The Vault itself never blocks in that state — this only offers a
+ * resilient path to harden it.
+ *
+ * Uses [DevicePolicyManager.ACTION_SET_NEW_PASSWORD], the OEM-portable intent that prompts the user
+ * to set a device security challenge (PIN / pattern / password). Available since API 8, needs no
+ * permission and no device-policy controller. On API 30+ the implicit-intent target is hidden by
+ * package-visibility filtering, so the manifest declares a matching `<queries>` entry — without it
+ * [isAvailable] would always return `false` on modern devices and the affordance would never appear.
+ * We never assume it resolves: [isAvailable] gates the affordance so it never renders a dead button,
+ * and [open] still guards the launch the way `AboutScreen.openUrl` guards its `ACTION_VIEW`.
+ */
+object ScreenLockSettings {
+    /** The implicit intent that opens the system set-screen-lock screen. */
+    fun intent(): Intent = Intent(DevicePolicyManager.ACTION_SET_NEW_PASSWORD)
+
+    /** True when some activity can handle [intent] — the affordance's visibility gate. */
+    fun isAvailable(context: Context): Boolean = intent().resolveActivity(context.packageManager) != null
+
+    /**
+     * Launches the set-screen-lock screen. Returns `false` (and tracks a non-fatal) if no activity
+     * handles it despite [isAvailable] returning `true` earlier — the same defensive pattern as the
+     * About screen's external-link launch.
+     */
+    fun open(context: Context): Boolean =
+        try {
+            context.startActivity(intent())
+            true
+        } catch (e: ActivityNotFoundException) {
+            Tracker.log("vault.screenlock_setup_unavailable")
+            Tracker.track(RuntimeException("Could not launch ACTION_SET_NEW_PASSWORD", e))
+            false
+        }
+}

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -96,6 +96,7 @@
     <string name="app_vault_screen_title">Baúl</string>
     <string name="app_vault_baul_name">Mi Baúl</string>
     <string name="app_vault_unprotected_warning_chip">Sin protección — configurá un bloqueo de pantalla</string>
+    <string name="app_vault_unprotected_setup_screenlock_cta">Configurar bloqueo de pantalla</string>
     <string name="app_vault_fab_new">Nuevo Baúl</string>
     <string name="app_vault_card_overflow_description">Más opciones para %1$s</string>
     <string name="app_manage_collections_overflow_view">Ver colección</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,6 +102,7 @@
     <string name="app_vault_screen_title">Vault</string>
     <string name="app_vault_baul_name">My Vault</string>
     <string name="app_vault_unprotected_warning_chip">Not protected — set a screen lock</string>
+    <string name="app_vault_unprotected_setup_screenlock_cta">Set up screen lock</string>
     <string name="app_vault_fab_new">New Vault</string>
     <string name="app_vault_card_overflow_description">More options for %1$s</string>
     <string name="app_manage_collections_overflow_view">View collection</string>

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/security/ScreenLockSettingsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/security/ScreenLockSettingsTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.vault.security
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.pm.ActivityInfo
+import android.content.pm.ResolveInfo
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
+
+/**
+ * Unit coverage for [ScreenLockSettings] — the resilient deep link the Vault offers when the device
+ * has no screen lock configured (spec § 6 "dispositivo sin PIN"). Pins the wire action string and
+ * the resolvability gate so a refactor can't silently swap the intent or let the affordance render
+ * as a dead button on a device that can't handle it.
+ */
+internal class ScreenLockSettingsTest : AbstractRobolectricTest() {
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `intent targets the system set-new-password action`() {
+        assertThat(ScreenLockSettings.intent().action).isEqualTo("android.app.action.SET_NEW_PASSWORD")
+    }
+
+    @Test
+    fun `isAvailable is true when an activity resolves the intent`() {
+        shadowOf(context.packageManager).addResolveInfoForIntent(ScreenLockSettings.intent(), settingsResolveInfo())
+
+        assertThat(ScreenLockSettings.isAvailable(context)).isTrue()
+    }
+
+    @Test
+    fun `isAvailable is false when nothing resolves the intent`() {
+        assertThat(ScreenLockSettings.isAvailable(context)).isFalse()
+    }
+
+    @Test
+    fun `open launches the set-new-password screen`() {
+        val activity = Robolectric.buildActivity(Activity::class.java).create().get()
+        shadowOf(activity.packageManager).addResolveInfoForIntent(ScreenLockSettings.intent(), settingsResolveInfo())
+
+        val launched = ScreenLockSettings.open(activity)
+
+        assertThat(launched).isTrue()
+        assertThat(shadowOf(activity).nextStartedActivity.action).isEqualTo("android.app.action.SET_NEW_PASSWORD")
+    }
+
+    @Test
+    fun `open returns false and tracks a non-fatal when no activity handles the launch`() {
+        // The resilience contract: even if isAvailable raced ahead of an uninstall, open must not
+        // crash. Force the ActivityNotFoundException branch with a context whose startActivity throws.
+        val context = mockk<Context>()
+        every { context.startActivity(any()) } throws ActivityNotFoundException("no handler")
+
+        val launched = ScreenLockSettings.open(context)
+
+        assertThat(launched).isFalse()
+        verify(exactly = 1) { Tracker.track(any()) }
+    }
+
+    private fun settingsResolveInfo() =
+        ResolveInfo().apply {
+            activityInfo =
+                ActivityInfo().apply {
+                    packageName = "com.android.settings"
+                    name = "SetNewPasswordActivity"
+                }
+        }
+}


### PR DESCRIPTION
### Summary

On a phone with no screen lock set, the Vault doesn't lock you out — but until now its "not protected" warning was a dead end: protecting the Vault meant leaving the app and hunting for the right Settings page yourself.

1. User opens the app
2. Taps the **Vault** tab → lands on the unlock screen

**before:** the screen warns "not protected — set a screen lock" but offers no way to act on it.
**after:** a secondary **Set up screen lock** shortcut jumps straight to Android's set-lock flow; set a PIN/pattern/fingerprint, come back, and the Vault recognizes it's protected (it asks to authenticate from then on).

### Technical detail

Adds a remediation affordance to the Vault's already-handled "unprotected device" edge case (design artboard *11 · Vault sin PIN configurado*).

- **`ScreenLockSettings`** (new) — wraps `DevicePolicyManager.ACTION_SET_NEW_PASSWORD`: `intent()`, `isAvailable()` (resolveActivity gate), `open()` (launches; catches `ActivityNotFoundException` → static `Tracker.track`, mirroring `AboutScreen.openUrl`).
- **`AndroidManifest` `<queries>`** — declares the `SET_NEW_PASSWORD` intent so `resolveActivity` resolves under API 30+ package visibility; without it the shortcut would never appear on modern devices.
- **`VaultScreen` / `UnlockGate`** — secondary `TextButton` (ADR 0010 text tier, `primary`, 18 dp lock icon) shown under the warning only when the intent resolves. Gate `status` is now a resume-refreshed `mutableStateOf` (`DisposableEffect` + `LifecycleEventObserver` on `ON_RESUME`, mirroring `AddButtonScreen`) so a newly-set lock flips the gate without an app restart.
- **Strings** en + es; **CHANGELOG** entry.
- **Out of scope:** the file's existing `collectAsState()` left as-is (repo-wide migration debt); no analytics event for the tap (`VaultUnprotectedWarningShown` already covers the state); no per-card warning plate (the app is gate-based, not card-based).

### Code review tips

- **Label interpretation:** the visible label is action-descriptive ("Set up screen lock"), not the literal "acceso directo" — read as the button's *nature* (a shortcut to Settings); the accessible name must describe the action (WCAG 2.5.3). Redirect if the literal label was intended.
- **Dual refresh cadence** (`VaultScreen.kt`): `screenLockShortcutAvailable` is cached once (`remember(context)` — intent resolvability is static); it's the `status` `ON_RESUME` refresh that hides the whole unprotected block once a lock exists. The outer `status != AVAILABLE` guard makes the cached value moot — harmless, but the coupling is non-obvious.
- **`<queries>` is app-global** but purely additive (only adds `SET_NEW_PASSWORD` visibility). The full instrumented suite below confirms no other flow regressed.

### Already tested

- **instrumented (local UI suite, cold-boot AVD — not run by CI):** full `:app:connectedDebugAndroidTest`, **101/101 passed**, 0 failures (2 pre-existing skips), incl. new `VaultTabFlowTest.unprotectedDeviceGateOffersScreenLockShortcut` verifying the deep link resolves + the CTA renders on a real API 34 device.
