### PR TITLE
feat(vault): immersive listen mode for Vault audios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 ## \[unreleased] (v2.1.0)
 
 ### Added
-- New **Vault** tab in the bottom navigation, grouping your private collections behind your fingerprint or screen lock. The "Baúl" lives there by default and you can create more private collections for specific people, moments, or memories. Audios tagged to a private collection only play from there, in an immersive listen view with no share button
+- New **Vault** tab in the bottom navigation, grouping your private collections behind your fingerprint or screen lock. The "Baúl" lives there by default and you can create more private collections for specific people, moments, or memories. Audios tagged to a private collection only play from there: tapping play opens an immersive, full-screen listen mode — waveform, the date and name, a single play/pause control, and no share button
 - On devices with no screen lock set, the Vault stays usable and its unlock screen now offers a one-tap shortcut to Android's screen-lock setup so you can protect it
 - Public **collections** for organizing your Bomps by context (Family, Work, Recipes…). A filter chip row at the top of My Sounds lets you narrow the list to one collection at a time — the last chip you used persists across cold starts
 - New "Assign to collections" section in New Bomp and Rename Bomp. Public collections show up as multi-select chips; private collections appear behind a "Show private collections (requires unlock)" CTA that asks for your fingerprint before revealing them

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultImmersiveListenTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultImmersiveListenTest.kt
@@ -5,7 +5,10 @@
  */
 package com.github.barriosnahuel.vossosunboton.feature.vault
 
+import android.view.WindowInsets
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -15,6 +18,7 @@ import com.github.barriosnahuel.vossosunboton.TestData
 import com.github.barriosnahuel.vossosunboton.awaitNodeWithContentDescription
 import com.github.barriosnahuel.vossosunboton.awaitNodeWithText
 import com.github.barriosnahuel.vossosunboton.ui.home.LandingActivity
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -78,6 +82,38 @@ internal class VaultImmersiveListenTest : AbstractUiTest() {
         }
     }
 
+    @Test
+    fun immersiveListenTopBarClearsTheStatusBar() {
+        seedVaultAudio()
+
+        ActivityScenario.launch(LandingActivity::class.java).use { scenario ->
+            composeRule.awaitNodeWithText(vaultLabel()).performClick()
+            composeRule.awaitNodeWithContentDescription(playLabel()).performClick()
+            composeRule.awaitNodeWithText(listenModeLabel()).assertIsDisplayed()
+
+            // Read the real status-bar inset from the window rather than hard-coding a height.
+            var statusBarTopPx = 0
+            var density = 1f
+            scenario.onActivity { activity ->
+                statusBarTopPx =
+                    activity.window.decorView.rootWindowInsets
+                        .getInsets(WindowInsets.Type.statusBars())
+                        .top
+                density = activity.resources.displayMetrics.density
+            }
+            val statusBarTopDp = statusBarTopPx / density
+
+            // The back button (top of the bar) must sit at or below the status bar — under
+            // edge-to-edge the gradient bleeds behind it, but the control must stay tappable/legible.
+            val backTopDp =
+                composeRule
+                    .onNodeWithContentDescription(backLabel())
+                    .getUnclippedBoundsInRoot()
+                    .top.value
+            assertThat(backTopDp).isAtLeast(statusBarTopDp - INSET_TOLERANCE_DP)
+        }
+    }
+
     private fun seedVaultAudio() {
         val (audio) = TestData.seedCustomSounds(context, count = 1)
         TestData.seedPrivateCollection(context, name = "Caro", audioIds = listOf(audio.id))
@@ -95,5 +131,8 @@ internal class VaultImmersiveListenTest : AbstractUiTest() {
     private companion object {
         // seedCustomSounds names sounds custom_1, custom_2, ... — count = 1 yields custom_1.
         const val AUDIO_NAME = "custom_1"
+
+        // Rounding slack between the px→dp inset conversion and Compose's dp bounds.
+        const val INSET_TOLERANCE_DP = 1f
     }
 }

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultImmersiveListenTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultImmersiveListenTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.vault
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.barriosnahuel.vossosunboton.AbstractUiTest
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.TestData
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithContentDescription
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithText
+import com.github.barriosnahuel.vossosunboton.ui.home.LandingActivity
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Flow guard for Vault listen mode (`CollectionPlaybackUI.IMMERSIVE`).
+ *
+ * The Vault list stays identical to My Sounds, but tapping play opens the full-screen, listen-only
+ * player instead of the inline card transport. The Robolectric layer covers the rendering and the
+ * label/omission contract; this instrumented variant exercises the real navigation wiring
+ * (list → overlay → back) and the durable-state survival across an Activity recreate, neither of
+ * which is reachable from the Robolectric stateless-screen tests.
+ *
+ * Vault is force-opened via [TestData.markVaultOpen] so the test does not depend on a biometric
+ * being configured on the emulator (the gate falls through to "open directly" on unprotected
+ * devices, spec § 6).
+ */
+@RunWith(AndroidJUnit4::class)
+internal class VaultImmersiveListenTest : AbstractUiTest() {
+    @Test
+    fun tappingPlayOnAVaultAudioOpensImmersiveListenMode() {
+        seedVaultAudio()
+
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            composeRule.awaitNodeWithText(vaultLabel()).performClick()
+            composeRule.awaitNodeWithText(AUDIO_NAME).assertIsDisplayed()
+            composeRule.awaitNodeWithContentDescription(playLabel()).performClick()
+
+            composeRule.awaitNodeWithText(listenModeLabel()).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun backFromImmersiveListenModeReturnsToTheVaultList() {
+        seedVaultAudio()
+
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            composeRule.awaitNodeWithText(vaultLabel()).performClick()
+            composeRule.awaitNodeWithContentDescription(playLabel()).performClick()
+            composeRule.awaitNodeWithText(listenModeLabel()).assertIsDisplayed()
+
+            composeRule.awaitNodeWithContentDescription(backLabel()).performClick()
+
+            // Back closes listen mode and reveals the Vault list again.
+            composeRule.awaitNodeWithText(AUDIO_NAME).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun immersiveListenModeSurvivesActivityRecreate() {
+        seedVaultAudio()
+
+        ActivityScenario.launch(LandingActivity::class.java).use { scenario ->
+            composeRule.awaitNodeWithText(vaultLabel()).performClick()
+            composeRule.awaitNodeWithContentDescription(playLabel()).performClick()
+            composeRule.awaitNodeWithText(listenModeLabel()).assertIsDisplayed()
+
+            scenario.recreate()
+
+            // The rememberSaveable overlay id restores; the host re-resolves the audio from library.
+            composeRule.awaitNodeWithText(listenModeLabel()).assertIsDisplayed()
+        }
+    }
+
+    private fun seedVaultAudio() {
+        val (audio) = TestData.seedCustomSounds(context, count = 1)
+        TestData.seedPrivateCollection(context, name = "Caro", audioIds = listOf(audio.id))
+        TestData.markVaultOpen()
+    }
+
+    private fun vaultLabel() = context.getString(R.string.app_navigation_menu_item_vault)
+
+    private fun playLabel() = context.getString(R.string.app_play)
+
+    private fun backLabel() = context.getString(R.string.app_vault_immersive_back)
+
+    private fun listenModeLabel() = context.getString(R.string.app_vault_immersive_mode_label).uppercase()
+
+    private companion object {
+        // seedCustomSounds names sounds custom_1, custom_2, ... — count = 1 yields custom_1.
+        const val AUDIO_NAME = "custom_1"
+    }
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -32,7 +33,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -59,8 +62,8 @@ import com.github.barriosnahuel.vossosunboton.ui.home.SoundsViewModel
 import com.github.barriosnahuel.vossosunboton.ui.home.formatDuration
 import com.github.barriosnahuel.vossosunboton.ui.home.formatFullDate
 import com.github.barriosnahuel.vossosunboton.ui.predictiveBackTransition
+import com.github.barriosnahuel.vossosunboton.ui.theme.ImmersiveListenTheme
 import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
-import kotlin.math.sin
 
 /**
  * Listen mode — the full-screen, listen-only player for a single Vault audio. Reached by tapping
@@ -109,9 +112,19 @@ internal fun ImmersiveListenHost(
         // Library not hydrated yet (cold start / process recreate). Hold an opaque backdrop that
         // still honours back instead of flashing the Vault list behind it.
         ImmersiveBackdrop(modifier = Modifier.predictiveBackTransition(onBack = onBack)) {
-            Column { ImmersiveTopBar(collectionLabel = "", onBack = onBack) }
+            Column(modifier = Modifier.fillMaxSize().safeDrawingPadding()) {
+                ImmersiveTopBar(collectionLabel = "", onBack = onBack)
+            }
         }
         return
+    }
+
+    // Real amplitude envelope — instant if already decoded this session, otherwise decoded off the
+    // main thread (the screen shows a neutral placeholder until it arrives). Kept in-memory only;
+    // see the PR discussion on why persisting this derived data is not worth it yet.
+    var peaks by remember(sound.id) { mutableStateOf(WaveformExtractor.cached(sound.id)) }
+    LaunchedEffect(sound.id) {
+        if (peaks == null) peaks = WaveformExtractor.extract(context, sound, WAVEFORM_BARS)
     }
 
     val isThisPlaying = playingSound?.id == soundId
@@ -130,6 +143,7 @@ internal fun ImmersiveListenHost(
         durationMs = durationMs,
         isPlaying = isThisPlaying,
         progressFraction = fraction,
+        peaks = peaks,
         onPlayPause = { viewModel.playOrStop(sound.copy(isPlaying = isThisPlaying)) },
         onBack = onBack,
     )
@@ -164,12 +178,15 @@ internal fun ImmersiveListenScreen(
     durationMs: Int?,
     isPlaying: Boolean,
     progressFraction: Float,
+    peaks: FloatArray?,
     onPlayPause: () -> Unit,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     ImmersiveBackdrop(modifier = modifier.predictiveBackTransition(onBack = onBack)) {
-        Column(modifier = Modifier.fillMaxSize()) {
+        // safeDrawingPadding keeps the content clear of the status/navigation bars while the
+        // backdrop gradient still bleeds full-screen behind them (edge-to-edge).
+        Column(modifier = Modifier.fillMaxSize().safeDrawingPadding()) {
             ImmersiveTopBar(collectionLabel = collectionLabel, onBack = onBack)
             // `heightIn(min = maxHeight)` + `verticalScroll` keeps the spread layout (hero up top,
             // transport pinned low) when the content fits, but lets it scroll instead of clipping on
@@ -197,6 +214,7 @@ internal fun ImmersiveListenScreen(
                         durationMs = durationMs,
                         isPlaying = isPlaying,
                         progressFraction = progressFraction,
+                        peaks = peaks,
                         onPlayPause = onPlayPause,
                     )
                 }
@@ -210,29 +228,32 @@ private fun ImmersiveBackdrop(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
-    // Warm-mood wash adapted to the palette: the accent role at low alpha gives an emotional glow
-    // without a one-off color token. Same approach as VaultEmptyState; theme-aware in both modes.
-    val accent = MaterialTheme.colorScheme.primary
-    val backgroundColor = MaterialTheme.colorScheme.background
-    val wash =
-        remember(accent, backgroundColor) {
-            Brush.radialGradient(
-                colorStops =
-                    arrayOf(
-                        GLOW_STOP_CENTER to accent.copy(alpha = GLOW_CENTER_ALPHA),
-                        GLOW_STOP_MID to accent.copy(alpha = GLOW_MID_ALPHA),
-                        GLOW_STOP_EDGE to backgroundColor,
-                    ),
-            )
+    // Always-dark "lights-down" surface (see ImmersiveListenTheme): legible status-bar icons in both
+    // modes + matches the design. The acid wash at low alpha gives an emotional glow without a
+    // one-off color token (same approach as VaultEmptyState).
+    ImmersiveListenTheme {
+        val accent = MaterialTheme.colorScheme.primary
+        val backgroundColor = MaterialTheme.colorScheme.background
+        val wash =
+            remember(accent, backgroundColor) {
+                Brush.radialGradient(
+                    colorStops =
+                        arrayOf(
+                            GLOW_STOP_CENTER to accent.copy(alpha = GLOW_CENTER_ALPHA),
+                            GLOW_STOP_MID to accent.copy(alpha = GLOW_MID_ALPHA),
+                            GLOW_STOP_EDGE to backgroundColor,
+                        ),
+                )
+            }
+        Box(
+            modifier =
+                modifier
+                    .fillMaxSize()
+                    .background(backgroundColor)
+                    .background(wash),
+        ) {
+            content()
         }
-    Box(
-        modifier =
-            modifier
-                .fillMaxSize()
-                .background(backgroundColor)
-                .background(wash),
-    ) {
-        content()
     }
 }
 
@@ -333,6 +354,7 @@ private fun ImmersiveTransport(
     durationMs: Int?,
     isPlaying: Boolean,
     progressFraction: Float,
+    peaks: FloatArray?,
     onPlayPause: () -> Unit,
 ) {
     Column(
@@ -342,6 +364,7 @@ private fun ImmersiveTransport(
     ) {
         ImmersiveWaveform(
             progressFraction = progressFraction,
+            peaks = peaks,
             modifier =
                 Modifier
                     .fillMaxWidth()
@@ -393,25 +416,26 @@ private fun ImmersiveTransport(
 }
 
 @Composable
-@Suppress("MagicNumber")
 private fun ImmersiveWaveform(
     progressFraction: Float,
+    peaks: FloatArray?,
     modifier: Modifier = Modifier,
 ) {
-    // Synthetic, deterministic bars: the player exposes position/duration, not amplitude samples,
-    // so (like the mock) heights come from a fixed sin seed. No animation — keeps the screen idle
-    // for `waitForIdle()`-based tests. Played portion uses the accent role; the rest is muted.
+    // Real amplitude envelope from [WaveformExtractor]. Until it arrives (or if decoding failed)
+    // `peaks` is null and we draw a neutral flat baseline — never a fake-looking wave. No animation,
+    // so the screen stays idle for `waitForIdle()`-based tests. Played bars use the accent role.
     val playedColor = MaterialTheme.colorScheme.primary
-    val unplayedColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.30f)
+    val unplayedColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = WAVEFORM_UNPLAYED_ALPHA)
+    val barCount = peaks?.size ?: WAVEFORM_BARS
     Canvas(modifier = modifier) {
-        val slot = size.width / WAVEFORM_BARS
+        val slot = size.width / barCount
         val barWidth = slot * WAVEFORM_BAR_FILL
         val centerY = size.height / 2f
         val corner = CornerRadius(barWidth / 2f, barWidth / 2f)
-        for (i in 0 until WAVEFORM_BARS) {
-            val seed = sin(i * 0.7) * 0.4 + sin(i * 0.23) * 0.35 + 0.5
-            val barHeight = seed.coerceIn(WAVEFORM_MIN_FRACTION.toDouble(), 1.0).toFloat() * size.height
-            val played = i.toFloat() / WAVEFORM_BARS < progressFraction
+        for (i in 0 until barCount) {
+            val amplitude = peaks?.getOrNull(i) ?: WAVEFORM_PLACEHOLDER_FRACTION
+            val barHeight = amplitude.coerceIn(WAVEFORM_MIN_FRACTION, 1f) * size.height
+            val played = i.toFloat() / barCount < progressFraction
             val x = i * slot + (slot - barWidth) / 2f
             drawRoundRect(
                 color = if (played) playedColor else unplayedColor,
@@ -423,9 +447,12 @@ private fun ImmersiveWaveform(
     }
 }
 
+// Bar count used for the placeholder + as the extractor's target resolution.
 private const val WAVEFORM_BARS = 56
 private const val WAVEFORM_BAR_FILL = 0.45f
-private const val WAVEFORM_MIN_FRACTION = 0.10f
+private const val WAVEFORM_MIN_FRACTION = 0.06f
+private const val WAVEFORM_PLACEHOLDER_FRACTION = 0.12f
+private const val WAVEFORM_UNPLAYED_ALPHA = 0.30f
 private val WAVEFORM_HEIGHT = 96.dp
 private val MEMORY_TILE_SIZE = 188.dp
 private const val MEMORY_TILE_TILT = -3f

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreen.kt
@@ -7,23 +7,19 @@ package com.github.barriosnahuel.vossosunboton.feature.vault
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -38,16 +34,20 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.progressBarRangeInfo
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.setProgress
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -70,16 +70,11 @@ import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
  * play on any audio in the Vault tab (`CollectionPlaybackUI.IMMERSIVE`); the Vault list itself is
  * unchanged (same `SoundsList` cards as My Sounds).
  *
- * Renders only the four facts a Vault audio actually carries — name, date, duration and the private
- * collection it belongs to. The Claude Design mock additionally shows a hand-written caption, an
- * event eyebrow and a free-text subtitle; the Vault stores none of those, so they are deliberately
- * omitted (mirroring `VaultEmptyState`, which dropped the polaroid for the same reason). The hero
- * photo is replaced by a decorative gradient tile, and the waveform is synthetic (the player exposes
- * position/duration, not amplitude samples) — both follow the design's own synthetic approach.
- *
- * Colors stay on the ink × acid `AppTheme` roles (no warm literals, no `isSystemInDarkTheme`),
- * matching the Vault-list decision to render against the real theme: dark mode reads like the mock,
- * light mode follows the theme. Always-dark, if wanted, is a follow-up theming choice.
+ * Layout: the three facts a Vault audio carries — collection, date, name — are grouped in the top
+ * half; the audio's real waveform sits in the bottom half; the transport (back-to-start + play)
+ * pins to the very bottom. Colors stay on the always-dark [ImmersiveListenTheme] (status-bar icon
+ * legibility + design intent). The Claude Design mock additionally shows a polaroid, a caption and
+ * a subtitle; the Vault stores none of those, so they are omitted.
  */
 @Composable
 internal fun ImmersiveListenHost(
@@ -113,7 +108,7 @@ internal fun ImmersiveListenHost(
         // still honours back instead of flashing the Vault list behind it.
         ImmersiveBackdrop(modifier = Modifier.predictiveBackTransition(onBack = onBack)) {
             Column(modifier = Modifier.fillMaxSize().safeDrawingPadding()) {
-                ImmersiveTopBar(collectionLabel = "", onBack = onBack)
+                ImmersiveTopBar(onBack = onBack)
             }
         }
         return
@@ -145,12 +140,14 @@ internal fun ImmersiveListenHost(
         progressFraction = fraction,
         peaks = peaks,
         onPlayPause = { viewModel.playOrStop(sound.copy(isPlaying = isThisPlaying)) },
+        onRestart = { viewModel.seekTo(0, soundId) },
+        onSeek = { f -> durationMs?.let { d -> viewModel.seekTo((f * d).toInt(), soundId) } },
         onBack = onBack,
     )
 }
 
 /**
- * Resolves the private-collection label for the top bar. Prefers the active Vault filter chip when
+ * Resolves the private-collection label for the header. Prefers the active Vault filter chip when
  * the audio belongs to it; otherwise the first private collection the audio is in (an audio can be
  * tagged to several). System "Baúl" resolves to its locale-aware label.
  */
@@ -170,6 +167,7 @@ internal fun resolveListenCollectionLabel(
 }
 
 @Composable
+@Suppress("LongParameterList")
 internal fun ImmersiveListenScreen(
     title: String,
     collectionLabel: String,
@@ -180,6 +178,8 @@ internal fun ImmersiveListenScreen(
     progressFraction: Float,
     peaks: FloatArray?,
     onPlayPause: () -> Unit,
+    onRestart: () -> Unit,
+    onSeek: (Float) -> Unit,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -187,37 +187,42 @@ internal fun ImmersiveListenScreen(
         // safeDrawingPadding keeps the content clear of the status/navigation bars while the
         // backdrop gradient still bleeds full-screen behind them (edge-to-edge).
         Column(modifier = Modifier.fillMaxSize().safeDrawingPadding()) {
-            ImmersiveTopBar(collectionLabel = collectionLabel, onBack = onBack)
-            // `heightIn(min = maxHeight)` + `verticalScroll` keeps the spread layout (hero up top,
-            // transport pinned low) when the content fits, but lets it scroll instead of clipping on
-            // short screens or at large accessibility font scales.
-            BoxWithConstraints(
+            ImmersiveTopBar(onBack = onBack)
+            Column(
                 modifier =
                     Modifier
                         .weight(1f)
-                        .fillMaxWidth(),
+                        .fillMaxWidth()
+                        .padding(horizontal = Spacing.XL),
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                Column(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .heightIn(min = maxHeight)
-                            .verticalScroll(rememberScrollState())
-                            .padding(horizontal = Spacing.XL, vertical = Spacing.LG),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.SpaceBetween,
-                ) {
-                    MemoryTile()
-                    ImmersiveTitleBlock(title = title, dateLabel = dateLabel)
-                    ImmersiveTransport(
-                        positionMs = positionMs,
-                        durationMs = durationMs,
-                        isPlaying = isPlaying,
-                        progressFraction = progressFraction,
-                        peaks = peaks,
-                        onPlayPause = onPlayPause,
-                    )
+                // Top half: collection · date · name, grouped close together.
+                Box(modifier = Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
+                    ImmersiveFields(collectionLabel = collectionLabel, dateLabel = dateLabel, title = title)
                 }
+                // Bottom half: the real waveform (scrubbable) + the position / duration readout.
+                Box(modifier = Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        ImmersiveWaveform(
+                            progressFraction = progressFraction,
+                            peaks = peaks,
+                            onSeek = onSeek,
+                            modifier = Modifier.fillMaxWidth().height(WAVEFORM_HEIGHT),
+                        )
+                        Spacer(modifier = Modifier.height(Spacing.SM))
+                        TimeReadout(positionMs = positionMs, durationMs = durationMs)
+                    }
+                }
+                ImmersiveControls(isPlaying = isPlaying, onRestart = onRestart, onPlayPause = onPlayPause)
+                Spacer(modifier = Modifier.height(Spacing.MD))
+                Text(
+                    text = stringResource(R.string.app_vault_immersive_listen_only_label).uppercase(),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    letterSpacing = EYEBROW_LETTER_SPACING,
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(modifier = Modifier.height(Spacing.LG))
             }
         }
     }
@@ -258,10 +263,7 @@ private fun ImmersiveBackdrop(
 }
 
 @Composable
-private fun ImmersiveTopBar(
-    collectionLabel: String,
-    onBack: () -> Unit,
-) {
+private fun ImmersiveTopBar(onBack: () -> Unit) {
     Row(
         modifier =
             Modifier
@@ -277,58 +279,38 @@ private fun ImmersiveTopBar(
                 tint = MaterialTheme.colorScheme.onBackground,
             )
         }
-        Column(
-            modifier = Modifier.weight(1f),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
+        Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
             Text(
                 text = stringResource(R.string.app_vault_immersive_mode_label).uppercase(),
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.primary,
                 letterSpacing = EYEBROW_LETTER_SPACING,
             )
-            if (collectionLabel.isNotEmpty()) {
-                Text(
-                    text = collectionLabel.uppercase(),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    letterSpacing = EYEBROW_LETTER_SPACING,
-                )
-            }
         }
-        // Balances the back button so the title column stays centered. No overflow menu: listen
-        // mode is listen-only and exposes no per-audio actions (share is forbidden in the Vault).
+        // Balances the back button so the title stays centered. No overflow menu: listen mode is
+        // listen-only and exposes no per-audio actions (share is forbidden in the Vault).
         Spacer(modifier = Modifier.width(TOP_BAR_ICON_SLOT))
     }
 }
 
 @Composable
-private fun MemoryTile() {
-    // Decorative hero standing in for the mock's polaroid. The Vault stores no images, so this is a
-    // palette gradient, not a (fake) photo — and carries no caption. Purely decorative => no
-    // contentDescription.
-    val accent = MaterialTheme.colorScheme.primary
-    val surface = MaterialTheme.colorScheme.surfaceVariant
-    val tileBrush =
-        remember(accent, surface) {
-            Brush.linearGradient(listOf(accent.copy(alpha = TILE_ACCENT_ALPHA), surface))
-        }
-    Box(
-        modifier =
-            Modifier
-                .rotate(MEMORY_TILE_TILT)
-                .size(MEMORY_TILE_SIZE)
-                .clip(RoundedCornerShape(Spacing.MD))
-                .background(tileBrush),
-    )
-}
-
-@Composable
-private fun ImmersiveTitleBlock(
-    title: String,
+private fun ImmersiveFields(
+    collectionLabel: String,
     dateLabel: String?,
+    title: String,
 ) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(Spacing.SM),
+    ) {
+        if (collectionLabel.isNotEmpty()) {
+            Text(
+                text = collectionLabel.uppercase(),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                letterSpacing = EYEBROW_LETTER_SPACING,
+            )
+        }
         if (dateLabel != null) {
             Text(
                 text = dateLabel,
@@ -336,7 +318,6 @@ private fun ImmersiveTitleBlock(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 letterSpacing = EYEBROW_LETTER_SPACING,
             )
-            Spacer(modifier = Modifier.height(Spacing.SM))
         }
         Text(
             text = title,
@@ -349,40 +330,47 @@ private fun ImmersiveTitleBlock(
 }
 
 @Composable
-private fun ImmersiveTransport(
+private fun TimeReadout(
     positionMs: Int,
     durationMs: Int?,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = formatDuration(positionMs),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = formatDuration(durationMs ?: 0),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun ImmersiveControls(
     isPlaying: Boolean,
-    progressFraction: Float,
-    peaks: FloatArray?,
+    onRestart: () -> Unit,
     onPlayPause: () -> Unit,
 ) {
-    Column(
+    Row(
         modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(Spacing.LG),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.XL, Alignment.CenterHorizontally),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        ImmersiveWaveform(
-            progressFraction = progressFraction,
-            peaks = peaks,
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .height(WAVEFORM_HEIGHT),
-        )
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Text(
-                text = formatDuration(positionMs),
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Text(
-                text = formatDuration(durationMs ?: 0),
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+        // Skip-to-start on the LEFT — the universal transport convention (music/podcast players),
+        // not a square "stop" on the right. Secondary action: plain icon button, play stays the
+        // prominent filled control.
+        IconButton(onClick = onRestart, modifier = Modifier.size(RESTART_BUTTON_SIZE)) {
+            Icon(
+                painter = rememberVectorPainter(AppIcons.SkipPrevious),
+                contentDescription = stringResource(R.string.app_vault_immersive_restart),
+                tint = MaterialTheme.colorScheme.onBackground,
+                modifier = Modifier.size(RESTART_ICON_SIZE),
             )
         }
         FilledIconButton(
@@ -405,13 +393,6 @@ private fun ImmersiveTransport(
                 modifier = Modifier.size(TRANSPORT_ICON_SIZE),
             )
         }
-        Text(
-            text = stringResource(R.string.app_vault_immersive_listen_only_label).uppercase(),
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            letterSpacing = EYEBROW_LETTER_SPACING,
-            textAlign = TextAlign.Center,
-        )
     }
 }
 
@@ -419,15 +400,43 @@ private fun ImmersiveTransport(
 private fun ImmersiveWaveform(
     progressFraction: Float,
     peaks: FloatArray?,
+    onSeek: (Float) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     // Real amplitude envelope from [WaveformExtractor]. Until it arrives (or if decoding failed)
-    // `peaks` is null and we draw a neutral flat baseline — never a fake-looking wave. No animation,
-    // so the screen stays idle for `waitForIdle()`-based tests. Played bars use the accent role.
+    // `peaks` is null and we draw a neutral flat baseline — never a fake-looking wave. Dragging
+    // horizontally scrubs: the fill follows the finger and `onSeek` fires the fraction on release.
     val playedColor = MaterialTheme.colorScheme.primary
     val unplayedColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = WAVEFORM_UNPLAYED_ALPHA)
     val barCount = peaks?.size ?: WAVEFORM_BARS
-    Canvas(modifier = modifier) {
+    val scrubberLabel = stringResource(R.string.app_vault_immersive_waveform)
+    var scrub by remember { mutableStateOf<Float?>(null) }
+    val displayFraction = (scrub ?: progressFraction).coerceIn(0f, 1f)
+    Canvas(
+        modifier =
+            modifier
+                .semantics {
+                    contentDescription = scrubberLabel
+                    progressBarRangeInfo = ProgressBarRangeInfo(displayFraction, 0f..1f)
+                    setProgress { target ->
+                        onSeek(target.coerceIn(0f, 1f))
+                        true
+                    }
+                }.pointerInput(Unit) {
+                    detectHorizontalDragGestures(
+                        onDragStart = { offset -> scrub = (offset.x / size.width.toFloat()).coerceIn(0f, 1f) },
+                        onHorizontalDrag = { change, _ ->
+                            change.consume()
+                            scrub = (change.position.x / size.width.toFloat()).coerceIn(0f, 1f)
+                        },
+                        onDragEnd = {
+                            scrub?.let(onSeek)
+                            scrub = null
+                        },
+                        onDragCancel = { scrub = null },
+                    )
+                },
+    ) {
         val slot = size.width / barCount
         val barWidth = slot * WAVEFORM_BAR_FILL
         val centerY = size.height / 2f
@@ -435,7 +444,7 @@ private fun ImmersiveWaveform(
         for (i in 0 until barCount) {
             val amplitude = peaks?.getOrNull(i) ?: WAVEFORM_PLACEHOLDER_FRACTION
             val barHeight = amplitude.coerceIn(WAVEFORM_MIN_FRACTION, 1f) * size.height
-            val played = i.toFloat() / barCount < progressFraction
+            val played = i.toFloat() / barCount < displayFraction
             val x = i * slot + (slot - barWidth) / 2f
             drawRoundRect(
                 color = if (played) playedColor else unplayedColor,
@@ -453,14 +462,13 @@ private const val WAVEFORM_BAR_FILL = 0.45f
 private const val WAVEFORM_MIN_FRACTION = 0.06f
 private const val WAVEFORM_PLACEHOLDER_FRACTION = 0.12f
 private const val WAVEFORM_UNPLAYED_ALPHA = 0.30f
-private val WAVEFORM_HEIGHT = 96.dp
-private val MEMORY_TILE_SIZE = 188.dp
-private const val MEMORY_TILE_TILT = -3f
-private const val TILE_ACCENT_ALPHA = 0.55f
+private val WAVEFORM_HEIGHT = 120.dp
 private val TOP_BAR_HEIGHT = 64.dp
 private val TOP_BAR_ICON_SLOT = 48.dp
 private val TRANSPORT_BUTTON_SIZE = 80.dp
 private val TRANSPORT_ICON_SIZE = 36.dp
+private val RESTART_BUTTON_SIZE = 56.dp
+private val RESTART_ICON_SIZE = 30.dp
 private val EYEBROW_LETTER_SPACING = 2.sp
 
 // Radial-glow stops + alphas — mirror VaultEmptyState's emotional wash (low on purpose).

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreen.kt
@@ -1,0 +1,444 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.vault
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
+import com.github.barriosnahuel.vossosunboton.model.Collection
+import com.github.barriosnahuel.vossosunboton.ui.AppIcons
+import com.github.barriosnahuel.vossosunboton.ui.home.SoundsViewModel
+import com.github.barriosnahuel.vossosunboton.ui.home.formatDuration
+import com.github.barriosnahuel.vossosunboton.ui.home.formatFullDate
+import com.github.barriosnahuel.vossosunboton.ui.predictiveBackTransition
+import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
+import kotlin.math.sin
+
+/**
+ * Listen mode — the full-screen, listen-only player for a single Vault audio. Reached by tapping
+ * play on any audio in the Vault tab (`CollectionPlaybackUI.IMMERSIVE`); the Vault list itself is
+ * unchanged (same `SoundsList` cards as My Sounds).
+ *
+ * Renders only the four facts a Vault audio actually carries — name, date, duration and the private
+ * collection it belongs to. The Claude Design mock additionally shows a hand-written caption, an
+ * event eyebrow and a free-text subtitle; the Vault stores none of those, so they are deliberately
+ * omitted (mirroring `VaultEmptyState`, which dropped the polaroid for the same reason). The hero
+ * photo is replaced by a decorative gradient tile, and the waveform is synthetic (the player exposes
+ * position/duration, not amplitude samples) — both follow the design's own synthetic approach.
+ *
+ * Colors stay on the ink × acid `AppTheme` roles (no warm literals, no `isSystemInDarkTheme`),
+ * matching the Vault-list decision to render against the real theme: dark mode reads like the mock,
+ * light mode follows the theme. Always-dark, if wanted, is a follow-up theming choice.
+ */
+@Composable
+internal fun ImmersiveListenHost(
+    viewModel: SoundsViewModel,
+    soundId: String,
+    onBack: () -> Unit,
+) {
+    val context = LocalContext.current
+    val tracker = remember(context) { AnalyticsTrackerProvider.get(context.applicationContext) }
+    LaunchedEffect(Unit) { tracker.logScreen(CanonicalScreenName.VAULT_LISTEN) }
+
+    val library by viewModel.library.collectAsStateWithLifecycle()
+    val playingSound by viewModel.playingSound.collectAsStateWithLifecycle()
+    val playbackProgress by viewModel.playbackProgress.collectAsStateWithLifecycle()
+    val pausedProgress by viewModel.pausedProgress.collectAsStateWithLifecycle()
+    val durations by viewModel.soundDurations.collectAsStateWithLifecycle()
+    val collections by viewModel.collections.collectAsStateWithLifecycle()
+    val collectionsByAudio by viewModel.audioCollectionsIndex.collectAsStateWithLifecycle()
+    val activeFilter by viewModel.activeVaultFilter.collectAsStateWithLifecycle()
+    val systemLabel = stringResource(R.string.app_vault_baul_name)
+
+    val sound = library.firstOrNull { it.id == soundId }
+
+    // The audio left the library (deleted from another surface while listen mode was open) — close.
+    LaunchedEffect(library, soundId) {
+        if (library.isNotEmpty() && library.none { it.id == soundId }) onBack()
+    }
+
+    if (sound == null) {
+        // Library not hydrated yet (cold start / process recreate). Hold an opaque backdrop that
+        // still honours back instead of flashing the Vault list behind it.
+        ImmersiveBackdrop(modifier = Modifier.predictiveBackTransition(onBack = onBack)) {
+            Column { ImmersiveTopBar(collectionLabel = "", onBack = onBack) }
+        }
+        return
+    }
+
+    val isThisPlaying = playingSound?.id == soundId
+    val paused = pausedProgress[soundId]
+    val durationMs =
+        if (isThisPlaying) playbackProgress?.durationMs else paused?.durationMs ?: durations[soundId]
+    val positionMs = if (isThisPlaying) playbackProgress?.positionMs ?: 0 else paused?.positionMs ?: 0
+    val fraction =
+        (if (isThisPlaying) playbackProgress?.fraction ?: 0f else paused?.fraction ?: 0f).coerceIn(0f, 1f)
+
+    ImmersiveListenScreen(
+        title = sound.name,
+        collectionLabel = resolveListenCollectionLabel(soundId, collections, collectionsByAudio, activeFilter, systemLabel),
+        dateLabel = sound.dateAdded?.let { formatFullDate(it) },
+        positionMs = positionMs,
+        durationMs = durationMs,
+        isPlaying = isThisPlaying,
+        progressFraction = fraction,
+        onPlayPause = { viewModel.playOrStop(sound.copy(isPlaying = isThisPlaying)) },
+        onBack = onBack,
+    )
+}
+
+/**
+ * Resolves the private-collection label for the top bar. Prefers the active Vault filter chip when
+ * the audio belongs to it; otherwise the first private collection the audio is in (an audio can be
+ * tagged to several). System "Baúl" resolves to its locale-aware label.
+ */
+internal fun resolveListenCollectionLabel(
+    soundId: String,
+    collections: List<Collection>,
+    collectionsByAudio: Map<String, List<String>>,
+    activeFilter: String?,
+    systemLabel: String,
+): String {
+    val memberIds = collectionsByAudio[soundId].orEmpty().toSet()
+    val privateMemberships = collections.filter { it.isPrivate && it.id in memberIds }
+    val chosen =
+        activeFilter?.let { filter -> privateMemberships.firstOrNull { it.id == filter } }
+            ?: privateMemberships.firstOrNull()
+    return chosen?.let { if (it.isSystem) systemLabel else it.name }.orEmpty()
+}
+
+@Composable
+internal fun ImmersiveListenScreen(
+    title: String,
+    collectionLabel: String,
+    dateLabel: String?,
+    positionMs: Int,
+    durationMs: Int?,
+    isPlaying: Boolean,
+    progressFraction: Float,
+    onPlayPause: () -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ImmersiveBackdrop(modifier = modifier.predictiveBackTransition(onBack = onBack)) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            ImmersiveTopBar(collectionLabel = collectionLabel, onBack = onBack)
+            // `heightIn(min = maxHeight)` + `verticalScroll` keeps the spread layout (hero up top,
+            // transport pinned low) when the content fits, but lets it scroll instead of clipping on
+            // short screens or at large accessibility font scales.
+            BoxWithConstraints(
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .fillMaxWidth(),
+            ) {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = maxHeight)
+                            .verticalScroll(rememberScrollState())
+                            .padding(horizontal = Spacing.XL, vertical = Spacing.LG),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    MemoryTile()
+                    ImmersiveTitleBlock(title = title, dateLabel = dateLabel)
+                    ImmersiveTransport(
+                        positionMs = positionMs,
+                        durationMs = durationMs,
+                        isPlaying = isPlaying,
+                        progressFraction = progressFraction,
+                        onPlayPause = onPlayPause,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ImmersiveBackdrop(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    // Warm-mood wash adapted to the palette: the accent role at low alpha gives an emotional glow
+    // without a one-off color token. Same approach as VaultEmptyState; theme-aware in both modes.
+    val accent = MaterialTheme.colorScheme.primary
+    val backgroundColor = MaterialTheme.colorScheme.background
+    val wash =
+        remember(accent, backgroundColor) {
+            Brush.radialGradient(
+                colorStops =
+                    arrayOf(
+                        GLOW_STOP_CENTER to accent.copy(alpha = GLOW_CENTER_ALPHA),
+                        GLOW_STOP_MID to accent.copy(alpha = GLOW_MID_ALPHA),
+                        GLOW_STOP_EDGE to backgroundColor,
+                    ),
+            )
+        }
+    Box(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .background(backgroundColor)
+                .background(wash),
+    ) {
+        content()
+    }
+}
+
+@Composable
+private fun ImmersiveTopBar(
+    collectionLabel: String,
+    onBack: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .height(TOP_BAR_HEIGHT)
+                .padding(horizontal = Spacing.SM),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(
+                painter = painterResource(R.drawable.app_ic_arrow_back),
+                contentDescription = stringResource(R.string.app_vault_immersive_back),
+                tint = MaterialTheme.colorScheme.onBackground,
+            )
+        }
+        Column(
+            modifier = Modifier.weight(1f),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = stringResource(R.string.app_vault_immersive_mode_label).uppercase(),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+                letterSpacing = EYEBROW_LETTER_SPACING,
+            )
+            if (collectionLabel.isNotEmpty()) {
+                Text(
+                    text = collectionLabel.uppercase(),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    letterSpacing = EYEBROW_LETTER_SPACING,
+                )
+            }
+        }
+        // Balances the back button so the title column stays centered. No overflow menu: listen
+        // mode is listen-only and exposes no per-audio actions (share is forbidden in the Vault).
+        Spacer(modifier = Modifier.width(TOP_BAR_ICON_SLOT))
+    }
+}
+
+@Composable
+private fun MemoryTile() {
+    // Decorative hero standing in for the mock's polaroid. The Vault stores no images, so this is a
+    // palette gradient, not a (fake) photo — and carries no caption. Purely decorative => no
+    // contentDescription.
+    val accent = MaterialTheme.colorScheme.primary
+    val surface = MaterialTheme.colorScheme.surfaceVariant
+    val tileBrush =
+        remember(accent, surface) {
+            Brush.linearGradient(listOf(accent.copy(alpha = TILE_ACCENT_ALPHA), surface))
+        }
+    Box(
+        modifier =
+            Modifier
+                .rotate(MEMORY_TILE_TILT)
+                .size(MEMORY_TILE_SIZE)
+                .clip(RoundedCornerShape(Spacing.MD))
+                .background(tileBrush),
+    )
+}
+
+@Composable
+private fun ImmersiveTitleBlock(
+    title: String,
+    dateLabel: String?,
+) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        if (dateLabel != null) {
+            Text(
+                text = dateLabel,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                letterSpacing = EYEBROW_LETTER_SPACING,
+            )
+            Spacer(modifier = Modifier.height(Spacing.SM))
+        }
+        Text(
+            text = title,
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onBackground,
+            fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Composable
+private fun ImmersiveTransport(
+    positionMs: Int,
+    durationMs: Int?,
+    isPlaying: Boolean,
+    progressFraction: Float,
+    onPlayPause: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(Spacing.LG),
+    ) {
+        ImmersiveWaveform(
+            progressFraction = progressFraction,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(WAVEFORM_HEIGHT),
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = formatDuration(positionMs),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = formatDuration(durationMs ?: 0),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        FilledIconButton(
+            onClick = onPlayPause,
+            modifier = Modifier.size(TRANSPORT_BUTTON_SIZE),
+            colors =
+                IconButtonDefaults.filledIconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                ),
+        ) {
+            Icon(
+                painter =
+                    if (isPlaying) {
+                        rememberVectorPainter(AppIcons.Pause)
+                    } else {
+                        painterResource(R.drawable.app_ic_play_arrow)
+                    },
+                contentDescription = stringResource(if (isPlaying) R.string.app_pause else R.string.app_play),
+                modifier = Modifier.size(TRANSPORT_ICON_SIZE),
+            )
+        }
+        Text(
+            text = stringResource(R.string.app_vault_immersive_listen_only_label).uppercase(),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            letterSpacing = EYEBROW_LETTER_SPACING,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Composable
+@Suppress("MagicNumber")
+private fun ImmersiveWaveform(
+    progressFraction: Float,
+    modifier: Modifier = Modifier,
+) {
+    // Synthetic, deterministic bars: the player exposes position/duration, not amplitude samples,
+    // so (like the mock) heights come from a fixed sin seed. No animation — keeps the screen idle
+    // for `waitForIdle()`-based tests. Played portion uses the accent role; the rest is muted.
+    val playedColor = MaterialTheme.colorScheme.primary
+    val unplayedColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.30f)
+    Canvas(modifier = modifier) {
+        val slot = size.width / WAVEFORM_BARS
+        val barWidth = slot * WAVEFORM_BAR_FILL
+        val centerY = size.height / 2f
+        val corner = CornerRadius(barWidth / 2f, barWidth / 2f)
+        for (i in 0 until WAVEFORM_BARS) {
+            val seed = sin(i * 0.7) * 0.4 + sin(i * 0.23) * 0.35 + 0.5
+            val barHeight = seed.coerceIn(WAVEFORM_MIN_FRACTION.toDouble(), 1.0).toFloat() * size.height
+            val played = i.toFloat() / WAVEFORM_BARS < progressFraction
+            val x = i * slot + (slot - barWidth) / 2f
+            drawRoundRect(
+                color = if (played) playedColor else unplayedColor,
+                topLeft = Offset(x, centerY - barHeight / 2f),
+                size = Size(barWidth, barHeight),
+                cornerRadius = corner,
+            )
+        }
+    }
+}
+
+private const val WAVEFORM_BARS = 56
+private const val WAVEFORM_BAR_FILL = 0.45f
+private const val WAVEFORM_MIN_FRACTION = 0.10f
+private val WAVEFORM_HEIGHT = 96.dp
+private val MEMORY_TILE_SIZE = 188.dp
+private const val MEMORY_TILE_TILT = -3f
+private const val TILE_ACCENT_ALPHA = 0.55f
+private val TOP_BAR_HEIGHT = 64.dp
+private val TOP_BAR_ICON_SLOT = 48.dp
+private val TRANSPORT_BUTTON_SIZE = 80.dp
+private val TRANSPORT_ICON_SIZE = 36.dp
+private val EYEBROW_LETTER_SPACING = 2.sp
+
+// Radial-glow stops + alphas — mirror VaultEmptyState's emotional wash (low on purpose).
+private const val GLOW_CENTER_ALPHA = 0.16f
+private const val GLOW_MID_ALPHA = 0.04f
+private const val GLOW_STOP_CENTER = 0.0f
+private const val GLOW_STOP_MID = 0.55f
+private const val GLOW_STOP_EDGE = 1.0f

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreen.kt
@@ -214,14 +214,6 @@ internal fun ImmersiveListenScreen(
                     }
                 }
                 ImmersiveControls(isPlaying = isPlaying, onRestart = onRestart, onPlayPause = onPlayPause)
-                Spacer(modifier = Modifier.height(Spacing.MD))
-                Text(
-                    text = stringResource(R.string.app_vault_immersive_listen_only_label).uppercase(),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    letterSpacing = EYEBROW_LETTER_SPACING,
-                    textAlign = TextAlign.Center,
-                )
                 Spacer(modifier = Modifier.height(Spacing.LG))
             }
         }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreen.kt
@@ -359,7 +359,7 @@ private fun ImmersiveControls(
         // prominent filled control.
         IconButton(onClick = onRestart, modifier = Modifier.size(RESTART_BUTTON_SIZE)) {
             Icon(
-                painter = rememberVectorPainter(AppIcons.SkipPrevious),
+                painter = painterResource(R.drawable.app_ic_skip_previous),
                 contentDescription = stringResource(R.string.app_vault_immersive_restart),
                 tint = MaterialTheme.colorScheme.onBackground,
                 modifier = Modifier.size(RESTART_ICON_SIZE),

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultScreen.kt
@@ -56,6 +56,7 @@ import com.github.barriosnahuel.vossosunboton.feature.vault.security.ScreenLockS
 import com.github.barriosnahuel.vossosunboton.feature.vault.security.VaultSessionState
 import com.github.barriosnahuel.vossosunboton.model.Collection
 import com.github.barriosnahuel.vossosunboton.model.CollectionAccess
+import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.ui.AppIcons
 import com.github.barriosnahuel.vossosunboton.ui.home.LandingActivity
 import com.github.barriosnahuel.vossosunboton.ui.home.SoundsList
@@ -81,6 +82,7 @@ fun VaultScreen(
     viewModel: SoundsViewModel,
     listState: LazyListState,
     onActiveFilterEditClick: (String) -> Unit,
+    onImmersivePlay: (Sound) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -146,6 +148,7 @@ fun VaultScreen(
                     viewModel = viewModel,
                     listState = listState,
                     onActiveFilterEditClick = onActiveFilterEditClick,
+                    onImmersivePlay = onImmersivePlay,
                 )
         }
     }
@@ -291,6 +294,7 @@ private fun VaultBody(
     viewModel: SoundsViewModel,
     listState: LazyListState,
     onActiveFilterEditClick: (String) -> Unit,
+    onImmersivePlay: (Sound) -> Unit,
 ) {
     val vaultAudios by viewModel.vaultAudios.collectAsState()
     val activeFilter by viewModel.activeVaultFilter.collectAsState()
@@ -347,7 +351,9 @@ private fun VaultBody(
                     // can scroll fully into view instead of sitting under the FAB. Default FAB
                     // height (56dp) + Spacing.LG margin + Spacing.MD breathing room.
                     bottomContentPadding = VAULT_FAB_CLEARANCE,
-                    onPlayClick = { sound -> viewModel.playOrStop(sound) },
+                    // Vault audios use the immersive listen-mode player (CollectionPlaybackUI.IMMERSIVE)
+                    // instead of the inline card transport: tapping play opens the full-screen screen.
+                    onPlayClick = { sound -> onImmersivePlay(sound) },
                     onSeek = { positionMs -> viewModel.seekTo(positionMs) },
                     onShareClick = { sound -> viewModel.share(sound) },
                     onDelete = { sound -> viewModel.deleteSound(sound) },

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/WaveformExtractor.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/WaveformExtractor.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.vault
+
+import android.content.Context
+import android.media.MediaCodec
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
+import com.github.barriosnahuel.vossosunboton.commons.file.getFile
+import com.github.barriosnahuel.vossosunboton.model.Sound
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+import java.nio.ByteOrder
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.coroutines.coroutineContext
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Real amplitude-envelope waveform for a [Sound] — decodes the audio to PCM and folds it into
+ * [barCount] normalized peaks (0..1). This is genuine audio data, not a synthetic shape; the
+ * mock's waveform is the only synthetic part we deliberately do NOT reproduce.
+ *
+ * A live [android.media.audiofx.Visualizer] would give a reactive waveform but requires
+ * `RECORD_AUDIO` — a non-starter for a privacy-first Vault — so we extract a static envelope of the
+ * whole clip instead (which is also what the design shows: a fixed shape with a progress fill).
+ *
+ * Extraction is off the main thread, cached per [Sound.id] for the process lifetime (each result is
+ * a tiny `FloatArray`), and returns `null` on any failure so the UI falls back to a neutral
+ * placeholder rather than a fake-looking wave.
+ */
+internal object WaveformExtractor {
+    private val cache = ConcurrentHashMap<String, FloatArray>()
+
+    suspend fun extract(
+        context: Context,
+        sound: Sound,
+        barCount: Int,
+        dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    ): FloatArray? {
+        cache[sound.id]?.let { return it }
+        val peaks =
+            withContext(dispatcher) {
+                runCatching { decodeEnvelope(context, sound, barCount) }
+                    .onFailure { error ->
+                        if (error is CancellationException) throw error
+                        Tracker.log("immersive.waveform_fail=${error.javaClass.simpleName}")
+                        Tracker.track(RuntimeException("Vault waveform extraction failed", error))
+                    }.getOrNull()
+            }
+        return peaks?.also { cache[sound.id] = it }
+    }
+
+    /** Visible for the cold-start / no-data fallback path and tests. */
+    fun cached(soundId: String): FloatArray? = cache[soundId]
+
+    private suspend fun decodeEnvelope(
+        context: Context,
+        sound: Sound,
+        barCount: Int,
+    ): FloatArray {
+        val extractor = MediaExtractor()
+        try {
+            if (sound.file != null) {
+                extractor.setDataSource(getFile(context, sound.file!!).path)
+            } else {
+                context.resources.openRawResourceFd(sound.rawRes).use { afd ->
+                    extractor.setDataSource(afd.fileDescriptor, afd.startOffset, afd.declaredLength)
+                }
+            }
+            val trackIndex = audioTrackIndex(extractor)
+            require(trackIndex >= 0) { "no audio track" }
+            extractor.selectTrack(trackIndex)
+            val inputFormat = extractor.getTrackFormat(trackIndex)
+            val mime = inputFormat.getString(MediaFormat.KEY_MIME) ?: error("no mime")
+
+            val sampleRate = inputFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+            val channels = inputFormat.runCatching { getInteger(MediaFormat.KEY_CHANNEL_COUNT) }.getOrDefault(1)
+            val durationUs = inputFormat.runCatching { getLong(MediaFormat.KEY_DURATION) }.getOrDefault(0L)
+            val estimatedSamples = (durationUs / MICROS_PER_SECOND.toDouble() * sampleRate * channels).toLong()
+            val accumulator = PeakAccumulator(barCount, estimatedSamples)
+
+            val codec = MediaCodec.createDecoderByType(mime)
+            try {
+                codec.configure(inputFormat, null, null, 0)
+                codec.start()
+                decodeLoop(codec, extractor, accumulator)
+            } finally {
+                runCatching { codec.stop() }
+                codec.release()
+            }
+            return accumulator.result()
+        } finally {
+            extractor.release()
+        }
+    }
+
+    private suspend fun decodeLoop(
+        codec: MediaCodec,
+        extractor: MediaExtractor,
+        accumulator: PeakAccumulator,
+    ) {
+        val bufferInfo = MediaCodec.BufferInfo()
+        var inputDone = false
+        var outputDone = false
+        while (!outputDone) {
+            coroutineContext.ensureActive()
+            if (!inputDone) inputDone = feedInput(codec, extractor)
+            outputDone = drainOutput(codec, bufferInfo, accumulator)
+        }
+    }
+
+    /** Queues one input sample (or end-of-stream). Returns true once the stream is exhausted. */
+    private fun feedInput(
+        codec: MediaCodec,
+        extractor: MediaExtractor,
+    ): Boolean {
+        val inIndex = codec.dequeueInputBuffer(DEQUEUE_TIMEOUT_US)
+        if (inIndex < 0) return false
+        val size = extractor.readSampleData(codec.getInputBuffer(inIndex)!!, 0)
+        val endOfStream = size < 0
+        if (endOfStream) {
+            codec.queueInputBuffer(inIndex, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM)
+        } else {
+            codec.queueInputBuffer(inIndex, 0, size, extractor.sampleTime, 0)
+            extractor.advance()
+        }
+        return endOfStream
+    }
+
+    /** Folds one decoded PCM buffer into [accumulator]. Returns true on the end-of-stream buffer. */
+    private fun drainOutput(
+        codec: MediaCodec,
+        bufferInfo: MediaCodec.BufferInfo,
+        accumulator: PeakAccumulator,
+    ): Boolean {
+        val outIndex = codec.dequeueOutputBuffer(bufferInfo, DEQUEUE_TIMEOUT_US)
+        if (outIndex < 0) return false
+        if (bufferInfo.size > 0) {
+            val outBuffer =
+                codec.getOutputBuffer(outIndex)!!.apply {
+                    position(bufferInfo.offset)
+                    limit(bufferInfo.offset + bufferInfo.size)
+                }
+            val shorts = outBuffer.order(ByteOrder.nativeOrder()).asShortBuffer()
+            while (shorts.hasRemaining()) accumulator.add(shorts.get())
+        }
+        codec.releaseOutputBuffer(outIndex, false)
+        return bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0
+    }
+
+    private fun audioTrackIndex(extractor: MediaExtractor): Int {
+        for (i in 0 until extractor.trackCount) {
+            val mime = extractor.getTrackFormat(i).getString(MediaFormat.KEY_MIME).orEmpty()
+            if (mime.startsWith("audio/")) return i
+        }
+        return -1
+    }
+
+    private const val DEQUEUE_TIMEOUT_US = 10_000L
+    private const val MICROS_PER_SECOND = 1_000_000L
+}
+
+/**
+ * Folds an interleaved 16-bit PCM stream into [barCount] peak buckets, then normalizes so the
+ * loudest bucket is 1.0. Pure (no Android types) so the bucketing + normalization is unit-tested
+ * without decoding real audio. Each sample lands in a bucket by its position in the estimated
+ * total; a wrong estimate only distorts the tail slightly (extra samples clamp into the last bucket).
+ */
+internal class PeakAccumulator(
+    private val barCount: Int,
+    estimatedTotalSamples: Long,
+) {
+    init {
+        require(barCount > 0) { "barCount must be positive" }
+    }
+
+    private val total = max(1L, estimatedTotalSamples)
+    private val peaks = FloatArray(barCount)
+    private var index = 0L
+
+    fun add(sample: Short) {
+        val bucket = min(barCount - 1L, index * barCount / total).toInt()
+        val magnitude = abs(sample.toInt()) / SHORT_FULL_SCALE
+        if (magnitude > peaks[bucket]) peaks[bucket] = magnitude
+        index++
+    }
+
+    /** Normalized peaks in [MIN_BAR, 1]. Silent / empty input yields a flat [MIN_BAR] baseline. */
+    fun result(): FloatArray {
+        val loudest = peaks.maxOrNull() ?: 0f
+        if (loudest <= 0f) return FloatArray(barCount) { MIN_BAR }
+        return FloatArray(barCount) { i -> max(MIN_BAR, peaks[i] / loudest) }
+    }
+
+    private companion object {
+        const val SHORT_FULL_SCALE = 32_768f
+        const val MIN_BAR = 0.06f
+    }
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/AppIcons.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/AppIcons.kt
@@ -90,6 +90,34 @@ public object AppIcons {
             }.build()
     }
 
+    /**
+     * Material "skip_previous" (⏮): a left bar + a left-pointing triangle. Bundled like [Pause]/[Stop]
+     * because material-icons-extended isn't a dependency. Used as the "back to start" transport
+     * control in immersive listen mode.
+     */
+    val SkipPrevious: ImageVector by lazy {
+        ImageVector
+            .Builder(
+                name = "SkipPrevious",
+                defaultWidth = 24.dp,
+                defaultHeight = 24.dp,
+                viewportWidth = 24f,
+                viewportHeight = 24f,
+            ).apply {
+                path(fill = SolidColor(Color.Black)) {
+                    moveTo(6f, 6f)
+                    horizontalLineToRelative(2f)
+                    verticalLineToRelative(12f)
+                    horizontalLineToRelative(-2f)
+                    close()
+                    moveTo(18f, 6f)
+                    lineTo(9.5f, 12f)
+                    lineTo(18f, 18f)
+                    close()
+                }
+            }.build()
+    }
+
     val PushPin: ImageVector by lazy {
         ImageVector
             .Builder(

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/AppIcons.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/AppIcons.kt
@@ -90,34 +90,6 @@ public object AppIcons {
             }.build()
     }
 
-    /**
-     * Material "skip_previous" (⏮): a left bar + a left-pointing triangle. Bundled like [Pause]/[Stop]
-     * because material-icons-extended isn't a dependency. Used as the "back to start" transport
-     * control in immersive listen mode.
-     */
-    val SkipPrevious: ImageVector by lazy {
-        ImageVector
-            .Builder(
-                name = "SkipPrevious",
-                defaultWidth = 24.dp,
-                defaultHeight = 24.dp,
-                viewportWidth = 24f,
-                viewportHeight = 24f,
-            ).apply {
-                path(fill = SolidColor(Color.Black)) {
-                    moveTo(6f, 6f)
-                    horizontalLineToRelative(2f)
-                    verticalLineToRelative(12f)
-                    horizontalLineToRelative(-2f)
-                    close()
-                    moveTo(18f, 6f)
-                    lineTo(9.5f, 12f)
-                    lineTo(18f, 18f)
-                    close()
-                }
-            }.build()
-    }
-
     val PushPin: ImageVector by lazy {
         ImageVector
             .Builder(

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/DurationFormatter.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/DurationFormatter.kt
@@ -13,6 +13,7 @@ import com.github.barriosnahuel.vossosunboton.R
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 fun formatDuration(ms: Int): String {
@@ -53,6 +54,21 @@ fun formatRelativeDate(epochMs: Long): String {
         else -> SimpleDateFormat("d MMM", LocalLocale.current.platformLocale).format(Date(epochMs))
     }
 }
+
+/**
+ * Absolute "day month year" date for the immersive listen header — e.g. `24 DIC 2024` (es) /
+ * `24 DEC 2024` (en). Unlike [formatRelativeDate] (which collapses recent dates to "today" /
+ * "3 days ago") the listen mode always shows the full memory date, uppercased to read as a
+ * mono-style eyebrow above the title. Pure over an explicit [locale] so it is unit-testable
+ * without a Compose tree.
+ */
+fun fullDate(
+    epochMs: Long,
+    locale: Locale,
+): String = SimpleDateFormat("d MMM yyyy", locale).format(Date(epochMs)).uppercase(locale)
+
+@Composable
+fun formatFullDate(epochMs: Long): String = fullDate(epochMs, LocalLocale.current.platformLocale)
 
 internal const val RELATIVE_DATE_MAX_DAYS = 7L
 private const val SECONDS_PER_MINUTE = 60L

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -102,6 +102,10 @@ fun LandingScreen(viewModel: SoundsViewModel) {
     var manageRequest by rememberSaveable(stateSaver = ManageRequest.Saver) {
         mutableStateOf<ManageRequest?>(null)
     }
+    // Id of the Vault audio whose immersive listen-mode player is open, or null. Saveable so the
+    // overlay survives an Activity recreate (rotation, theme, system kill); the host re-resolves
+    // the Sound from `library` on the way back.
+    var immersiveListenSoundId by rememberSaveable { mutableStateOf<String?>(null) }
 
     LaunchedEffect(selectedTab, isAboutVisible, manageRequest, isSearchVisible) {
         val name =
@@ -119,7 +123,9 @@ fun LandingScreen(viewModel: SoundsViewModel) {
         }
     }
 
-    BackHandler(enabled = !isAboutVisible && manageRequest == null && tabBackStack.isNotEmpty()) {
+    BackHandler(
+        enabled = !isAboutVisible && manageRequest == null && immersiveListenSoundId == null && tabBackStack.isNotEmpty(),
+    ) {
         viewModel.selectTab(tabBackStack.removeAt(tabBackStack.lastIndex))
     }
 
@@ -150,7 +156,7 @@ fun LandingScreen(viewModel: SoundsViewModel) {
     // and UI tests neither reach nor double-match nodes hidden behind the opaque overlay (e.g. a
     // collection name shown both in the chip row and in the Manage list). Drawing is untouched, so
     // the gesture still reveals the live list visually.
-    val subScreenOpen = isAboutVisible || manageRequest != null
+    val subScreenOpen = isAboutVisible || manageRequest != null || immersiveListenSoundId != null
     ScaffoldedLanding(
         modifier = if (subScreenOpen) Modifier.clearAndSetSemantics {} else Modifier,
         viewModel = viewModel,
@@ -175,6 +181,11 @@ fun LandingScreen(viewModel: SoundsViewModel) {
         onActiveFilterEditClick = { collectionId ->
             manageRequest = ManageRequest.Focused(collectionId)
         },
+        onImmersivePlay = { sound ->
+            // Vault play opens immersive listen mode and starts playback (unless already playing).
+            immersiveListenSoundId = sound.id
+            if (!sound.isPlaying) viewModel.playOrStop(sound)
+        },
     )
 
     // Exactly one sub-screen overlays the list at a time (About wins over Manage, preserving the
@@ -187,6 +198,22 @@ fun LandingScreen(viewModel: SoundsViewModel) {
                 focusedCollectionId = (manageRequest as? ManageRequest.Focused)?.collectionId,
                 onBack = { manageRequest = null },
             )
+    }
+
+    // Immersive listen mode for a Vault audio — layers above everything (it covers the top bar, so
+    // About/Manage are unreachable while it is open). Back pauses playback (position retained) so no
+    // audio keeps playing headless behind the Vault list, then closes the overlay.
+    immersiveListenSoundId?.let { listeningId ->
+        com.github.barriosnahuel.vossosunboton.feature.vault.ImmersiveListenHost(
+            viewModel = viewModel,
+            soundId = listeningId,
+            onBack = {
+                viewModel.playingSound.value
+                    ?.takeIf { it.id == listeningId }
+                    ?.let { viewModel.playOrStop(it) }
+                immersiveListenSoundId = null
+            },
+        )
     }
 
     com.github.barriosnahuel.vossosunboton.feature.collections
@@ -306,6 +333,7 @@ private fun ScaffoldedLanding(
     onAboutClick: () -> Unit,
     onManageCollectionsClick: () -> Unit,
     onActiveFilterEditClick: (String) -> Unit,
+    onImmersivePlay: (Sound) -> Unit,
 ) {
     Scaffold(
         modifier = modifier,
@@ -355,6 +383,7 @@ private fun ScaffoldedLanding(
                     viewModel = viewModel,
                     listState = listState,
                     onActiveFilterEditClick = onActiveFilterEditClick,
+                    onImmersivePlay = onImmersivePlay,
                     modifier = Modifier.padding(innerPadding),
                 )
             else -> {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -738,6 +738,23 @@ class SoundsViewModel(
         _playbackProgress.update { it?.copy(positionMs = positionMs) }
     }
 
+    /**
+     * Seek used by the immersive listen player (waveform scrub + "back to start"). Unlike the
+     * single-arg [seekTo] — which only the playing card uses — this also keeps a *paused* audio's
+     * retained position in sync ([pausedProgress]) so the wave and time reflect the new spot. The
+     * MediaPlayer head moves either way, so a later resume (or preempt) continues from there.
+     */
+    fun seekTo(
+        positionMs: Int,
+        soundId: String,
+    ) {
+        PlayerControllerFactory.instance.seekTo(positionMs)
+        _playbackProgress.update { it?.copy(positionMs = positionMs) }
+        _pausedProgress.update { current ->
+            current[soundId]?.let { current + (soundId to it.copy(positionMs = positionMs)) } ?: current
+        }
+    }
+
     fun share(sound: Sound) {
         viewModelScope.launch {
             // applicationContext (via getApplication()) is enough: file resolution + FileProvider

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/theme/AppTheme.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/theme/AppTheme.kt
@@ -112,3 +112,19 @@ fun AppTheme(
         content = content,
     )
 }
+
+/**
+ * Forces the dark scheme regardless of the system theme — for full-bleed "lights-down" surfaces
+ * (the Vault immersive listen player). Two reasons it must be dark in both modes:
+ *  1. The app sets a non-adaptive light-icon status bar (`enableEdgeToEdge(SystemBarStyle.dark)`),
+ *     legible only over a dark top region. Every other screen tops out in an always-dark `secondary`
+ *     bar; this full-bleed player has no such bar, so a light (Paper) background would leave the
+ *     status-bar icons unreadable (non-text contrast, WCAG 1.4.11).
+ *  2. It matches the design's dark, immersive intent.
+ * The dark role pairs are already AA-verified by `AppThemeContrastTest`, so no new contrast risk.
+ * Living in the theme package (not the component) keeps `isSystemInDarkTheme()` out of UI files.
+ */
+@Composable
+fun ImmersiveListenTheme(content: @Composable () -> Unit) {
+    MaterialTheme(colorScheme = DarkColors, content = content)
+}

--- a/app/src/main/res/drawable/app_ic_skip_previous.xml
+++ b/app/src/main/res/drawable/app_ic_skip_previous.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M220-240v-480h80v480h-80Zm520 0L380-480l360-240v480Z" />
+    </group>
+</vector>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -117,7 +117,6 @@
 
     <!-- Modo escucha inmersivo (reproductor de audios del Baúl) -->
     <string name="app_vault_immersive_mode_label">Modo escucha</string>
-    <string name="app_vault_immersive_listen_only_label">No se comparte · Solo escucha</string>
     <string name="app_vault_immersive_back">Volver</string>
     <string name="app_vault_immersive_restart">Volver al inicio</string>
     <string name="app_vault_immersive_waveform">Posición de reproducción</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -115,6 +115,11 @@
     <string name="app_vault_biometric_prompt_subtitle">Usá tu huella o el bloqueo del teléfono para escuchar.</string>
     <string name="app_vault_biometric_negative">Cancelar</string>
 
+    <!-- Modo escucha inmersivo (reproductor de audios del Baúl) -->
+    <string name="app_vault_immersive_mode_label">Modo escucha</string>
+    <string name="app_vault_immersive_listen_only_label">No se comparte · Solo escucha</string>
+    <string name="app_vault_immersive_back">Volver</string>
+
     <!-- Sheet de crear / editar colección -->
     <string name="app_collection_sheet_title_new_public">Nueva colección</string>
     <string name="app_collection_sheet_title_new_private">Nuevo Baúl</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -119,6 +119,8 @@
     <string name="app_vault_immersive_mode_label">Modo escucha</string>
     <string name="app_vault_immersive_listen_only_label">No se comparte · Solo escucha</string>
     <string name="app_vault_immersive_back">Volver</string>
+    <string name="app_vault_immersive_restart">Volver al inicio</string>
+    <string name="app_vault_immersive_waveform">Posición de reproducción</string>
 
     <!-- Sheet de crear / editar colección -->
     <string name="app_collection_sheet_title_new_public">Nueva colección</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,6 +125,8 @@
     <string name="app_vault_immersive_mode_label">Listen mode</string>
     <string name="app_vault_immersive_listen_only_label">Not shared · Listen only</string>
     <string name="app_vault_immersive_back">Back</string>
+    <string name="app_vault_immersive_restart">Back to start</string>
+    <string name="app_vault_immersive_waveform">Playback position</string>
 
     <!-- Create / edit collection sheet -->
     <string name="app_collection_sheet_title_new_public">New collection</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,7 +123,6 @@
 
     <!-- Immersive listen mode (Vault audio player) -->
     <string name="app_vault_immersive_mode_label">Listen mode</string>
-    <string name="app_vault_immersive_listen_only_label">Not shared · Listen only</string>
     <string name="app_vault_immersive_back">Back</string>
     <string name="app_vault_immersive_restart">Back to start</string>
     <string name="app_vault_immersive_waveform">Playback position</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,6 +121,11 @@
     <string name="app_vault_biometric_prompt_subtitle">Use your fingerprint or screen lock to listen.</string>
     <string name="app_vault_biometric_negative">Cancel</string>
 
+    <!-- Immersive listen mode (Vault audio player) -->
+    <string name="app_vault_immersive_mode_label">Listen mode</string>
+    <string name="app_vault_immersive_listen_only_label">Not shared · Listen only</string>
+    <string name="app_vault_immersive_back">Back</string>
+
     <!-- Create / edit collection sheet -->
     <string name="app_collection_sheet_title_new_public">New collection</string>
     <string name="app_collection_sheet_title_new_private">New Vault</string>

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreenTest.kt
@@ -12,7 +12,8 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeRight
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.R
@@ -23,6 +24,7 @@ import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerF
 import com.github.barriosnahuel.vossosunboton.ui.home.SoundsViewModel
 import com.github.barriosnahuel.vossosunboton.ui.home.cancelAndJoinAll
 import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
+import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
@@ -68,6 +70,8 @@ internal class ImmersiveListenScreenTest : AbstractRobolectricTest() {
         durationMs: Int? = 98_000,
         isPlaying: Boolean = false,
         onPlayPause: () -> Unit = {},
+        onRestart: () -> Unit = {},
+        onSeek: (Float) -> Unit = {},
         onBack: () -> Unit = {},
     ) {
         composeTestRule.setContent {
@@ -82,6 +86,8 @@ internal class ImmersiveListenScreenTest : AbstractRobolectricTest() {
                     progressFraction = 0.42f,
                     peaks = null,
                     onPlayPause = onPlayPause,
+                    onRestart = onRestart,
+                    onSeek = onSeek,
                     onBack = onBack,
                 )
             }
@@ -91,13 +97,12 @@ internal class ImmersiveListenScreenTest : AbstractRobolectricTest() {
     @Test
     fun `renders the four facts a vault audio carries`() {
         launchScreen()
-        // Collection sits in the fixed top bar; name/date/duration are in the scrollable body, so
-        // scroll to them (a no-op when the screen already fits) before asserting.
+        // Collection · date · name grouped up top; position / duration in the readout below the wave.
         composeTestRule.onNodeWithText("CARO").assertIsDisplayed()
-        composeTestRule.onNodeWithText("La risa de la abuela").performScrollTo().assertIsDisplayed()
-        composeTestRule.onNodeWithText("24 DEC 2024").performScrollTo().assertIsDisplayed()
-        composeTestRule.onNodeWithText("0:42").performScrollTo().assertIsDisplayed()
-        composeTestRule.onNodeWithText("1:38").performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithText("La risa de la abuela").assertIsDisplayed()
+        composeTestRule.onNodeWithText("24 DEC 2024").assertIsDisplayed()
+        composeTestRule.onNodeWithText("0:42").assertIsDisplayed()
+        composeTestRule.onNodeWithText("1:38").assertIsDisplayed()
     }
 
     @Test
@@ -108,7 +113,6 @@ internal class ImmersiveListenScreenTest : AbstractRobolectricTest() {
             .assertIsDisplayed()
         composeTestRule
             .onNodeWithText(context.getString(R.string.app_vault_immersive_listen_only_label).uppercase())
-            .performScrollTo()
             .assertIsDisplayed()
     }
 
@@ -122,30 +126,51 @@ internal class ImmersiveListenScreenTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `transport shows pause while playing and play while paused`() {
+    fun `transport shows pause while playing`() {
         launchScreen(isPlaying = true)
-        composeTestRule.onNodeWithContentDescription(context.getString(R.string.app_pause)).performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription(context.getString(R.string.app_pause)).assertIsDisplayed()
     }
 
     @Test
     fun `transport shows play while not playing`() {
         launchScreen(isPlaying = false)
-        composeTestRule.onNodeWithContentDescription(context.getString(R.string.app_play)).performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription(context.getString(R.string.app_play)).assertIsDisplayed()
     }
 
     @Test
     fun `tapping the transport invokes onPlayPause`() {
         var tapped = false
         launchScreen(onPlayPause = { tapped = true })
-        composeTestRule.onNodeWithContentDescription(context.getString(R.string.app_play)).performScrollTo().performClick()
+        composeTestRule.onNodeWithContentDescription(context.getString(R.string.app_play)).performClick()
         assertTrue(tapped)
+    }
+
+    @Test
+    fun `tapping back to start invokes onRestart`() {
+        var restarted = false
+        launchScreen(onRestart = { restarted = true })
+        composeTestRule.onNodeWithContentDescription(context.getString(R.string.app_vault_immersive_restart)).performClick()
+        assertTrue(restarted)
+    }
+
+    @Test
+    fun `dragging the waveform seeks on release`() {
+        var seeked: Float? = null
+        launchScreen(onSeek = { seeked = it })
+        composeTestRule
+            .onNodeWithContentDescription(context.getString(R.string.app_vault_immersive_waveform))
+            .performTouchInput { swipeRight() }
+        composeTestRule.waitForIdle()
+        // Released near the right edge → a fraction well into the second half of the clip.
+        assertThat(seeked).isNotNull()
+        assertThat(seeked!!).isAtLeast(0.5f)
+        assertThat(seeked!!).isAtMost(1f)
     }
 
     @Test
     fun `tapping back invokes onBack`() {
         var backed = false
         launchScreen(onBack = { backed = true })
-        // Back lives in the fixed top bar (not the scrollable body), so no scroll needed.
         composeTestRule.onNodeWithContentDescription(context.getString(R.string.app_vault_immersive_back)).performClick()
         assertTrue(backed)
     }
@@ -153,7 +178,7 @@ internal class ImmersiveListenScreenTest : AbstractRobolectricTest() {
     @Test
     fun `renders without a date when dateLabel is null`() {
         launchScreen(dateLabel = null)
-        composeTestRule.onNodeWithText("La risa de la abuela").performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithText("La risa de la abuela").assertIsDisplayed()
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreenTest.kt
@@ -106,13 +106,10 @@ internal class ImmersiveListenScreenTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `renders the listen mode eyebrow and the listen-only footer`() {
+    fun `renders the listen mode eyebrow`() {
         launchScreen()
         composeTestRule
             .onNodeWithText(context.getString(R.string.app_vault_immersive_mode_label).uppercase())
-            .assertIsDisplayed()
-        composeTestRule
-            .onNodeWithText(context.getString(R.string.app_vault_immersive_listen_only_label).uppercase())
             .assertIsDisplayed()
     }
 

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreenTest.kt
@@ -80,6 +80,7 @@ internal class ImmersiveListenScreenTest : AbstractRobolectricTest() {
                     durationMs = durationMs,
                     isPlaying = isPlaying,
                     progressFraction = 0.42f,
+                    peaks = null,
                     onPlayPause = onPlayPause,
                     onBack = onBack,
                 )

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreenTest.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.vault
+
+import android.content.Context
+import android.os.Build
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.FakeAnalyticsTracker
+import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
+import com.github.barriosnahuel.vossosunboton.ui.home.SoundsViewModel
+import com.github.barriosnahuel.vossosunboton.ui.home.cancelAndJoinAll
+import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.robolectric.annotation.Config
+
+@Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+internal class ImmersiveListenScreenTest : AbstractRobolectricTest() {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+    private val fakeTracker = FakeAnalyticsTracker()
+    private val createdViewModels = mutableListOf<SoundsViewModel>()
+
+    @Before
+    fun setUp() {
+        AnalyticsTrackerProvider.setForTest(fakeTracker)
+        mockkObject(PlayerControllerFactory)
+        every { PlayerControllerFactory.instance.setOnStartStopListener(any()) } answers { nothing }
+    }
+
+    @After
+    fun tearDown() {
+        createdViewModels.cancelAndJoinAll()
+        createdViewModels.clear()
+        AnalyticsTrackerProvider.setForTest(null)
+        unmockkAll()
+    }
+
+    @Suppress("LongParameterList")
+    private fun launchScreen(
+        title: String = "La risa de la abuela",
+        collectionLabel: String = "Caro",
+        dateLabel: String? = "24 DEC 2024",
+        positionMs: Int = 42_000,
+        durationMs: Int? = 98_000,
+        isPlaying: Boolean = false,
+        onPlayPause: () -> Unit = {},
+        onBack: () -> Unit = {},
+    ) {
+        composeTestRule.setContent {
+            AppTheme {
+                ImmersiveListenScreen(
+                    title = title,
+                    collectionLabel = collectionLabel,
+                    dateLabel = dateLabel,
+                    positionMs = positionMs,
+                    durationMs = durationMs,
+                    isPlaying = isPlaying,
+                    progressFraction = 0.42f,
+                    onPlayPause = onPlayPause,
+                    onBack = onBack,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `renders the four facts a vault audio carries`() {
+        launchScreen()
+        // Collection sits in the fixed top bar; name/date/duration are in the scrollable body, so
+        // scroll to them (a no-op when the screen already fits) before asserting.
+        composeTestRule.onNodeWithText("CARO").assertIsDisplayed()
+        composeTestRule.onNodeWithText("La risa de la abuela").performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithText("24 DEC 2024").performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithText("0:42").performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithText("1:38").performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun `renders the listen mode eyebrow and the listen-only footer`() {
+        launchScreen()
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.app_vault_immersive_mode_label).uppercase())
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(context.getString(R.string.app_vault_immersive_listen_only_label).uppercase())
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `does not render a caption or subtitle the vault has no data for`() {
+        // Regression for the spec: the Claude Design mock shows a hand-written caption and a free
+        // text subtitle; the Vault stores neither, so listen mode must never render them.
+        launchScreen()
+        composeTestRule.onNodeWithText("mamá, abuela y yo").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Cuando le contamos lo del casamiento").assertDoesNotExist()
+    }
+
+    @Test
+    fun `transport shows pause while playing and play while paused`() {
+        launchScreen(isPlaying = true)
+        composeTestRule.onNodeWithContentDescription(context.getString(R.string.app_pause)).performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun `transport shows play while not playing`() {
+        launchScreen(isPlaying = false)
+        composeTestRule.onNodeWithContentDescription(context.getString(R.string.app_play)).performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun `tapping the transport invokes onPlayPause`() {
+        var tapped = false
+        launchScreen(onPlayPause = { tapped = true })
+        composeTestRule.onNodeWithContentDescription(context.getString(R.string.app_play)).performScrollTo().performClick()
+        assertTrue(tapped)
+    }
+
+    @Test
+    fun `tapping back invokes onBack`() {
+        var backed = false
+        launchScreen(onBack = { backed = true })
+        // Back lives in the fixed top bar (not the scrollable body), so no scroll needed.
+        composeTestRule.onNodeWithContentDescription(context.getString(R.string.app_vault_immersive_back)).performClick()
+        assertTrue(backed)
+    }
+
+    @Test
+    fun `renders without a date when dateLabel is null`() {
+        launchScreen(dateLabel = null)
+        composeTestRule.onNodeWithText("La risa de la abuela").performScrollTo().assertIsDisplayed()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `host emits the vault_listen screen view on entry`() {
+        val viewModel =
+            SoundsViewModel(
+                ApplicationProvider.getApplicationContext(),
+                ioDispatcher = UnconfinedTestDispatcher(),
+            )
+        createdViewModels += viewModel
+
+        composeTestRule.setContent {
+            AppTheme { ImmersiveListenHost(viewModel = viewModel, soundId = "any-id", onBack = {}) }
+        }
+        composeTestRule.waitForIdle()
+
+        fakeTracker.assertScreenView(CanonicalScreenName.VAULT_LISTEN)
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/PeakAccumulatorTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/PeakAccumulatorTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.vault
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * The PCM decode itself needs a device (MediaCodec), but the bucketing + normalization that turns
+ * samples into bar heights is pure — and it's where the visual correctness lives. These guard it.
+ */
+internal class PeakAccumulatorTest {
+    @Test
+    fun `loudest bucket normalizes to 1`() {
+        // 4 samples over 4 buckets, total = 4: one sample per bucket, rising magnitude.
+        val accumulator = PeakAccumulator(barCount = 4, estimatedTotalSamples = 4)
+        listOf<Short>(1000, 2000, 4000, 8000).forEach(accumulator::add)
+
+        val peaks = accumulator.result()
+
+        assertThat(peaks).hasLength(4)
+        // 8000 is the loudest → its bucket is 1.0; the rest are proportional.
+        assertThat(peaks[3]).isWithin(TOLERANCE).of(1f)
+        assertThat(peaks[2]).isWithin(TOLERANCE).of(0.5f)
+        assertThat(peaks[1]).isWithin(TOLERANCE).of(0.25f)
+    }
+
+    @Test
+    fun `keeps the peak (max abs) within a bucket, not the last sample`() {
+        // Two samples per bucket; the bucket peak must be the larger magnitude, sign-independent.
+        val accumulator = PeakAccumulator(barCount = 2, estimatedTotalSamples = 4)
+        listOf<Short>(-8000, 1000, 2000, 1000).forEach(accumulator::add)
+
+        val peaks = accumulator.result()
+
+        // Bucket 0 peak = |−8000| = 8000 (loudest overall → 1.0); bucket 1 peak = 2000 → 0.25.
+        assertThat(peaks[0]).isWithin(TOLERANCE).of(1f)
+        assertThat(peaks[1]).isWithin(TOLERANCE).of(0.25f)
+    }
+
+    @Test
+    fun `silence yields a flat minimum baseline, never zero`() {
+        val accumulator = PeakAccumulator(barCount = 5, estimatedTotalSamples = 5)
+        repeat(5) { accumulator.add(0) }
+
+        val peaks = accumulator.result()
+
+        assertThat(peaks).hasLength(5)
+        peaks.forEach { assertThat(it).isGreaterThan(0f) }
+        // All equal (flat baseline).
+        assertThat(peaks.toSet()).hasSize(1)
+    }
+
+    @Test
+    fun `extra samples beyond the estimate clamp into the last bucket without crashing`() {
+        val accumulator = PeakAccumulator(barCount = 3, estimatedTotalSamples = 3)
+        // 6 samples though only 3 were estimated — must not throw or index out of bounds.
+        repeat(6) { accumulator.add(3000) }
+
+        assertThat(accumulator.result()).hasLength(3)
+    }
+
+    private companion object {
+        const val TOLERANCE = 0.001f
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/ResolveListenCollectionLabelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/ResolveListenCollectionLabelTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.vault
+
+import com.github.barriosnahuel.vossosunboton.model.Collection
+import com.github.barriosnahuel.vossosunboton.model.CollectionProfile
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+internal class ResolveListenCollectionLabelTest {
+    private fun privateCollection(
+        id: String,
+        name: String,
+        system: Boolean = false,
+    ) = Collection(id = id, name = name, profile = CollectionProfile.VAULT, isSystem = system)
+
+    private fun publicCollection(
+        id: String,
+        name: String,
+    ) = Collection(id = id, name = name, profile = CollectionProfile.GENERIC_PUBLIC)
+
+    @Test
+    fun `prefers the active filter collection when the audio belongs to it`() {
+        val collections = listOf(privateCollection("a", "Caro"), privateCollection("b", "Trabajo"))
+        val byAudio = mapOf("s1" to listOf("a", "b"))
+
+        val label = resolveListenCollectionLabel("s1", collections, byAudio, activeFilter = "b", systemLabel = "Baúl")
+
+        assertThat(label).isEqualTo("Trabajo")
+    }
+
+    @Test
+    fun `falls back to the first private membership when no filter is active`() {
+        val collections = listOf(privateCollection("a", "Caro"), privateCollection("b", "Trabajo"))
+        val byAudio = mapOf("s1" to listOf("a", "b"))
+
+        val label = resolveListenCollectionLabel("s1", collections, byAudio, activeFilter = null, systemLabel = "Baúl")
+
+        assertThat(label).isEqualTo("Caro")
+    }
+
+    @Test
+    fun `resolves the system collection to the locale-aware label`() {
+        val collections = listOf(privateCollection("sys", "internal-name", system = true))
+        val byAudio = mapOf("s1" to listOf("sys"))
+
+        val label = resolveListenCollectionLabel("s1", collections, byAudio, activeFilter = null, systemLabel = "My Vault")
+
+        assertThat(label).isEqualTo("My Vault")
+    }
+
+    @Test
+    fun `returns empty when the audio has no private membership`() {
+        val collections = listOf(publicCollection("p", "Familia"))
+        val byAudio = mapOf("s1" to listOf("p"))
+
+        val label = resolveListenCollectionLabel("s1", collections, byAudio, activeFilter = null, systemLabel = "Baúl")
+
+        assertThat(label).isEmpty()
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/DurationFormatterTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/DurationFormatterTest.kt
@@ -7,9 +7,46 @@ package com.github.barriosnahuel.vossosunboton.ui.home
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
+import java.util.Calendar
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 internal class DurationFormatterTest {
+    // Noon (not midnight) so the calendar day cannot flip across the host timezone offset.
+    private fun epochOf(
+        year: Int,
+        month: Int,
+        day: Int,
+    ): Long =
+        Calendar
+            .getInstance()
+            .apply {
+                clear()
+                set(year, month, day, 12, 0, 0)
+            }.timeInMillis
+
+    @Test
+    fun `fullDate en-US formats day-month-year uppercased`() {
+        val epoch = epochOf(2024, Calendar.DECEMBER, 24)
+        assertThat(fullDate(epoch, Locale.US)).isEqualTo("24 DEC 2024")
+    }
+
+    @Test
+    fun `fullDate is uppercase and carries day and year regardless of locale`() {
+        val epoch = epochOf(2024, Calendar.DECEMBER, 24)
+        val formatted = fullDate(epoch, Locale("es", "AR"))
+        // Month abbreviation text varies by JVM locale data, so assert structure, not exact MMM.
+        assertThat(formatted).isEqualTo(formatted.uppercase(Locale("es", "AR")))
+        assertThat(formatted).contains("24")
+        assertThat(formatted).contains("2024")
+    }
+
+    @Test
+    fun `fullDate single-digit day has no leading zero`() {
+        val epoch = epochOf(2024, Calendar.JANUARY, 5)
+        assertThat(fullDate(epoch, Locale.US)).isEqualTo("5 JAN 2024")
+    }
+
     @Test
     fun `formatDuration zero milliseconds returns 0 colon 00`() {
         assertThat(formatDuration(0)).isEqualTo("0:00")

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
@@ -224,6 +224,36 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
     }
 
     @Test
+    fun `seekTo with soundId moves the player and updates live progress while playing`() {
+        every { PlayerControllerFactory.instance.seekTo(any()) } answers { nothing }
+        val viewModel = givenAViewModel()
+        val sound = testSound("test", rawRes = 1)
+        viewModel.onPlayerStart(sound, durationMs = 10_000)
+
+        viewModel.seekTo(5_000, sound.id)
+
+        verify { PlayerControllerFactory.instance.seekTo(5_000) }
+        assertThat(viewModel.playbackProgress.value?.positionMs).isEqualTo(5_000)
+    }
+
+    @Test
+    fun `seekTo with soundId updates the retained position while paused (back-to-start)`() {
+        every { PlayerControllerFactory.instance.seekTo(any()) } answers { nothing }
+        val viewModel = givenAViewModel()
+        val sound = testSound("test", rawRes = 1)
+        viewModel.onPlayerStart(sound, durationMs = 10_000)
+        viewModel.onPlayerPause(sound, positionMs = 3_500, durationMs = 10_000)
+
+        viewModel.seekTo(0, sound.id)
+
+        verify { PlayerControllerFactory.instance.seekTo(0) }
+        // Paused, so live progress stays null; the retained position (which the wave + a later
+        // resume read) moves to the start.
+        assertThat(viewModel.playbackProgress.value).isNull()
+        assertThat(viewModel.pausedProgress.value[sound.id]?.positionMs).isEqualTo(0)
+    }
+
+    @Test
     fun `playOrStop when sound is not playing calls startPlayingSound`() {
         every { PlayerControllerFactory.instance.startPlayingSound(any(), any()) } answers { nothing }
         val viewModel = givenAViewModel()

--- a/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/CanonicalScreenName.kt
+++ b/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/CanonicalScreenName.kt
@@ -21,6 +21,9 @@ object CanonicalScreenName {
     /** Vault tab — list of private collections; no audio content shown until per-collection unlock. */
     const val VAULT = "vault"
 
+    /** Immersive listen-only player opened by tapping play on a Vault audio (listen mode). */
+    const val VAULT_LISTEN = "vault_listen"
+
     /** Biometric unlock prompt invocation surface (analytics-only marker — the prompt itself is OS). */
     const val VAULT_UNLOCK = "vault_unlock"
 
@@ -39,6 +42,7 @@ object CanonicalScreenName {
             ADD_SOUND,
             EDIT_SOUND,
             VAULT,
+            VAULT_LISTEN,
             VAULT_UNLOCK,
             COLLECTION_CREATE,
             MANAGE_COLLECTIONS,

--- a/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsCoverageMatrixTest.kt
+++ b/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsCoverageMatrixTest.kt
@@ -100,6 +100,7 @@ internal class AnalyticsCoverageMatrixTest {
                 CanonicalScreenName.ADD_SOUND,
                 CanonicalScreenName.EDIT_SOUND,
                 CanonicalScreenName.VAULT,
+                CanonicalScreenName.VAULT_LISTEN,
                 CanonicalScreenName.VAULT_UNLOCK,
                 CanonicalScreenName.COLLECTION_CREATE,
                 CanonicalScreenName.MANAGE_COLLECTIONS,


### PR DESCRIPTION
### Summary
1. User opens the Vault and taps play on an audio.
2. Listen mode opens; user drags the waveform to scrub, or taps back-to-start to replay.

**before:** Vault audios played inline on the card, just like My Sounds — nothing set them apart, and there was no scrubbing.
**after:** a full-screen, listen-only player opens — collection · date · name grouped up top, the audio's **real** waveform below (drag it to seek), a back-to-start + play transport at the bottom, and no share button. Back pauses playback and returns to the list.

### Technical detail
Adds an immersive, listen-only player for Vault audios, consuming the pre-existing `CollectionPlaybackUI.IMMERSIVE` profile (until now declared but unused).

- **`ImmersiveListenScreen.kt` (new):** stateless screen + `ImmersiveListenHost` (resolves playback state, emits the `VAULT_LISTEN` screen_view). Layout: collection·date·name grouped in the **top half**, the waveform in the **bottom half**, transport pinned at the bottom. Renders only the four facts a Vault audio carries (name/date/duration/collection) — the mock's polaroid, caption and subtitle are omitted (the Vault stores none).
- **Real waveform (`WaveformExtractor.kt`):** the audio's actual amplitude envelope — `MediaExtractor`+`MediaCodec` → PCM folded into 56 normalized peaks (`PeakAccumulator`), off-main, in-memory cached per `Sound.id`; decode failure → neutral placeholder, never a fake shape. No `Visualizer` (needs `RECORD_AUDIO`, contradicts the Vault). Persisting the envelope was considered and **deferred** (cheap to recompute; cache covers in-session re-opens).
- **Scrub + back-to-start:** the waveform is a drag-to-seek scrubber (preview fill, seeks on release) exposed as an accessible seekbar (`progressBarRangeInfo` + `setProgress`); a skip-previous control LEFT of play (transport convention, **not** a square stop on the right) seeks to 0. New `SoundsViewModel.seekTo(positionMs, soundId)` keeps a *paused* audio's retained position in sync — no controller change needed (the MediaPlayer head + preempt already persist it).
- **Edge-to-edge / safe area:** content gets `safeDrawingPadding()` (gradient still bleeds behind the bars); the screen is forced to the **dark scheme** (`ImmersiveListenTheme`) so the app's global light status-bar icons stay legible in light mode too.
- **`VaultScreen` → `LandingScreen`:** the Vault list's `onPlayClick` routes to a `rememberSaveable` overlay (same layering as About/Manage/Search); back pauses and closes.
- **Palette:** ink×acid, not the mock's warm amber (`VaultEmptyState` precedent); play = `primaryContainer` per ADR 0010; custom fonts deferred.

### Code review tips
- **`WaveformExtractor`** is the riskiest piece: the `MediaCodec` decode loop (`feedInput`/`drainOutput`), 16-bit-PCM assumption, `bufferInfo.offset` handling. Runs off-main, swallows failures into `null` (tracked) → placeholder, never a crash. `PeakAccumulator` is unit-tested; the decode is exercised by the instrumented flow.
- **Forced dark** is deliberate (status-bar-icon legibility under the global `SystemBarStyle.dark`); dark role pairs are AA-verified by `AppThemeContrastTest`.
- `SoundPlay.surface = "vault"` for listen-mode plays is deliberate (not a gap): the surface names the *place* (the Vault), not today's UI format. Every Vault play goes through listen mode, so `vault` is unambiguous, and it stays correct if the Vault's format ever changes. The `vault_listen` screen_view separately tracks listen-mode opens.
- Branch rebased onto `develop@2783972` (clean).

### Already tested
- Instrumented (full local suite — CI doesn't run it, ADR 0001): **106 run / 0 failed / 2 skipped**, cold-booted via `./scripts/run-instrumented-tests.sh`. `VaultImmersiveListenTest` covers open → immersive → back, `scenario.recreate()` survival, and a status-bar-inset guard (top bar vs. the real window inset).
- Unit + lint (detekt/ktlint/spotless/Android Lint): green via `./gradlew check`. New: `PeakAccumulatorTest` (waveform bucketing/normalization), VM `seekTo(positionMs, soundId)` (playing + paused), and Robolectric coverage of the restart click + drag-to-seek.
