### PR TITLE
fix: origin tags across the app, with private tags hidden while the Vault is locked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Audio preview no longer bleeds into the success confirmation when you save a new Bomp (or save a rename) while the preview is playing — the audio now stops the moment the confirmation appears
 - Sharing an audio into Bomp while a rename was left open in the background no longer drops you back into that unsaved rename screen with the wrong audio's data; the share now correctly opens the new-Bomp form for the incoming audio (anything you had typed in the unsaved rename is discarded since it was never saved)
 - Deleting several Bomps in a row (in My Sounds or the Vault) now removes all of them; previously only the most recent deletion stuck and the rest reappeared when the last undo snackbar faded or the list reloaded
-- Search results now carry an origin tag — the Bomp's collection, your Vault, or Explore for the bundled catalog — so matches that look alike across tabs are finally distinguishable (the tag had been announced but never appeared); a private collection's name only shows once the Vault is unlocked
+- Search results now carry an origin tag — the Bomp's collection, your Vault, or Explore for the bundled catalog — so matches that look alike across tabs are finally distinguishable (the tag had been announced but never appeared)
+- A Bomp's private collection name no longer appears on My Sounds or in search while the Vault is locked — private collection tags stay hidden until you unlock the Vault
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Audio preview no longer bleeds into the success confirmation when you save a new Bomp (or save a rename) while the preview is playing — the audio now stops the moment the confirmation appears
 - Sharing an audio into Bomp while a rename was left open in the background no longer drops you back into that unsaved rename screen with the wrong audio's data; the share now correctly opens the new-Bomp form for the incoming audio (anything you had typed in the unsaved rename is discarded since it was never saved)
 - Deleting several Bomps in a row (in My Sounds or the Vault) now removes all of them; previously only the most recent deletion stuck and the rest reappeared when the last undo snackbar faded or the list reloaded
+- Search results now carry an origin tag — the Bomp's collection, your Vault, or Explore for the bundled catalog — so matches that look alike across tabs are finally distinguishable (the tag had been announced but never appeared)
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Audio preview no longer bleeds into the success confirmation when you save a new Bomp (or save a rename) while the preview is playing — the audio now stops the moment the confirmation appears
 - Sharing an audio into Bomp while a rename was left open in the background no longer drops you back into that unsaved rename screen with the wrong audio's data; the share now correctly opens the new-Bomp form for the incoming audio (anything you had typed in the unsaved rename is discarded since it was never saved)
 - Deleting several Bomps in a row (in My Sounds or the Vault) now removes all of them; previously only the most recent deletion stuck and the rest reappeared when the last undo snackbar faded or the list reloaded
-- Search results now carry an origin tag — the Bomp's collection, your Vault, or Explore for the bundled catalog — so matches that look alike across tabs are finally distinguishable (the tag had been announced but never appeared)
+- Search results now carry an origin tag — the Bomp's collection, your Vault, or Explore for the bundled catalog — so matches that look alike across tabs are finally distinguishable (the tag had been announced but never appeared); a private collection's name only shows once the Vault is unlocked
 
 
 ### Changed

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/collections/SoundItemInlineLabelsFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/collections/SoundItemInlineLabelsFlowTest.kt
@@ -13,6 +13,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.barriosnahuel.vossosunboton.AbstractUiTest
 import com.github.barriosnahuel.vossosunboton.TestData
+import com.github.barriosnahuel.vossosunboton.awaitNode
 import com.github.barriosnahuel.vossosunboton.awaitNodeWithText
 import com.github.barriosnahuel.vossosunboton.ui.home.LandingActivity
 import org.junit.Test
@@ -56,6 +57,38 @@ internal class SoundItemInlineLabelsFlowTest : AbstractUiTest() {
             composeRule
                 .onAllNodes(hasText("Familia · ", substring = true))
                 .assertCountEquals(1)
+        }
+    }
+
+    @Test
+    fun cardHidesPrivateCollectionLabelWhileVaultIsLocked() {
+        // A cross-tagged audio (public + private) stays visible on My Sounds, but a private
+        // collection's name lives behind the Vault gate — with the Vault locked it must not leak in
+        // the card meta. Only the public tag shows.
+        val (audio) = TestData.seedCustomSounds(context, count = 1)
+        TestData.seedPublicCollection(context, name = "Familia", audioIds = listOf(audio.id))
+        TestData.seedPrivateCollection(context, name = "Secretos", audioIds = listOf(audio.id))
+
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            // Await the card meta carrying the public tag — proves collections loaded and the meta
+            // rendered, so the absence assertion below is meaningful (not a not-yet-loaded pass).
+            composeRule.awaitNode(hasText("Familia · ", substring = true)).assertIsDisplayed()
+            // The private collection name appears nowhere on My Sounds while locked: it is not a
+            // public filter chip, and the card tag suppresses it.
+            composeRule.onAllNodes(hasText("Secretos", substring = true)).assertCountEquals(0)
+        }
+    }
+
+    @Test
+    fun cardShowsPrivateCollectionLabelOnceVaultIsUnlocked() {
+        val (audio) = TestData.seedCustomSounds(context, count = 1)
+        TestData.seedPublicCollection(context, name = "Familia", audioIds = listOf(audio.id))
+        TestData.seedPrivateCollection(context, name = "Secretos", audioIds = listOf(audio.id))
+        TestData.markVaultOpen()
+
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            // Unlocked → the card meta now carries the private collection name too.
+            composeRule.awaitNode(hasText("Secretos", substring = true)).assertIsDisplayed()
         }
     }
 }

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlayTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlayTest.kt
@@ -50,6 +50,24 @@ internal class SearchOverlayTest : AbstractUiTest() {
     }
 
     @Test
+    fun searchResultsCarryTheirCollectionOriginTag() {
+        // Search spans every surface, so a result on its own gives no hint of where it lives — it
+        // now carries an origin tag. A *private* collection name is the unambiguous probe: it is
+        // never a My Sounds filter chip and its audio is hidden from My Sounds, so the name can only
+        // surface on the search result's tag (proving the result wiring, not the underlying list).
+        val sounds = TestData.seedCustomSounds(context, count = SOUNDS_FOR_VISIBLE_FAB + 1)
+        val privateAudio = sounds.last()
+        TestData.seedPrivateCollection(context, name = PRIVATE_COLLECTION, audioIds = listOf(privateAudio.id))
+        TestData.markVaultOpen()
+
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
+            composeRule.awaitNode(hasSetTextAction()).performTextInput(privateAudio.name)
+            composeRule.awaitNode(hasText(PRIVATE_COLLECTION, substring = true)).assertIsDisplayed()
+        }
+    }
+
+    @Test
     fun fabOpensSearchOverlay() {
         TestData.seedCustomSounds(context, count = SOUNDS_FOR_VISIBLE_FAB)
 
@@ -166,5 +184,9 @@ internal class SearchOverlayTest : AbstractUiTest() {
         // Below the threshold for the My Sounds tab on its own — the FAB only appears because the
         // global library (these + the bundled Explore catalog) crosses SEARCH_FAB_MIN_SOUNDS.
         const val SOUNDS_BELOW_TAB_THRESHOLD = 2
+
+        // A private collection name: never a My Sounds filter chip, so it can only appear on a
+        // search result's origin tag — the unambiguous probe for the collection-tag wiring.
+        const val PRIVATE_COLLECTION = "Secrets"
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/CollectionOriginLabels.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/CollectionOriginLabels.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home
+
+import com.github.barriosnahuel.vossosunboton.model.Collection
+
+/**
+ * Resolves the origin tags for one audio from its collection memberships — the single source of the
+ * rule shared by every surface that shows tags (My Sounds and the Vault list via `SoundsList`, plus
+ * the search overlay via [searchResultCollectionLabels]).
+ *
+ * Each membership id in [collectionsByAudio] for [audioId] is resolved against [collectionsById]:
+ * the system Vault collection substitutes its localized [systemCollectionLabel] for the stored
+ * literal name; any other collection uses its own name; a stale id (collection deleted) is dropped.
+ *
+ * Privacy: a private collection's name is content that lives behind the Vault gate. While the Vault
+ * session is locked ([vaultOpen] = false) those labels are suppressed, so a cross-tagged
+ * (public AND private) audio — which the upstream membership gate keeps visible on public surfaces —
+ * shows only its public tags and never leaks a private collection's name without authentication.
+ * Once the Vault is unlocked, every membership renders.
+ *
+ * Pure (no Android/Compose deps) so it can be unit-tested without composing any surface.
+ */
+internal fun collectionOriginLabels(
+    audioId: String,
+    collectionsByAudio: Map<String, List<String>>,
+    collectionsById: Map<String, Collection>,
+    systemCollectionLabel: String,
+    vaultOpen: Boolean,
+): List<String> =
+    collectionsByAudio[audioId].orEmpty().mapNotNull { id ->
+        val collection = collectionsById[id]
+        when {
+            collection == null -> null
+            !vaultOpen && collection.isPrivate -> null
+            collection.isSystem -> systemCollectionLabel
+            else -> collection.name
+        }
+    }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -310,6 +310,7 @@ private fun SearchOverlayHost(
         },
         collectionsByAudio = collectionsByAudio,
         allCollections = collections,
+        vaultOpen = vaultOpen,
     )
 }
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -653,6 +653,11 @@ internal fun SoundsList(
     // `mapNotNull` lambda.
     val systemCollectionLabel = stringResource(R.string.app_vault_baul_name)
     val collectionsById = remember(allCollections) { allCollections.associateBy { it.id } }
+    // Live Vault lock state, read directly here the same way SearchOverlayHost / VaultScreen do —
+    // private-collection tags are suppressed while locked so a cross-tagged audio shown on My Sounds
+    // never leaks a private collection's name. On the Vault tab this is always open (the tab only
+    // renders unlocked), so private tags show there as expected.
+    val vaultOpen by VaultSessionState.flow.collectAsState()
 
     Box(modifier = modifier.fillMaxSize()) {
         LazyColumn(
@@ -705,14 +710,7 @@ internal fun SoundsList(
                         if (isWelcome) {
                             emptyList()
                         } else {
-                            collectionsByAudio[sound.id].orEmpty().mapNotNull { id ->
-                                val collection = collectionsById[id]
-                                when {
-                                    collection == null -> null
-                                    collection.isSystem -> systemCollectionLabel
-                                    else -> collection.name
-                                }
-                            }
+                            collectionOriginLabels(sound.id, collectionsByAudio, collectionsById, systemCollectionLabel, vaultOpen)
                         }
                     SoundItem(
                         sound = sound,

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -267,6 +267,7 @@ private fun SearchOverlayHost(
     val tracker = remember(context) { AnalyticsTrackerProvider.get(context.applicationContext) }
     val vaultOpen by VaultSessionState.flow.collectAsState()
     val collections by viewModel.collections.collectAsState()
+    val collectionsByAudio by viewModel.audioCollectionsIndex.collectAsState()
     val hasSearchableVaultContent =
         remember(collections) {
             collections.any { it.isPrivate && it.audioIds.isNotEmpty() }
@@ -307,6 +308,8 @@ private fun SearchOverlayHost(
                 source = AnalyticsSource.SEARCH,
             )
         },
+        collectionsByAudio = collectionsByAudio,
+        allCollections = collections,
     )
 }
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlay.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlay.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
+import com.github.barriosnahuel.vossosunboton.model.Collection
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.ui.predictiveBackTransition
 import com.github.barriosnahuel.vossosunboton.ui.theme.MUTED_TEXT_ALPHA
@@ -86,6 +87,11 @@ fun SearchOverlay(
     onDelete: (Sound) -> Unit,
     showVaultUnlockCta: Boolean = false,
     onUnlockVault: () -> Unit = {},
+    // Per-audio reverse index of collection IDs, resolved against [allCollections] so each result
+    // shows where it lives (collection name, the Vault's localized name, or "Explore" for bundled
+    // audios). Default empty keeps the overlay renderable from previews/tests that don't wire it.
+    collectionsByAudio: Map<String, List<String>> = emptyMap(),
+    allCollections: List<Collection> = emptyList(),
 ) {
     val displayState =
         when {
@@ -163,6 +169,8 @@ fun SearchOverlay(
                                     playbackProgress = playbackProgress,
                                     pausedProgress = pausedProgress,
                                     soundDurations = soundDurations,
+                                    collectionsByAudio = collectionsByAudio,
+                                    allCollections = allCollections,
                                     onPlayClick = onPlayClick,
                                     onSeek = onSeek,
                                     onShareClick = onShareClick,
@@ -324,12 +332,17 @@ private fun SearchResultsList(
     playbackProgress: PlaybackProgress?,
     pausedProgress: Map<String, PlaybackProgress>,
     soundDurations: Map<String, Int>,
+    collectionsByAudio: Map<String, List<String>>,
+    allCollections: List<Collection>,
     onPlayClick: (Sound) -> Unit,
     onSeek: (Int) -> Unit,
     onShareClick: (Sound) -> Unit,
     onPinClick: (Sound) -> Unit,
     onDelete: (Sound) -> Unit,
 ) {
+    val collectionsById = remember(allCollections) { allCollections.associateBy { it.id } }
+    val systemCollectionLabel = stringResource(R.string.app_vault_baul_name)
+    val exploreLabel = stringResource(R.string.app_search_origin_explore)
     LazyColumn(contentPadding = PaddingValues(vertical = Spacing.SM)) {
         items(results, key = { it.id }) { sound ->
             SoundItem(
@@ -341,10 +354,46 @@ private fun SearchResultsList(
                 onShareClick = { onShareClick(sound) },
                 onDelete = { onDelete(sound) },
                 onPinClick = { onPinClick(sound) },
+                collectionLabels =
+                    searchResultCollectionLabels(
+                        sound = sound,
+                        collectionsByAudio = collectionsByAudio,
+                        collectionsById = collectionsById,
+                        systemCollectionLabel = systemCollectionLabel,
+                        exploreLabel = exploreLabel,
+                    ),
             )
         }
     }
 }
+
+/**
+ * Origin tags shown on a search result, since search spans every surface and a result on its own
+ * gives no hint of where it lives. A bundled audio belongs to the read-only Explore catalog, so it
+ * carries the single [exploreLabel]. Any other audio resolves its collection memberships the same
+ * way My Sounds does — the Vault's system collection substitutes its localized [systemCollectionLabel]
+ * for the stored literal — and an audio in no collection gets no tag. Pure so it can be unit-tested
+ * without composing the overlay.
+ */
+internal fun searchResultCollectionLabels(
+    sound: Sound,
+    collectionsByAudio: Map<String, List<String>>,
+    collectionsById: Map<String, Collection>,
+    systemCollectionLabel: String,
+    exploreLabel: String,
+): List<String> =
+    if (sound.isBundled()) {
+        listOf(exploreLabel)
+    } else {
+        collectionsByAudio[sound.id].orEmpty().mapNotNull { id ->
+            val collection = collectionsById[id]
+            when {
+                collection == null -> null
+                collection.isSystem -> systemCollectionLabel
+                else -> collection.name
+            }
+        }
+    }
 
 // Dim level of the full-screen scrim behind the search surface (over Color.Black). A named alpha,
 // not a magic literal — see ui/theme/Alpha.kt for the shared ones and the rationale.

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlay.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlay.kt
@@ -92,6 +92,10 @@ fun SearchOverlay(
     // audios). Default empty keeps the overlay renderable from previews/tests that don't wire it.
     collectionsByAudio: Map<String, List<String>> = emptyMap(),
     allCollections: List<Collection> = emptyList(),
+    // While the Vault session is locked, private-collection tags are suppressed so a cross-tagged
+    // result never leaks a private collection's name without authentication. Default false = safe
+    // (hide private) for callers that don't wire it.
+    vaultOpen: Boolean = false,
 ) {
     val displayState =
         when {
@@ -171,6 +175,7 @@ fun SearchOverlay(
                                     soundDurations = soundDurations,
                                     collectionsByAudio = collectionsByAudio,
                                     allCollections = allCollections,
+                                    vaultOpen = vaultOpen,
                                     onPlayClick = onPlayClick,
                                     onSeek = onSeek,
                                     onShareClick = onShareClick,
@@ -334,6 +339,7 @@ private fun SearchResultsList(
     soundDurations: Map<String, Int>,
     collectionsByAudio: Map<String, List<String>>,
     allCollections: List<Collection>,
+    vaultOpen: Boolean,
     onPlayClick: (Sound) -> Unit,
     onSeek: (Int) -> Unit,
     onShareClick: (Sound) -> Unit,
@@ -361,6 +367,7 @@ private fun SearchResultsList(
                         collectionsById = collectionsById,
                         systemCollectionLabel = systemCollectionLabel,
                         exploreLabel = exploreLabel,
+                        vaultOpen = vaultOpen,
                     ),
             )
         }
@@ -370,10 +377,16 @@ private fun SearchResultsList(
 /**
  * Origin tags shown on a search result, since search spans every surface and a result on its own
  * gives no hint of where it lives. A bundled audio belongs to the read-only Explore catalog, so it
- * carries the single [exploreLabel]. Any other audio resolves its collection memberships the same
- * way My Sounds does — the Vault's system collection substitutes its localized [systemCollectionLabel]
- * for the stored literal — and an audio in no collection gets no tag. Pure so it can be unit-tested
- * without composing the overlay.
+ * carries the single [exploreLabel]. Any other audio resolves its collection memberships — the
+ * Vault's system collection substitutes its localized [systemCollectionLabel] for the stored
+ * literal — and an audio in no collection gets no tag.
+ *
+ * Privacy: a *private* collection's name is content that lives behind the Vault gate, so while the
+ * Vault session is locked ([vaultOpen] = false) labels for private collections are suppressed —
+ * a cross-tagged (public AND private) audio that the upstream gate keeps visible then shows only
+ * its public tags, never leaking the private collection's name without authentication. Once the
+ * Vault is unlocked, all memberships render. Pure so it can be unit-tested without composing the
+ * overlay.
  */
 internal fun searchResultCollectionLabels(
     sound: Sound,
@@ -381,6 +394,7 @@ internal fun searchResultCollectionLabels(
     collectionsById: Map<String, Collection>,
     systemCollectionLabel: String,
     exploreLabel: String,
+    vaultOpen: Boolean,
 ): List<String> =
     if (sound.isBundled()) {
         listOf(exploreLabel)
@@ -389,6 +403,7 @@ internal fun searchResultCollectionLabels(
             val collection = collectionsById[id]
             when {
                 collection == null -> null
+                !vaultOpen && collection.isPrivate -> null
                 collection.isSystem -> systemCollectionLabel
                 else -> collection.name
             }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlay.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlay.kt
@@ -375,18 +375,10 @@ private fun SearchResultsList(
 }
 
 /**
- * Origin tags shown on a search result, since search spans every surface and a result on its own
- * gives no hint of where it lives. A bundled audio belongs to the read-only Explore catalog, so it
- * carries the single [exploreLabel]. Any other audio resolves its collection memberships — the
- * Vault's system collection substitutes its localized [systemCollectionLabel] for the stored
- * literal — and an audio in no collection gets no tag.
- *
- * Privacy: a *private* collection's name is content that lives behind the Vault gate, so while the
- * Vault session is locked ([vaultOpen] = false) labels for private collections are suppressed —
- * a cross-tagged (public AND private) audio that the upstream gate keeps visible then shows only
- * its public tags, never leaking the private collection's name without authentication. Once the
- * Vault is unlocked, all memberships render. Pure so it can be unit-tested without composing the
- * overlay.
+ * Origin tags for a search result. A bundled audio belongs to the read-only Explore catalog, so it
+ * carries the single [exploreLabel]; any other audio defers to the shared [collectionOriginLabels]
+ * — same lock-aware rule used by My Sounds and the Vault list, so a private collection's name never
+ * leaks on a locked search surface.
  */
 internal fun searchResultCollectionLabels(
     sound: Sound,
@@ -399,15 +391,7 @@ internal fun searchResultCollectionLabels(
     if (sound.isBundled()) {
         listOf(exploreLabel)
     } else {
-        collectionsByAudio[sound.id].orEmpty().mapNotNull { id ->
-            val collection = collectionsById[id]
-            when {
-                collection == null -> null
-                !vaultOpen && collection.isPrivate -> null
-                collection.isSystem -> systemCollectionLabel
-                else -> collection.name
-            }
-        }
+        collectionOriginLabels(sound.id, collectionsByAudio, collectionsById, systemCollectionLabel, vaultOpen)
     }
 
 // Dim level of the full-screen scrim behind the search surface (over Color.Black). A named alpha,

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -29,6 +29,9 @@
     <string name="app_search_empty_headline">Silencio absoluto…</string>
     <string name="app_search_empty_subtext">Este sticker aún no existe. Tu colección tiene un vacío que solo vos podés llenar.</string>
     <string name="app_search_vault_cta">Buscá también en tu Baúl</string>
+    <!-- Origin tag on a search result that comes from the read-only Explore catalog (bundled audios).
+         Keep in sync with the Explore tab label (app_navigation_menu_item_explore_sounds). -->
+    <string name="app_search_origin_explore">Explorar</string>
     <string name="app_edit">Renombrar</string>
     <string name="app_feedback_button_renamed">¡%1$s renombrado!</string>
     <string name="app_pin">Destacar al inicio</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,9 @@
     <string name="app_search_empty_headline">Absolute silence…</string>
     <string name="app_search_empty_subtext">This sticker doesn\'t exist yet. Your collection has a gap only you can fill.</string>
     <string name="app_search_vault_cta">Search your Vault too</string>
+    <!-- Origin tag on a search result that comes from the read-only Explore catalog (bundled audios).
+         Keep in sync with the Explore tab label (app_navigation_menu_item_explore_sounds). -->
+    <string name="app_search_origin_explore">Explore</string>
     <string name="app_edit">Rename</string>
     <string name="app_feedback_button_renamed">%1$s renamed!</string>
     <string name="app_pin">Pin to top</string>

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchResultLabelsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchResultLabelsTest.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home
+
+import com.github.barriosnahuel.vossosunboton.model.Collection
+import com.github.barriosnahuel.vossosunboton.model.CollectionProfile
+import com.github.barriosnahuel.vossosunboton.testSound
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+internal class SearchResultLabelsTest {
+    private val explore = "Explore"
+    private val vault = "My Vault"
+
+    private val work = Collection(id = "c-work", name = "Work", profile = CollectionProfile.GENERIC_PUBLIC)
+    private val family = Collection(id = "c-family", name = "Family", profile = CollectionProfile.GENERIC_PUBLIC)
+    private val baul = Collection(id = "c-baul", name = "stored-literal", profile = CollectionProfile.VAULT, isSystem = true)
+    private val byId = listOf(work, family, baul).associateBy { it.id }
+
+    @Test
+    fun `bundled audio is tagged Explore`() {
+        val bundled = testSound(name = "ambulancia", file = null)
+
+        val labels =
+            searchResultCollectionLabels(
+                bundled,
+                collectionsByAudio = emptyMap(),
+                collectionsById = byId,
+                systemCollectionLabel = vault,
+                exploreLabel = explore,
+            )
+
+        assertThat(labels).containsExactly(explore)
+    }
+
+    @Test
+    fun `bundled audio is tagged Explore even if it appears in the audio-collections index`() {
+        // Bundled audios cannot be added to collections, but the Explore branch must win regardless
+        // so a stale index entry never makes a bundled result show a collection tag instead.
+        val bundled = testSound(name = "ambulancia", file = null)
+        val index = mapOf(bundled.id to listOf("c-work"))
+
+        val labels =
+            searchResultCollectionLabels(
+                bundled,
+                collectionsByAudio = index,
+                collectionsById = byId,
+                systemCollectionLabel = vault,
+                exploreLabel = explore,
+            )
+
+        assertThat(labels).containsExactly(explore)
+    }
+
+    @Test
+    fun `custom audio in a public collection is tagged with the collection name`() {
+        val custom = testSound(name = "che", file = "/audio/che.mp3")
+        val index = mapOf(custom.id to listOf("c-work"))
+
+        val labels =
+            searchResultCollectionLabels(
+                custom,
+                collectionsByAudio = index,
+                collectionsById = byId,
+                systemCollectionLabel = vault,
+                exploreLabel = explore,
+            )
+
+        assertThat(labels).containsExactly("Work")
+    }
+
+    @Test
+    fun `custom audio in the system Vault collection is tagged with the localized name, not the stored literal`() {
+        val custom = testSound(name = "secreto", file = "/audio/secreto.mp3")
+        val index = mapOf(custom.id to listOf("c-baul"))
+
+        val labels =
+            searchResultCollectionLabels(
+                custom,
+                collectionsByAudio = index,
+                collectionsById = byId,
+                systemCollectionLabel = vault,
+                exploreLabel = explore,
+            )
+
+        assertThat(labels).containsExactly(vault)
+    }
+
+    @Test
+    fun `custom audio in several collections keeps the index order`() {
+        val custom = testSound(name = "multi", file = "/audio/multi.mp3")
+        val index = mapOf(custom.id to listOf("c-work", "c-family"))
+
+        val labels =
+            searchResultCollectionLabels(
+                custom,
+                collectionsByAudio = index,
+                collectionsById = byId,
+                systemCollectionLabel = vault,
+                exploreLabel = explore,
+            )
+
+        assertThat(labels).containsExactly("Work", "Family").inOrder()
+    }
+
+    @Test
+    fun `cross-tagged audio shows both its public collection and the Vault, mirroring My Sounds`() {
+        // A public+private audio stays searchable even while the Vault is locked (spec § 3.1), so
+        // its tag carries both memberships exactly as My Sounds renders them — the Vault substitutes
+        // its localized name. The lock-state filtering of private-only audios happens upstream in the
+        // ViewModel, never in this pure resolver, so the same labels apply regardless of lock state.
+        val custom = testSound(name = "cross", file = "/audio/cross.mp3")
+        val index = mapOf(custom.id to listOf("c-work", "c-baul"))
+
+        val labels =
+            searchResultCollectionLabels(
+                custom,
+                collectionsByAudio = index,
+                collectionsById = byId,
+                systemCollectionLabel = vault,
+                exploreLabel = explore,
+            )
+
+        assertThat(labels).containsExactly("Work", vault).inOrder()
+    }
+
+    @Test
+    fun `custom audio in no collection has no tag`() {
+        val custom = testSound(name = "orphan", file = "/audio/orphan.mp3")
+
+        val labels =
+            searchResultCollectionLabels(
+                custom,
+                collectionsByAudio = emptyMap(),
+                collectionsById = byId,
+                systemCollectionLabel = vault,
+                exploreLabel = explore,
+            )
+
+        assertThat(labels).isEmpty()
+    }
+
+    @Test
+    fun `custom audio referencing an unknown collection id drops that label`() {
+        // A reverse-index entry can outlive a deleted collection; resolving against an absent id
+        // must skip it rather than crash or surface a blank tag.
+        val custom = testSound(name = "stale", file = "/audio/stale.mp3")
+        val index = mapOf(custom.id to listOf("c-work", "c-deleted"))
+
+        val labels =
+            searchResultCollectionLabels(
+                custom,
+                collectionsByAudio = index,
+                collectionsById = byId,
+                systemCollectionLabel = vault,
+                exploreLabel = explore,
+            )
+
+        assertThat(labels).containsExactly("Work")
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchResultLabelsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchResultLabelsTest.kt
@@ -18,20 +18,14 @@ internal class SearchResultLabelsTest {
     private val work = Collection(id = "c-work", name = "Work", profile = CollectionProfile.GENERIC_PUBLIC)
     private val family = Collection(id = "c-family", name = "Family", profile = CollectionProfile.GENERIC_PUBLIC)
     private val baul = Collection(id = "c-baul", name = "stored-literal", profile = CollectionProfile.VAULT, isSystem = true)
-    private val byId = listOf(work, family, baul).associateBy { it.id }
+    private val secrets = Collection(id = "c-secrets", name = "Secrets", profile = CollectionProfile.VAULT)
+    private val byId = listOf(work, family, baul, secrets).associateBy { it.id }
 
     @Test
     fun `bundled audio is tagged Explore`() {
         val bundled = testSound(name = "ambulancia", file = null)
 
-        val labels =
-            searchResultCollectionLabels(
-                bundled,
-                collectionsByAudio = emptyMap(),
-                collectionsById = byId,
-                systemCollectionLabel = vault,
-                exploreLabel = explore,
-            )
+        val labels = labelsFor(bundled, index = emptyMap(), vaultOpen = false)
 
         assertThat(labels).containsExactly(explore)
     }
@@ -41,16 +35,8 @@ internal class SearchResultLabelsTest {
         // Bundled audios cannot be added to collections, but the Explore branch must win regardless
         // so a stale index entry never makes a bundled result show a collection tag instead.
         val bundled = testSound(name = "ambulancia", file = null)
-        val index = mapOf(bundled.id to listOf("c-work"))
 
-        val labels =
-            searchResultCollectionLabels(
-                bundled,
-                collectionsByAudio = index,
-                collectionsById = byId,
-                systemCollectionLabel = vault,
-                exploreLabel = explore,
-            )
+        val labels = labelsFor(bundled, index = mapOf(bundled.id to listOf("c-work")), vaultOpen = false)
 
         assertThat(labels).containsExactly(explore)
     }
@@ -58,87 +44,67 @@ internal class SearchResultLabelsTest {
     @Test
     fun `custom audio in a public collection is tagged with the collection name`() {
         val custom = testSound(name = "che", file = "/audio/che.mp3")
-        val index = mapOf(custom.id to listOf("c-work"))
 
-        val labels =
-            searchResultCollectionLabels(
-                custom,
-                collectionsByAudio = index,
-                collectionsById = byId,
-                systemCollectionLabel = vault,
-                exploreLabel = explore,
-            )
+        val labels = labelsFor(custom, index = mapOf(custom.id to listOf("c-work")), vaultOpen = false)
 
         assertThat(labels).containsExactly("Work")
     }
 
     @Test
-    fun `custom audio in the system Vault collection is tagged with the localized name, not the stored literal`() {
+    fun `system Vault collection shows its localized name when the Vault is unlocked`() {
         val custom = testSound(name = "secreto", file = "/audio/secreto.mp3")
-        val index = mapOf(custom.id to listOf("c-baul"))
 
-        val labels =
-            searchResultCollectionLabels(
-                custom,
-                collectionsByAudio = index,
-                collectionsById = byId,
-                systemCollectionLabel = vault,
-                exploreLabel = explore,
-            )
+        val labels = labelsFor(custom, index = mapOf(custom.id to listOf("c-baul")), vaultOpen = true)
 
         assertThat(labels).containsExactly(vault)
     }
 
     @Test
-    fun `custom audio in several collections keeps the index order`() {
-        val custom = testSound(name = "multi", file = "/audio/multi.mp3")
-        val index = mapOf(custom.id to listOf("c-work", "c-family"))
+    fun `private collection tag is hidden while the Vault is locked`() {
+        // The private collection's name is content behind the Vault gate — a locked session must
+        // not surface it. (Private-only audios are filtered out of search upstream anyway; this is
+        // the resolver's own guard.)
+        val custom = testSound(name = "secreto", file = "/audio/secreto.mp3")
 
-        val labels =
-            searchResultCollectionLabels(
-                custom,
-                collectionsByAudio = index,
-                collectionsById = byId,
-                systemCollectionLabel = vault,
-                exploreLabel = explore,
-            )
+        val labels = labelsFor(custom, index = mapOf(custom.id to listOf("c-secrets")), vaultOpen = false)
+
+        assertThat(labels).isEmpty()
+    }
+
+    @Test
+    fun `custom audio in several public collections keeps the index order`() {
+        val custom = testSound(name = "multi", file = "/audio/multi.mp3")
+
+        val labels = labelsFor(custom, index = mapOf(custom.id to listOf("c-work", "c-family")), vaultOpen = false)
 
         assertThat(labels).containsExactly("Work", "Family").inOrder()
     }
 
     @Test
-    fun `cross-tagged audio shows both its public collection and the Vault, mirroring My Sounds`() {
-        // A public+private audio stays searchable even while the Vault is locked (spec § 3.1), so
-        // its tag carries both memberships exactly as My Sounds renders them — the Vault substitutes
-        // its localized name. The lock-state filtering of private-only audios happens upstream in the
-        // ViewModel, never in this pure resolver, so the same labels apply regardless of lock state.
+    fun `cross-tagged audio shows both its public and private tags when the Vault is unlocked`() {
         val custom = testSound(name = "cross", file = "/audio/cross.mp3")
-        val index = mapOf(custom.id to listOf("c-work", "c-baul"))
 
-        val labels =
-            searchResultCollectionLabels(
-                custom,
-                collectionsByAudio = index,
-                collectionsById = byId,
-                systemCollectionLabel = vault,
-                exploreLabel = explore,
-            )
+        val labels = labelsFor(custom, index = mapOf(custom.id to listOf("c-work", "c-secrets")), vaultOpen = true)
 
-        assertThat(labels).containsExactly("Work", vault).inOrder()
+        assertThat(labels).containsExactly("Work", "Secrets").inOrder()
+    }
+
+    @Test
+    fun `cross-tagged audio hides its private collection tag while the Vault is locked`() {
+        // The leak guard: a public+private audio stays searchable while locked (spec § 3.1), but its
+        // tag must show only the public collection — never the private collection's name.
+        val custom = testSound(name = "cross", file = "/audio/cross.mp3")
+
+        val labels = labelsFor(custom, index = mapOf(custom.id to listOf("c-work", "c-secrets")), vaultOpen = false)
+
+        assertThat(labels).containsExactly("Work")
     }
 
     @Test
     fun `custom audio in no collection has no tag`() {
         val custom = testSound(name = "orphan", file = "/audio/orphan.mp3")
 
-        val labels =
-            searchResultCollectionLabels(
-                custom,
-                collectionsByAudio = emptyMap(),
-                collectionsById = byId,
-                systemCollectionLabel = vault,
-                exploreLabel = explore,
-            )
+        val labels = labelsFor(custom, index = emptyMap(), vaultOpen = false)
 
         assertThat(labels).isEmpty()
     }
@@ -148,17 +114,23 @@ internal class SearchResultLabelsTest {
         // A reverse-index entry can outlive a deleted collection; resolving against an absent id
         // must skip it rather than crash or surface a blank tag.
         val custom = testSound(name = "stale", file = "/audio/stale.mp3")
-        val index = mapOf(custom.id to listOf("c-work", "c-deleted"))
 
-        val labels =
-            searchResultCollectionLabels(
-                custom,
-                collectionsByAudio = index,
-                collectionsById = byId,
-                systemCollectionLabel = vault,
-                exploreLabel = explore,
-            )
+        val labels = labelsFor(custom, index = mapOf(custom.id to listOf("c-work", "c-deleted")), vaultOpen = false)
 
         assertThat(labels).containsExactly("Work")
     }
+
+    private fun labelsFor(
+        sound: com.github.barriosnahuel.vossosunboton.model.Sound,
+        index: Map<String, List<String>>,
+        vaultOpen: Boolean,
+    ): List<String> =
+        searchResultCollectionLabels(
+            sound = sound,
+            collectionsByAudio = index,
+            collectionsById = byId,
+            systemCollectionLabel = vault,
+            exploreLabel = explore,
+            vaultOpen = vaultOpen,
+        )
 }


### PR DESCRIPTION
### Summary

A user-facing fix to **origin tags** on Bomps, across the whole app.

1. User opens search (it spans every tab), or browses My Sounds
2. A Bomp may live in several collections — public and/or private

**before:** search results were bare names (the "origin badge" announced in v2.0.0 never rendered); and on My Sounds a Bomp that's *also* in a private collection showed that private collection's name even with the Vault **locked**.
**after:** every result/card shows where the Bomp lives — its collection, your Vault, or "Explore" — and a **private** collection's name appears only once the Vault is unlocked, on every surface.

### Technical detail

- **`CollectionOriginLabels.kt` (new, pure)** — `collectionOriginLabels` is the single source of the tag rule: resolve memberships, system Vault → localized name, and **suppress private-collection labels while the Vault is locked**.
- **`SoundsList`** (renders My Sounds *and* the Vault list) reads the live `VaultSessionState` and routes through the resolver — one change covers both surfaces. The Vault tab only renders unlocked, so its tags show.
- **`SearchOverlay`** — `searchResultCollectionLabels` keeps the bundled → `["Explore"]` branch and delegates the rest to the shared resolver.
- **strings** — new `app_search_origin_explore` (en "Explore", es-AR "Explorar").
- **Coherent commits:** (1) search tags, (2) search lock-aware, (3) shared resolver + My Sounds/Vault lock-aware.

### Code review tips

- **One rule, three surfaces:** search, My Sounds and the Vault list all go through `collectionOriginLabels`. Lock state is sourced per surface — search threads it from `SearchOverlayHost`; `SoundsList` reads `VaultSessionState` directly, mirroring how `SearchOverlayHost` / `VaultScreen` already access that singleton.
- **Audio-visibility gate untouched:** which *audios* surface is still `SoundsViewModel.recomputeSearchResults` (`inPrivate − inPublic`) and the My Sounds membership filter; this PR only changes which *tags* render.
- **Cross-tagged + locked is the path that mattered:** a public+private audio stays visible but must not leak the private name. Unit-tested in `SearchResultLabelsTest`; instrumented on My Sounds in `SoundItemInlineLabelsFlowTest` (locked hides it, unlocked shows it).

### Already tested

- instrumented (not in CI per ADR 0001): `SoundItemInlineLabelsFlowTest` + `SearchOverlayTest` + `VaultSystemCollectionLocaleTest` — 14/14 local green (incl. My Sounds locked-hides / unlocked-shows the private tag, and Vault tags still render)
