### PR TITLE
fix(playback): detach SoundsViewModel from PlayerController in onCleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,9 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - CircleCI PR workflow parallelizes `lint`, `test`, and `bundle` after the cheap linters (`detekt`, `ktlint`, `spotless`) instead of serializing them; `lint` job drops the redundant `app:lintRelease` re-invocation and `app:lintVitalRelease` (a fatal-only filter over the same checks); `bundle` job drops `bundleDebug` (the debug AAB was never consumed in CI). Critical path drops from ~14m39s to an estimated ~6-7min without losing coverage
 - Replaced the unmaintained `androidx.compose.material:material-icons-core` dependency with bundled Material Symbols vector drawables loaded via `painterResource`: the 15 icons in use become `app_ic_*` drawables (filled/outlined matched to the originals, `autoMirrored` preserved for the back arrow and chevron); `AppIcons` local vectors are untouched
 
+#### Fixed
+- Fixed a `SoundsViewModel` leak — it registered as the process-singleton `PlayerController`'s playback listener in `init` but never detached, so each cleared ViewModel stayed reachable for the life of the process; it now detaches in `onCleared`. Confirmed by heap analysis and guarded by `SoundsViewModelLifecycleTest`
+
 #### Removed
 - Dead post-save plumbing: `EXTRA_BUTTON_SAVED` / `EXTRA_BUTTON_RENAMED` / `EXTRA_BUTTON_NAME` Intent extras, `SoundsViewModel.buttonSavedEvent` / `buttonRenamedEvent` channels and their `onButtonSaved` / `onButtonRenamed` setters, the `LandingScreen` `LaunchedEffect`s that consumed them, and `AddButtonActivity.navigateBackSaved` / `navigateBackRenamed`
 - `bundledNames(context)` and the two `require(sound.name !in bundledNames(...))` guards in `SoundsRepository.save`/`rename` — with stable `Sound.id` (ADR 0008) a custom sound legitimately sharing a name with a bundled one is no longer an identity collision

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerController.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerController.kt
@@ -96,6 +96,14 @@ internal interface PlayerController {
      * @param listener the listener that will handle all play/stop callbacks for all buttons.
      */
     fun setOnStartStopListener(listener: PlayerControllerListener)
+
+    /**
+     * Detaches [listener] only if it is the currently-registered one (a no-op once a newer listener
+     * has replaced it). Call from the consumer's lifecycle teardown (e.g. `ViewModel.onCleared`): this
+     * controller is a process-singleton, so a consumer that never detaches is retained for the whole
+     * process — a leak (see [PlayerControllerFactory]).
+     */
+    fun removeOnStartStopListener(listener: PlayerControllerListener)
 }
 
 internal interface PlayerControllerListener {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerImpl.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerImpl.kt
@@ -410,6 +410,12 @@ internal class PlayerControllerImpl(
         this.listener = listener
     }
 
+    override fun removeOnStartStopListener(listener: PlayerControllerListener) {
+        if (this.listener === listener) {
+            this.listener = null
+        }
+    }
+
     private fun describeTarget(t: PlaybackTarget): String =
         when (t) {
             is PlaybackTarget.SoundTarget -> "sound=${t.sound.name}"

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -273,6 +273,16 @@ class SoundsViewModel(
     private val _movedToVaultEvent = Channel<MovedToVaultEvent>(Channel.CONFLATED)
     val movedToVaultEvent: Flow<MovedToVaultEvent> = _movedToVaultEvent.receiveAsFlow()
 
+    /**
+     * Detach from the process-singleton [PlayerControllerFactory] this registers with in [init].
+     * Without it, a cleared ViewModel — with its caches and collectors — stays reachable through
+     * `PlayerControllerImpl.listener` for the whole process (heap-confirmed leak).
+     */
+    override fun onCleared() {
+        PlayerControllerFactory.instance.removeOnStartStopListener(this)
+        super.onCleared()
+    }
+
     init {
         PlayerControllerFactory.instance.setOnStartStopListener(this)
         // Single coroutine: read welcome-sticker visibility BEFORE the first loadSounds so the

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenDuplicateNameHintTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenDuplicateNameHintTest.kt
@@ -96,6 +96,7 @@ internal class AddButtonScreenDuplicateNameHintTest : AbstractRobolectricTest() 
         every { PlayerControllerFactory.instance.resume() } answers { nothing }
         every { PlayerControllerFactory.instance.seekTo(any()) } answers { nothing }
         every { PlayerControllerFactory.instance.setOnStartStopListener(any()) } answers { nothing }
+        every { PlayerControllerFactory.instance.removeOnStartStopListener(any()) } answers { nothing }
         runBlocking { SoundsRepository(context).clearForTest() }
     }
 

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreenTest.kt
@@ -51,6 +51,7 @@ internal class ImmersiveListenScreenTest : AbstractRobolectricTest() {
         AnalyticsTrackerProvider.setForTest(fakeTracker)
         mockkObject(PlayerControllerFactory)
         every { PlayerControllerFactory.instance.setOnStartStopListener(any()) } answers { nothing }
+        every { PlayerControllerFactory.instance.removeOnStartStopListener(any()) } answers { nothing }
     }
 
     @After

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultScreenTest.kt
@@ -65,6 +65,7 @@ internal class VaultScreenTest : AbstractRobolectricTest() {
         }
         mockkObject(PlayerControllerFactory)
         every { PlayerControllerFactory.instance.setOnStartStopListener(any()) } answers { nothing }
+        every { PlayerControllerFactory.instance.removeOnStartStopListener(any()) } answers { nothing }
     }
 
     @After

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivityTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivityTest.kt
@@ -40,6 +40,7 @@ internal class LandingActivityTest : AbstractRobolectricTest() {
     fun setUp() {
         mockkObject(PlayerControllerFactory)
         every { PlayerControllerFactory.instance.setOnStartStopListener(any()) } answers { nothing }
+        every { PlayerControllerFactory.instance.removeOnStartStopListener(any()) } answers { nothing }
     }
 
     @After

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenAnalyticsTest.kt
@@ -45,6 +45,7 @@ internal class LandingScreenAnalyticsTest : AbstractRobolectricTest() {
         AnalyticsTrackerProvider.setForTest(fake)
         mockkObject(PlayerControllerFactory)
         every { PlayerControllerFactory.instance.setOnStartStopListener(any()) } answers { nothing }
+        every { PlayerControllerFactory.instance.removeOnStartStopListener(any()) } answers { nothing }
     }
 
     @After

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
@@ -41,6 +41,7 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
     fun setUp() {
         mockkObject(PlayerControllerFactory)
         every { PlayerControllerFactory.instance.setOnStartStopListener(any()) } answers { nothing }
+        every { PlayerControllerFactory.instance.removeOnStartStopListener(any()) } answers { nothing }
     }
 
     @After

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelAnalyticsTest.kt
@@ -60,6 +60,7 @@ internal class SoundsViewModelAnalyticsTest : AbstractRobolectricTest() {
         }
         mockkObject(PlayerControllerFactory)
         every { PlayerControllerFactory.instance.setOnStartStopListener(any()) } answers { nothing }
+        every { PlayerControllerFactory.instance.removeOnStartStopListener(any()) } answers { nothing }
         every { PlayerControllerFactory.instance.startPlayingSound(any(), any()) } answers { nothing }
         every { PlayerControllerFactory.instance.pause() } answers { nothing }
         every { PlayerControllerFactory.instance.forgetSound(any()) } answers { nothing }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelCollectionsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelCollectionsTest.kt
@@ -45,6 +45,7 @@ internal class SoundsViewModelCollectionsTest : AbstractRobolectricTest() {
         }
         mockkObject(PlayerControllerFactory)
         every { PlayerControllerFactory.instance.setOnStartStopListener(any()) } answers { nothing }
+        every { PlayerControllerFactory.instance.removeOnStartStopListener(any()) } answers { nothing }
         every { PlayerControllerFactory.instance.forgetSound(any()) } answers { nothing }
         every { PlayerControllerFactory.instance.pause() } answers { nothing }
     }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelLifecycleTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelLifecycleTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.feature.collections.MySoundsFilterStore
+import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
+import com.github.barriosnahuel.vossosunboton.feature.share.ShareFeature
+import com.github.barriosnahuel.vossosunboton.feature.vault.VaultFilterStore
+import com.github.barriosnahuel.vossosunboton.feature.welcome.WelcomeStickerStore
+import com.github.barriosnahuel.vossosunboton.model.data.manager.CollectionsRepository
+import com.github.barriosnahuel.vossosunboton.model.data.manager.SoundsRepository
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Guards the listener-leak fix proven by the LeakCanary heap analysis: a destroyed [SoundsViewModel]
+ * stayed reachable forever through `PlayerControllerFactory.instance` (a process-singleton) because it
+ * registered itself as the playback listener in `init` and never detached. The regression this guards:
+ * the user opens the app, navigates around (each visit builds and clears a `SoundsViewModel`), and every
+ * cleared ViewModel — with its caches and collectors — is pinned in memory for the life of the process.
+ */
+internal class SoundsViewModelLifecycleTest : AbstractRobolectricTest() {
+    private val createdViewModels = mutableListOf<SoundsViewModel>()
+
+    @Before
+    fun setUp() {
+        runBlocking {
+            val ctx = ApplicationProvider.getApplicationContext<android.content.Context>()
+            SoundsRepository(ctx).clearForTest()
+            WelcomeStickerStore(ctx).clearForTest()
+            CollectionsRepository(ctx).clearForTest()
+            MySoundsFilterStore(ctx).clearForTest()
+            VaultFilterStore(ctx).clearForTest()
+        }
+        mockkObject(PlayerControllerFactory)
+        every { PlayerControllerFactory.instance.setOnStartStopListener(any()) } answers { nothing }
+        every { PlayerControllerFactory.instance.removeOnStartStopListener(any()) } answers { nothing }
+    }
+
+    @After
+    fun tearDown() {
+        createdViewModels.cancelAndJoinAll()
+        createdViewModels.clear()
+        unmockkAll()
+    }
+
+    @Test
+    fun `detaches the playback listener when the ViewModel is cleared`() {
+        val viewModel = givenAViewModel()
+        verify { PlayerControllerFactory.instance.setOnStartStopListener(viewModel) }
+
+        clearViaViewModelStore(viewModel)
+
+        verify { PlayerControllerFactory.instance.removeOnStartStopListener(viewModel) }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun givenAViewModel(): SoundsViewModel {
+        val context = ApplicationProvider.getApplicationContext<android.app.Application>()
+        val vm =
+            SoundsViewModel(
+                context,
+                ioDispatcher = UnconfinedTestDispatcher(),
+                welcomeStore = WelcomeStickerStore(context),
+                shareFeature = ShareFeature.instance,
+            )
+        createdViewModels += vm
+        runBlocking { vm.isInitialLoadComplete.first { it } }
+        return vm
+    }
+
+    /**
+     * Drives the real ViewModel teardown: hosting [viewModel] in a [ViewModelStore] and clearing it is
+     * what the framework does on `Activity.onDestroy`, and it invokes `onCleared()` — the hook under test.
+     */
+    private fun clearViaViewModelStore(viewModel: SoundsViewModel) {
+        val store = ViewModelStore()
+        ViewModelProvider(
+            store,
+            object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(
+                    modelClass: Class<T>,
+                    extras: CreationExtras,
+                ): T = viewModel as T
+            },
+        )[SoundsViewModel::class.java]
+        store.clear()
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelSearchTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelSearchTest.kt
@@ -32,6 +32,7 @@ internal class SoundsViewModelSearchTest : AbstractRobolectricTest() {
     fun setUp() {
         mockkObject(PlayerControllerFactory)
         every { PlayerControllerFactory.instance.setOnStartStopListener(any()) } answers { nothing }
+        every { PlayerControllerFactory.instance.removeOnStartStopListener(any()) } answers { nothing }
         every { PlayerControllerFactory.instance.forgetSound(any()) } answers { nothing }
     }
 

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
@@ -57,6 +57,7 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
         }
         mockkObject(PlayerControllerFactory)
         every { PlayerControllerFactory.instance.setOnStartStopListener(any()) } answers { nothing }
+        every { PlayerControllerFactory.instance.removeOnStartStopListener(any()) } answers { nothing }
         // deleteSound always asks the controller to forget the sound. Stubbing here keeps individual
         // delete-related tests free of boilerplate; tests that need to assert the call still verify
         // it explicitly.

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelVisibilityTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelVisibilityTest.kt
@@ -61,6 +61,7 @@ internal class SoundsViewModelVisibilityTest : AbstractRobolectricTest() {
         }
         mockkObject(PlayerControllerFactory)
         every { PlayerControllerFactory.instance.setOnStartStopListener(any()) } answers { nothing }
+        every { PlayerControllerFactory.instance.removeOnStartStopListener(any()) } answers { nothing }
         every { PlayerControllerFactory.instance.forgetSound(any()) } answers { nothing }
         every { PlayerControllerFactory.instance.pause() } answers { nothing }
     }


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change. Removes a process-lifetime retention of the cleared Home/tabs ViewModel: every time the user navigated away and the `SoundsViewModel` was cleared, the ViewModel (with its caches and collectors) stayed reachable for the whole process. Bounded in practice (one stale instance, overwritten each time), but a real leak — confirmed by heap analysis.

### Technical detail

Fixes a `SoundsViewModel` retention leak found via on-device heap analysis.

- **Root cause:** `init` registers the VM as the listener on the process-singleton `PlayerControllerFactory.instance`; nothing ever detached it. Heap chain: `PlayerControllerFactory.instance → PlayerControllerImpl.listener → SoundsViewModel`.
- **Fix:** new `PlayerController.removeOnStartStopListener(listener)` that detaches **only if it is still the current listener** (won't clobber a successor registered by a fast Activity recreate); called from a new `SoundsViewModel.onCleared`.
- **Regression guard:** `SoundsViewModelLifecycleTest` drives real teardown through a `ViewModelStore` and asserts the detach (TDD: red → fix → green).
- **Test-infra:** added the symmetric `removeOnStartStopListener` stub to the 12 tests that mock `PlayerControllerFactory` with a strict mock — `onCleared` now invokes it during Activity/VM teardown, which a strict mock rejects otherwise.
- **Out of scope:** the flaky `InstanceCountViolation` (`LandingActivity instances=3>2`) from the prior handoff. Diagnosed as **not** an Activity leak — LeakCanary reported 0 Activity leaks even under a deliberate warm-degradation hunt; the Activity is collectable. It's a StrictMode `detectActivityLeaks` GC-timing artifact, left to the LeakCanary-adoption track (which removes `detectActivityLeaks`).

### Code review tips

- **`removeOnStartStopListener` identity guard** (`if (this.listener === listener)`): without it, a fast Activity recreate where the new VM registers before the old VM's `onCleared` runs would null out the live listener.
- **The 12 test-infra edits** are one mechanical line each; the failure mode if one is missed is a `MockKException` at teardown (caught by `./gradlew check`), not a behavior change.

### Already tested

- [x] `./gradlew check` — detekt/ktlint/spotless/Android Lint + all unit tests, all modules — green on the merged branch
- [x] Full local instrumented suite (cold-boot) — green, 0 StrictMode violations
- [x] Heap analysis (temporary LeakCanary) confirmed **0 leaks** with the fix; all diagnostic scaffolding fully reverted
- [x] New `SoundsViewModelLifecycleTest` guards the regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)
