### PR TITLE
test: deflake two SoundsViewModel reactive-recompute races

### DIFF
--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelAnalyticsTest.kt
@@ -188,9 +188,20 @@ internal class SoundsViewModelAnalyticsTest : AbstractRobolectricTest() {
     fun `togglePin updates current_pinned user property to the count of pinned sounds`() {
         val viewModel = givenAViewModel()
         val sound = testSound("test", file = "test.mp3")
-        viewModel.injectSounds(listOf(sound))
+        // Persist + await the audio reaching allSoundsCache via the reactive loadSounds BEFORE
+        // toggling. togglePin derives current_pinned from allSoundsCache (SoundsViewModel.kt); a
+        // not-yet-arrived loadSounds on a loaded CI machine resets that cache to the empty repo, so
+        // the toggle counts 0 and the assertion flakes (CLAUDE.md § JVM tests — await every async
+        // input). Mirrors the Vault-bucket tests below; replaces the reflection-injection race.
+        runBlocking {
+            SoundsRepository(ApplicationProvider.getApplicationContext()).save(sound)
+            viewModel.library.first { lib -> lib.any { it.id == sound.id } }
+        }
 
         viewModel.togglePin(sound)
+        // Await the asserted property itself, not a proxy: savePin re-emits through the reactive
+        // collector and recomputes current_pinned, converging on "1" once the toggle is committed.
+        runBlocking { awaitUserProperty(fake, AnalyticsUserProperty.CURRENT_PINNED, "1") }
 
         assertThat(fake.userProperties[AnalyticsUserProperty.CURRENT_PINNED]).isEqualTo("1")
     }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelSearchTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelSearchTest.kt
@@ -5,6 +5,7 @@
  */
 package com.github.barriosnahuel.vossosunboton.ui.home
 
+import android.os.Looper
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
 import com.github.barriosnahuel.vossosunboton.feature.vault.security.VaultSessionState
@@ -22,6 +23,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import org.robolectric.Shadows.shadowOf
 
 internal class SoundsViewModelSearchTest : AbstractRobolectricTest() {
     private val createdViewModels = mutableListOf<SoundsViewModel>()
@@ -180,6 +182,12 @@ internal class SoundsViewModelSearchTest : AbstractRobolectricTest() {
         assertThat(viewModel.searchResults.value.map { it.id }).doesNotContain(privateAudio.id)
 
         VaultSessionState.markVaultOpen()
+        // The session-flip recompute runs on the VM's `viewModelScope` collector (Dispatchers.Main,
+        // SoundsViewModel.kt). Robolectric's main looper is PAUSED, so that resumption is queued and
+        // hasn't run when we read searchResults.value synchronously — it flakes on the slower SDK 23
+        // run under CI load. Flush the looper so the recompute lands first. (A `first {}` await would
+        // deadlock here: runBlocking does not pump the Android looper the collector is parked on.)
+        shadowOf(Looper.getMainLooper()).idle()
 
         assertThat(viewModel.searchResults.value.map { it.id }).contains(privateAudio.id)
         VaultSessionState.clearForTest()


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change. Deflakes two existing `SoundsViewModel` tests so CI stops false-failing. Same bug class in both: a value the VM recomputes **reactively** is asserted before the recompute lands. The app behaviour is correct; only the tests raced.

- **`current_pinned`:** a user pins a Bomp → the `current_pinned` user property should equal the count of pinned audios. On a loaded CI machine the test counted 0 and failed red — no production regression behind it.
- **Vault mid-search:** a user searches, then unlocks the Vault mid-search → previously-hidden private matches should appear without re-typing. The test read `searchResults` before the session-flip recompute ran (SDK 23 under load), failing red.

### Technical detail

Two test-only fixes, no production code touched.

- **`SoundsViewModelAnalyticsTest` (current_pinned):** replaced the reflection `allSoundsCache` injection — which a late reactive `loadSounds` (empty repo) could reset before `togglePin` counted — with the file's await pattern: `repo.save` → await `library.first { it.has(id) }` → `togglePin` → `awaitUserProperty(CURRENT_PINNED,"1")`. Mirrors the Vault-bucket tests.
- **`SoundsViewModelSearchTest` (mid-search):** the session-flip recompute runs on the VM's `viewModelScope` collector (Dispatchers.Main, `SoundsViewModel.kt:366`); Robolectric's PAUSED main looper hadn't run it before the synchronous `.value` read. Added `shadowOf(getMainLooper()).idle()` after `markVaultOpen()`. A `first {}` await would **deadlock** — `runBlocking` doesn't pump the Android looper the collector parks on.
- **Unchanged / out of scope:** sibling `togglePin emits pin_toggle` and the "marks open *before* search" test don't race (they assert the event param / recompute synchronously via `onSearchQueryChange`); `injectSounds` helper retained.

### Code review tips

- **current_pinned await** can't pass for the wrong reason: at await-start the property is `"0"` (pre-toggle `loadSounds`); only `togglePin` (and its `savePin` re-emit) drive it to `"1"`, which holds through the assert.
- **`idle()`** doesn't mask a missing recompute: if the production session collector never recomputed, flushing the looper would still leave `searchResults` empty → assertion still fails. It removes only the timing race.

### Already tested

- Flake stability (local, `--rerun-tasks`, all SDK params 23/33/35): `SoundsViewModelAnalyticsTest` 10/10 green · `SoundsViewModelSearchTest` 10/10 green.
