### PR TITLE
chore(version): set unreleased version to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][], and this project adheres to [Semantic Versioning][].
 
-## \[unreleased] (v2.0.1)
+## \[unreleased] (v2.1.0)
 
 ### Added
 - New **Vault** tab in the bottom navigation, grouping your private collections behind your fingerprint or screen lock. The "Baúl" lives there by default and you can create more private collections for specific people, moments, or memories. Audios tagged to a private collection only play from there, in an immersive listen view with no share button

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,7 +20,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 37
         versionCode 5
-        versionName '2.0.0'
+        versionName '2.1.0'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
### Summary

Development has moved to the 2.1.0 cycle, but the app still reported **2.0.0**. Now the About screen reads **2.1.0**, and the CHANGELOG `[unreleased]` marker is `(v2.1.0)` so it matches the milestone PRs are tagged against.

### Technical detail

- `app/build.gradle`: `versionName '2.0.0'` → `'2.1.0'`. The About screen renders `info.versionName` via `PackageInfo` (`AboutScreen.kt:453`), so this is the single source for the displayed version.
- `CHANGELOG.md`: `[unreleased] (v2.0.1)` → `(v2.1.0)` — resolves the mismatch where recent PRs were milestoned `v2.1.0` (the real open milestone) while the CHANGELOG said `v2.0.1` (no such milestone). Per CLAUDE.md, the `[unreleased]` parens drive milestone derivation; this makes that rule point at the right milestone going forward.
- `versionCode` left at **5** — it's a release/Play-upload concern, bumped when 2.1.0 actually ships, not during development.

### Code review tips

- Single source of truth confirmed: no test hardcodes the version string, and About reads `info.versionName` dynamically — so the bump can't desync a test or a second copy of the version.
- Config + CHANGELOG only; no Composable or logic touched (About already reads the version dynamically), so it's instrumented-exempt per CLAUDE.md § *Pre-PR checklists*.

### Already tested

- Local: `./gradlew check -x test` green; About unit tests green. (CI also runs the full lint + unit suites.)
