### PR TITLE
fix(home): gate Search FAB by global library, not the visible tab

### DIFF
--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlayTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlayTest.kt
@@ -23,11 +23,32 @@ import com.github.barriosnahuel.vossosunboton.WAIT_TIMEOUT_MS
 import com.github.barriosnahuel.vossosunboton.awaitNode
 import com.github.barriosnahuel.vossosunboton.awaitNodeWithContentDescription
 import com.github.barriosnahuel.vossosunboton.awaitNodeWithText
+import com.github.barriosnahuel.vossosunboton.model.data.local.defaultaudios.PackagedAudios
+import org.junit.Assume.assumeTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 internal class SearchOverlayTest : AbstractUiTest() {
+    @Test
+    fun searchFabShowsOnMySoundsWhenOnlyTheGlobalCatalogCrossesTheThreshold() {
+        // Regression: the FAB used to gate on the *currently visible tab's* filtered list, so My
+        // Sounds with only a couple of custom sounds hid it — even though search is global and the
+        // bundled Explore catalog (always ≥ SEARCH_FAB_MIN_SOUNDS in debug) is searchable from here.
+        // Seed two custom sounds: My Sounds shows two (below the threshold on its own) while the
+        // global library is well above it. The FAB must be present on My Sounds.
+        assumeTrue(
+            "Needs a bundled catalog large enough that the global library crosses the FAB threshold " +
+                "while My Sounds stays sparse (bundled raw audio is a best-effort, uncommitted copy).",
+            SOUNDS_BELOW_TAB_THRESHOLD + PackagedAudios.get(context).size >= SOUNDS_FOR_VISIBLE_FAB,
+        )
+        TestData.seedCustomSounds(context, count = SOUNDS_BELOW_TAB_THRESHOLD)
+
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            composeRule.awaitNodeWithContentDescription(searchLabel()).assertIsDisplayed()
+        }
+    }
+
     @Test
     fun fabOpensSearchOverlay() {
         TestData.seedCustomSounds(context, count = SOUNDS_FOR_VISIBLE_FAB)
@@ -137,8 +158,13 @@ internal class SearchOverlayTest : AbstractUiTest() {
     private fun clearSearchLabel() = context.getString(R.string.app_search_clear)
 
     private companion object {
-        // Matches SEARCH_FAB_MIN_SOUNDS in LandingScreen.kt — the FAB stays hidden below this
-        // threshold, so any test that needs to tap it must seed at least this many sounds.
+        // Matches SEARCH_FAB_MIN_SOUNDS in LandingScreen.kt — the FAB stays hidden until the global
+        // library crosses this threshold, so any test that needs to tap it must seed at least this
+        // many sounds (or rely on the always-present bundled catalog).
         const val SOUNDS_FOR_VISIBLE_FAB = 7
+
+        // Below the threshold for the My Sounds tab on its own — the FAB only appears because the
+        // global library (these + the bundled Explore catalog) crosses SEARCH_FAB_MIN_SOUNDS.
+        const val SOUNDS_BELOW_TAB_THRESHOLD = 2
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -81,6 +81,11 @@ import kotlinx.coroutines.launch
 @Composable
 fun LandingScreen(viewModel: SoundsViewModel) {
     val sounds by viewModel.sounds.collectAsState()
+    // Full catalog across every surface (custom + bundled), independent of the visible tab — the
+    // Search FAB gates on this because search itself is global. `sounds` is the tab-filtered list
+    // and would wrongly hide the FAB on a sparse tab (e.g. My Sounds with a couple of audios) while
+    // the rest of the library is searchable.
+    val library by viewModel.library.collectAsState()
     val selectedTab by viewModel.selectedTab.collectAsState()
     val hasBundledSounds by viewModel.hasBundledSounds.collectAsState()
     val playbackProgress by viewModel.playbackProgress.collectAsState()
@@ -161,6 +166,7 @@ fun LandingScreen(viewModel: SoundsViewModel) {
         modifier = if (subScreenOpen) Modifier.clearAndSetSemantics {} else Modifier,
         viewModel = viewModel,
         sounds = sounds,
+        librarySize = library.size,
         selectedTab = selectedTab,
         hasBundledSounds = hasBundledSounds,
         playbackProgress = playbackProgress,
@@ -315,6 +321,7 @@ private fun ScaffoldedLanding(
     modifier: Modifier = Modifier,
     viewModel: SoundsViewModel,
     sounds: List<Sound>,
+    librarySize: Int,
     selectedTab: AppTab,
     hasBundledSounds: Boolean,
     playbackProgress: PlaybackProgress?,
@@ -361,8 +368,10 @@ private fun ScaffoldedLanding(
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         floatingActionButton = {
-            // Search FAB only renders on the sound-list tabs; Vault has its own FAB.
-            if (selectedTab != AppTab.VAULT && sounds.size >= SEARCH_FAB_MIN_SOUNDS) {
+            // Search FAB only renders on the sound-list tabs; Vault has its own FAB. Gated on the
+            // global library size (not the tab-filtered `sounds`) because search spans every
+            // surface — a sparse current tab must not hide a FAB that searches the whole catalog.
+            if (selectedTab != AppTab.VAULT && librarySize >= SEARCH_FAB_MIN_SOUNDS) {
                 FloatingActionButton(
                     onClick = { viewModel.showSearch() },
                     containerColor = MaterialTheme.colorScheme.primaryContainer,

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
@@ -84,36 +84,39 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `Search FAB is hidden when sound list is empty`() {
+    fun `Search FAB is hidden when the global library is empty`() {
         val viewModel = givenAViewModel()
 
         composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
         composeTestRule.waitForIdle()
-        viewModel.injectSounds(emptyList())
+        viewModel.injectLibrary(emptyList())
         composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithContentDescription("Search").assertDoesNotExist()
     }
 
     @Test
-    fun `Search FAB is hidden when sound list has 6 items`() {
+    fun `Search FAB is hidden when the global library has 6 sounds`() {
         val viewModel = givenAViewModel()
 
         composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
         composeTestRule.waitForIdle()
-        viewModel.injectSounds(stubSounds(count = 6))
+        viewModel.injectLibrary(stubSounds(count = 6))
         composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithContentDescription("Search").assertDoesNotExist()
     }
 
     @Test
-    fun `Search FAB is shown when sound list has 7 items`() {
+    fun `Search FAB is shown when the global library has 7 sounds`() {
         val viewModel = givenAViewModel()
 
         composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
         composeTestRule.waitForIdle()
-        viewModel.injectSounds(stubSounds(count = 7))
+        // `_sounds` (the My Sounds tab list) stays empty here — nothing custom is seeded — so this
+        // also pins the headline behaviour: the FAB shows on an otherwise-empty My Sounds tab once
+        // the *global* library crosses the threshold, which the old per-tab gate would have hidden.
+        viewModel.injectLibrary(stubSounds(count = 7))
         composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithContentDescription("Search").assertIsDisplayed()
@@ -142,11 +145,15 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
             .let { (it.get(this) as MutableStateFlow<Boolean>).value = value }
     }
 
-    private fun SoundsViewModel.injectSounds(value: List<Sound>) {
+    // The Search FAB gates on the global library (allSoundsCache), not the tab-filtered `_sounds` —
+    // search spans every surface. The debug build's loadSounds primes allSoundsCache with the
+    // bundled catalog, so injecting AFTER waitForIdle (once that cascade settles, same reasoning as
+    // injectHasBundledSounds) is the only way to drive the count below the threshold.
+    private fun SoundsViewModel.injectLibrary(value: List<Sound>) {
         SoundsViewModel::class.java
-            .getDeclaredField("_sounds")
+            .getDeclaredField("allSoundsCache")
             .also { it.isAccessible = true }
-            // Safe: _sounds is always MutableStateFlow<List<Sound>> — type parameter erased at runtime
+            // Safe: allSoundsCache is always MutableStateFlow<List<Sound>> — type parameter erased at runtime
             .let { (it.get(this) as MutableStateFlow<List<Sound>>).value = value }
     }
 


### PR DESCRIPTION
### Summary

A user-facing fix to when the **Search** action appears.

1. User opens the app on **My Sounds** with just a couple of Bomps
2. Their wider library (other tabs, the Explore catalog) has plenty more

**before:** the Search button is hidden — it only counts the current tab's short list, even though search actually looks across every tab.
**after:** the Search button stays available whenever your whole library has enough Bomps to be worth searching.

### Technical detail

The Search FAB now gates on the global library count, not the tab-filtered list.

- **`LandingScreen.kt`** — collects `viewModel.library` (the full custom + bundled catalog) and threads `librarySize` into `ScaffoldedLanding`; the FAB condition reads `librarySize >= SEARCH_FAB_MIN_SOUNDS` (was `sounds.size`).
- **`LandingScreenTest.kt`** — the three FAB-threshold Robolectric tests inject `allSoundsCache` (what `library` exposes) instead of `_sounds`: same empty / 6 / 7 boundaries, now driving the field the FAB actually reads.
- **`SearchOverlayTest.kt`** — new instrumented regression: My Sounds with 2 custom Bomps shows the FAB because the global library crosses the threshold; `assumeTrue`-guarded on bundled-catalog presence per the package convention.
- **No CHANGELOG line** — the per-tab gate landed this same unreleased cycle (`5dad2ab`), so per CLAUDE.md the fix lives in git history; the existing "Search action hidden until enough Bomps" *Changed* entry stays accurate.
- Out of scope: file-wide `collectAsState()` → lifecycle-aware migration (pre-existing debt).

### Code review tips

- Intended behaviour shift: with the bundled Explore catalog always present, the FAB is now effectively always visible on non-Vault tabs — that's the "search is global" semantics, not a regression. The `selectedTab != VAULT` half is untouched.
- The realigned Robolectric "7 sounds" test doubles as the headline assertion (FAB shows on an empty My Sounds tab once the global library ≥ threshold — `_sounds` stays empty there).

### Already tested

- instrumented (ui.home, not in CI per ADR 0001): run local, 32 tests / 0 failed (1 pre-existing skip). SearchOverlayTest flake-triaged: run 1 was a process-crash flake, runs 2–3 green 8/8
