### PR TITLE
feat(welcome): persist welcome audio + warm SnackBar (feedback v2.1.0 #1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][], and this project adheres to [Semantic Versioning][].
 
+## \[unreleased] (v2.2.0)
+
+### Changed
+- The welcome audio no longer vanishes on its own after it plays — it stays in your list like any other audio, sorted by date, and the first time it finishes a warm note reminds you it's yours to keep or delete whenever you want; a one-time nudge shows you can swipe it away
+
 ## \[v2.1.0] - 2026-05-25
 
 ### Added

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/WelcomeStickerFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/WelcomeStickerFlowTest.kt
@@ -33,8 +33,8 @@ import org.junit.runner.RunWith
  *  - The Material3 `SwipeToDismissBox` threshold + animation actually fire on a real surface
  *    (the `rememberSaveable` re-trigger bug documented in `SoundItem.kt:164` was a device-only
  *    discovery).
- *  - The date-driven ordering is observable in the actual rendered list with real file timestamps
- *    (feedback v2.1.0 #1 — the welcome is no longer force-positioned).
+ *  - The date-driven ordering is observable in the actual rendered list with real file timestamps —
+ *    the welcome is no longer force-positioned.
  */
 @RunWith(AndroidJUnit4::class)
 internal class WelcomeStickerFlowTest : AbstractUiTest() {
@@ -66,7 +66,7 @@ internal class WelcomeStickerFlowTest : AbstractUiTest() {
             composeRule.onNodeWithText(undoLabel).performClick()
             composeRule.awaitNodeWithText(title).assertIsDisplayed()
 
-            // The welcome reappears sorted by date like any other audio (feedback v2.1.0 #1). It is
+            // The welcome reappears sorted by date like any other audio. It is
             // the newer audio here (its install timestamp postdates the pre-seeded custom file), so
             // it sits ABOVE the custom — no longer force-demoted to the bottom.
             val welcomeTop =

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/WelcomeStickerFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/WelcomeStickerFlowTest.kt
@@ -33,7 +33,8 @@ import org.junit.runner.RunWith
  *  - The Material3 `SwipeToDismissBox` threshold + animation actually fire on a real surface
  *    (the `rememberSaveable` re-trigger bug documented in `SoundItem.kt:164` was a device-only
  *    discovery).
- *  - The post-Undo demotion is observable in the actual rendered list order.
+ *  - The date-driven ordering is observable in the actual rendered list with real file timestamps
+ *    (feedback v2.1.0 #1 — the welcome is no longer force-positioned).
  */
 @RunWith(AndroidJUnit4::class)
 internal class WelcomeStickerFlowTest : AbstractUiTest() {
@@ -50,8 +51,10 @@ internal class WelcomeStickerFlowTest : AbstractUiTest() {
     }
 
     @Test
-    fun swipeLeftOnWelcomeShowsUndoSnackbarAndDemotesToBottomOnUndo() {
+    fun swipeLeftOnWelcomeShowsUndoSnackbarAndRestoresItSortedByDate() {
         TestData.enableWelcomeSticker(context)
+        // Seeded before launch, so the custom file's timestamp predates the welcome's install
+        // timestamp (captured at first load) — the welcome is the newer audio.
         TestData.seedCustomSounds(context, count = 1)
         val title = context.getString(R.string.app_welcome_sticker_title)
         val undoLabel = context.getString(R.string.app_undo)
@@ -63,8 +66,9 @@ internal class WelcomeStickerFlowTest : AbstractUiTest() {
             composeRule.onNodeWithText(undoLabel).performClick()
             composeRule.awaitNodeWithText(title).assertIsDisplayed()
 
-            // The welcome must reappear BELOW the user's custom sound — row 0 belongs to the
-            // user once they've shown they want this sticker back rather than letting it consume.
+            // The welcome reappears sorted by date like any other audio (feedback v2.1.0 #1). It is
+            // the newer audio here (its install timestamp postdates the pre-seeded custom file), so
+            // it sits ABOVE the custom — no longer force-demoted to the bottom.
             val welcomeTop =
                 composeRule
                     .onNodeWithText(title)
@@ -75,7 +79,7 @@ internal class WelcomeStickerFlowTest : AbstractUiTest() {
                     .onNodeWithText("custom_1")
                     .fetchSemanticsNode()
                     .boundsInRoot.top
-            assertThat(welcomeTop).isGreaterThan(customTop)
+            assertThat(welcomeTop).isLessThan(customTop)
         }
     }
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/welcome/WelcomeSticker.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/welcome/WelcomeSticker.kt
@@ -18,17 +18,19 @@ import com.github.barriosnahuel.vossosunboton.model.Sound
  * `res/raw-es/app_welcome_sticker.mp3` overrides it for Spanish-locale devices. Android resolves
  * the right one automatically based on `Configuration.locale`.
  */
-internal fun welcomeSticker(context: Context): Sound =
+internal fun welcomeSticker(
+    context: Context,
+    dateAdded: Long? = null,
+): Sound =
     Sound(
         name = context.getString(R.string.app_welcome_sticker_title),
         rawRes = R.raw.app_welcome_sticker,
-    )
+    ).copy(dateAdded = dateAdded)
 
 /**
  * Identifies the welcome sticker by its stable [Sound.id], not its display name. A user-created
  * Bomp that happens to share the welcome's localized title would otherwise be misidentified as the
- * welcome — losing pin/edit affordances, emitting wrong analytics, and getting auto-removed from
- * the list on natural play completion. Bundled ids are `"bundled:$rawRes"` (see ADR 0008), so the
- * welcome's id is unique and stable across installs.
+ * welcome — losing pin/edit affordances, emitting wrong analytics. Bundled ids are
+ * `"bundled:$rawRes"` (see ADR 0008), so the welcome's id is unique and stable across installs.
  */
 internal fun isWelcomeSticker(sound: Sound): Boolean = sound.id == "bundled:${R.raw.app_welcome_sticker}"

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/welcome/WelcomeStickerStore.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/welcome/WelcomeStickerStore.kt
@@ -122,7 +122,7 @@ class WelcomeStickerStore(
 
     /**
      * One-time migration from the old "ephemeral, self-destruct on completion" model to the new
-     * persistent one (feedback v2.1.0 #1). Under the old model, letting the welcome play to the end
+     * persistent one. Under the old model, letting the welcome play to the end
      * set `consumed=true` and it vanished forever — many Bompers lost it without understanding why.
      * Since the old `consumed` is ambiguous (auto-destruct vs intentional delete, indistinguishable
      * on disk), we resurface it for everyone once: clear `consumed`, drop the orphaned `was_restored`

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/welcome/WelcomeStickerStore.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/welcome/WelcomeStickerStore.kt
@@ -13,6 +13,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
@@ -21,44 +22,49 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 
 /**
- * Persists the visibility of the home-grid welcome sticker (Sticker Cero, fresh-install variant).
+ * Persists the state of the home-grid welcome sticker (Sticker Cero, fresh-install variant).
  *
- * Two booleans:
- * - `consumed`: flips to `true` when the user lets the dismiss snackbar time out (or, after a
- *   restored welcome, when they manually dismiss again). Once `true`, the welcome never reappears
- *   on this install.
- * - `was_restored`: sticky `true` after the user taps Undo at least once. The next render demotes
- *   the welcome from row 0 to the END of MY_SOUNDS so the prime spot belongs to the user.
+ * The welcome audio is **persistent** — it is treated as just-another-audio that the Bomper deletes
+ * manually whenever they want. It no longer self-destructs on playback completion (feedback
+ * v2.1.0 #1). Four pieces of state:
+ * - `consumed`: flips to `true` **only** when the user manually deletes the welcome and lets the
+ *   Undo snackbar time out. Once `true`, the welcome never reappears on this install.
+ * - `acknowledged`: flips to `true` the first time the welcome plays to completion. Drives the
+ *   one-shot informative snackbar AND is the hook a future "What's New" overwrite should gate on
+ *   ("the Bomper already experienced the welcome"), decoupled from `consumed` (card removal).
+ * - `hint_shown`: flips to `true` after the one-time swipe-hint nudge runs, so the card peeks the
+ *   delete affordance only once per install.
+ * - `install_ts`: the welcome's `dateAdded`, captured lazily on first read. Lets the welcome sort
+ *   by date alongside the user's own audios (newest-first) instead of being force-pinned to row 0.
  *
- * Both reads are race-protected by an in-memory cache populated lazily on first read and updated
- * synchronously by [consume] / [restore]. Without the cache, an Undo immediately followed by a tab
- * switch could re-prepend the welcome at row 0 because the next [wasRestored] would observe stale
- * disk state (the async `store.edit` may not have committed yet). Same shape as the analytics
- * stores in `commons_android`.
+ * Reads are race-protected by in-memory caches populated lazily on first read and updated
+ * synchronously by the mutators. Without the cache, a mutate immediately followed by a reload could
+ * observe stale disk state because the async `store.edit` may not have committed yet. Same shape as
+ * the analytics stores in `commons_android`.
  *
  * Lives in its own DataStore Preferences file (`datastore/welcome-sticker.preferences_pb`) on
- * purpose:
- * - The audio metadata DataStore (`bomps.preferences_pb`) holds user-created Bomps and is also
- *   backed up but the data shape is different (JSON-encoded list).
- * - The analytics flags / counters live in their own DataStores with different backup postures.
- *
- * Backup posture: included in `app_backup_rules.xml` and `app_data_extraction_rules.xml` — the
- * user's "I dismissed this" gesture is meaningful state that should survive a restore.
- * `BackupRulesTest` enforces the include rules.
+ * purpose, separate from the audio-metadata store. Backup posture: included in
+ * `app_backup_rules.xml` and `app_data_extraction_rules.xml` — the user's "I dismissed this" gesture
+ * is meaningful state that should survive a restore. `BackupRulesTest` enforces the include rules.
  */
 class WelcomeStickerStore(
     context: Context,
+    private val now: () -> Long = { System.currentTimeMillis() },
 ) {
     private val store: DataStore<Preferences> = context.applicationContext.welcomeStickerStore
 
     @Volatile private var consumedCache: Boolean? = null
 
-    @Volatile private var wasRestoredCache: Boolean? = null
+    @Volatile private var acknowledgedCache: Boolean? = null
+
+    @Volatile private var hintShownCache: Boolean? = null
+
+    @Volatile private var installTsCache: Long? = null
 
     /**
-     * `true` until the user has consumed the welcome sticker. Returns `false` when the bundled
-     * resource is missing — matches the spec's "no storage for `resource_update` → silently skip"
-     * stance.
+     * `true` until the user has manually deleted the welcome sticker. Returns `false` when the
+     * bundled resource is missing — matches the spec's "no storage for `resource_update` → silently
+     * skip" stance.
      */
     suspend fun isActive(): Boolean {
         if (R.raw.app_welcome_sticker == 0) return false
@@ -66,46 +72,99 @@ class WelcomeStickerStore(
     }
 
     /**
-     * `true` after the user has tapped Undo on the dismiss snackbar at least once. Used by
-     * `SoundsViewModel.loadSounds()` to demote the welcome from row 0 to the end of MY_SOUNDS:
-     * the prime spot belongs to the user once they've shown they want this sticker back rather
-     * than letting it consume.
+     * `true` once the welcome has played to completion at least once. The informative snackbar is
+     * shown only on the transition to `true`; a future "What's New" overwrite gates on this rather
+     * than on [isActive] so a persistent (never-deleted) welcome doesn't block update stickers.
      */
-    suspend fun wasRestored(): Boolean = readWasRestored()
+    suspend fun isAcknowledged(): Boolean {
+        acknowledgedCache?.let { return it }
+        val value = readFlag(KEY_ACKNOWLEDGED)
+        acknowledgedCache = value
+        return value
+    }
+
+    /** `true` once the one-time swipe-hint nudge has run. */
+    suspend fun isHintShown(): Boolean {
+        hintShownCache?.let { return it }
+        val value = readFlag(KEY_HINT_SHOWN)
+        hintShownCache = value
+        return value
+    }
+
+    /** The welcome's stable `dateAdded`, captured on first read so ordering is deterministic. */
+    suspend fun installTimestamp(): Long {
+        installTsCache?.let { return it }
+        val existing = withContext(Dispatchers.IO) { store.data.first()[KEY_INSTALL_TS] }
+        val value =
+            existing ?: now().also { ts ->
+                withContext(Dispatchers.IO) { store.edit { it[KEY_INSTALL_TS] = ts } }
+            }
+        installTsCache = value
+        return value
+    }
 
     suspend fun consume() {
-        // Update the in-memory cache before dispatching the disk write so a follow-up read
-        // observes the new value immediately, regardless of when the `store.edit` commits.
+        // Update the in-memory cache before dispatching the disk write so a follow-up read observes
+        // the new value immediately, regardless of when the `store.edit` commits.
         consumedCache = true
         withContext(Dispatchers.IO) {
             store.edit { it[KEY_CONSUMED] = true }
         }
     }
 
-    /**
-     * Re-enables the welcome AND records the restore atomically. The two effects are coupled: an
-     * Undo by definition means "user was restored at least once", and from that moment on the
-     * welcome is no longer eligible for row 0.
-     */
+    /** Re-enables the welcome after a manual delete was undone within the snackbar window. */
     suspend fun restore() {
         consumedCache = false
-        wasRestoredCache = true
         withContext(Dispatchers.IO) {
-            store.edit {
-                it[KEY_CONSUMED] = false
-                it[KEY_WAS_RESTORED] = true
-            }
+            store.edit { it[KEY_CONSUMED] = false }
         }
     }
 
     /**
-     * Test-only escape hatch to reset state. Same `@VisibleForTesting(otherwise = NONE)`
-     * protection as `SoundsRepository.clearForTest`.
+     * One-time migration from the old "ephemeral, self-destruct on completion" model to the new
+     * persistent one (feedback v2.1.0 #1). Under the old model, letting the welcome play to the end
+     * set `consumed=true` and it vanished forever — many Bompers lost it without understanding why.
+     * Since the old `consumed` is ambiguous (auto-destruct vs intentional delete, indistinguishable
+     * on disk), we resurface it for everyone once: clear `consumed`, drop the orphaned `was_restored`
+     * key, and set the guard so this never runs again — a deliberate manual delete afterwards sticks.
+     * Precedent: `SoundsRepository.migrateVisibilityIfNeeded` (ADR 0012).
+     */
+    suspend fun migrateToPersistentIfNeeded() {
+        if (readFlag(KEY_MIGRATED_PERSISTENT)) return
+        consumedCache = false
+        withContext(Dispatchers.IO) {
+            store.edit {
+                it[KEY_CONSUMED] = false
+                it[KEY_MIGRATED_PERSISTENT] = true
+                it.remove(LEGACY_KEY_WAS_RESTORED)
+            }
+        }
+    }
+
+    suspend fun markAcknowledged() {
+        acknowledgedCache = true
+        withContext(Dispatchers.IO) {
+            store.edit { it[KEY_ACKNOWLEDGED] = true }
+        }
+    }
+
+    suspend fun markHintShown() {
+        hintShownCache = true
+        withContext(Dispatchers.IO) {
+            store.edit { it[KEY_HINT_SHOWN] = true }
+        }
+    }
+
+    /**
+     * Test-only escape hatch to reset state. Same `@VisibleForTesting(otherwise = NONE)` protection
+     * as `SoundsRepository.clearForTest`.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     suspend fun clearForTest() {
         consumedCache = null
-        wasRestoredCache = null
+        acknowledgedCache = null
+        hintShownCache = null
+        installTsCache = null
         withContext(Dispatchers.IO) {
             store.edit { it.clear() }
         }
@@ -118,13 +177,6 @@ class WelcomeStickerStore(
         return value
     }
 
-    private suspend fun readWasRestored(): Boolean {
-        wasRestoredCache?.let { return it }
-        val value = readFlag(KEY_WAS_RESTORED)
-        wasRestoredCache = value
-        return value
-    }
-
     private suspend fun readFlag(key: Preferences.Key<Boolean>): Boolean =
         withContext(Dispatchers.IO) {
             store.data.first()[key] ?: false
@@ -133,7 +185,13 @@ class WelcomeStickerStore(
     companion object {
         const val DATASTORE_NAME = "welcome-sticker"
         private val KEY_CONSUMED = booleanPreferencesKey("consumed")
-        private val KEY_WAS_RESTORED = booleanPreferencesKey("was_restored")
+        private val KEY_ACKNOWLEDGED = booleanPreferencesKey("acknowledged")
+        private val KEY_HINT_SHOWN = booleanPreferencesKey("hint_shown")
+        private val KEY_INSTALL_TS = longPreferencesKey("install_ts")
+        private val KEY_MIGRATED_PERSISTENT = booleanPreferencesKey("migrated_persistent")
+
+        // Legacy key from the old ephemeral model — only referenced to drop it during migration.
+        private val LEGACY_KEY_WAS_RESTORED = booleanPreferencesKey("was_restored")
     }
 }
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -492,13 +492,14 @@ private fun SnackbarEffects(
     }
 
     // Informative, one-shot snackbar shown the first time the welcome audio finishes playing — warm
-    // "it's yours, delete it whenever" message. No action: the swipe-hint nudge
-    // teaches deletion; this just reassures. Long so it stays readable.
+    // "it's yours, delete it whenever" message. No action: the swipe-hint nudge teaches deletion;
+    // this just reassures. Short (Material's duration for actionless info) — it's brief, non-critical
+    // reassurance (the card stays whether read or not), so Long would linger.
     LaunchedEffect(Unit) {
         viewModel.welcomeInfoEvent.collect {
             snackbarHostState.showSnackbar(
                 message = welcomeInfoMessage,
-                duration = SnackbarDuration.Long,
+                duration = SnackbarDuration.Short,
             )
         }
     }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsEvent
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsSource
@@ -451,6 +452,7 @@ private fun SnackbarEffects(
     val deletedEvent by viewModel.deletedSoundEvent.collectAsState()
     val audioDeletedMessage = stringResource(R.string.app_feedback_audio_deleted)
     val welcomeDismissedMessage = stringResource(R.string.app_welcome_sticker_feedback_dismissed)
+    val welcomeInfoMessage = stringResource(R.string.app_welcome_sticker_info)
     val undoLabel = stringResource(R.string.app_undo)
     val playbackErrorMessage = stringResource(R.string.app_error_playback_failed)
     val shareDismissLabel = stringResource(R.string.app_snackbar_action_dismiss)
@@ -486,6 +488,18 @@ private fun SnackbarEffects(
     LaunchedEffect(Unit) {
         viewModel.shareErrorEvent.collect { errorRes ->
             showShareErrorSnackbar(snackbarHostState, activityContext, errorRes, shareDismissLabel)
+        }
+    }
+
+    // Informative, one-shot snackbar shown the first time the welcome audio finishes playing — warm
+    // "it's yours, delete it whenever" message (feedback v2.1.0 #1). No action: the swipe-hint nudge
+    // teaches deletion; this just reassures. Long so it stays readable.
+    LaunchedEffect(Unit) {
+        viewModel.welcomeInfoEvent.collect {
+            snackbarHostState.showSnackbar(
+                message = welcomeInfoMessage,
+                duration = SnackbarDuration.Long,
+            )
         }
     }
 
@@ -683,10 +697,14 @@ internal fun SoundsList(
     // CTA on top of the list (e.g. the Vault tab's ExtendedFloatingActionButton) bump this so the
     // last item can scroll above the overlay; everything else stays at the default Spacing.SM.
     bottomContentPadding: androidx.compose.ui.unit.Dp = Spacing.SM,
+    // When true, the welcome card runs its one-time swipe-hint nudge (peek the delete background and
+    // settle back) to teach the swipe gesture; [onWelcomeHintShown] fires once it has run. Only the
+    // My Sounds list passes these — the Vault never renders the welcome.
+    welcomeHintPending: Boolean = false,
+    onWelcomeHintShown: () -> Unit = {},
 ) {
     val dismissingItems = remember { mutableStateSetOf<String>() }
     val coroutineScope = rememberCoroutineScope()
-    val remainingFormat = stringResource(R.string.app_welcome_sticker_remaining_format)
     // Locale-aware fallback for system collections (the seeded "Baúl") — resolved once at the
     // top of the composable since `stringResource` cannot be invoked from a non-Composable
     // `mapNotNull` lambda.
@@ -732,19 +750,6 @@ internal fun SoundsList(
                         } else {
                             null
                         }
-                    val welcomeTrailingLabel =
-                        if (isWelcome) {
-                            val remainingMs =
-                                when {
-                                    effectiveProgress != null ->
-                                        (effectiveProgress.durationMs - effectiveProgress.positionMs).coerceAtLeast(0)
-                                    resolvedDurationMs != null -> resolvedDurationMs
-                                    else -> null
-                                }
-                            remainingMs?.let { String.format(remainingFormat, formatDuration(it)) }
-                        } else {
-                            null
-                        }
                     val labels =
                         if (isWelcome) {
                             emptyList()
@@ -782,7 +787,8 @@ internal fun SoundsList(
                         originLabel = if (isWelcome) stringResource(R.string.app_welcome_sticker_origin) else null,
                         isWelcomeVariant = isWelcome,
                         borderOverride = welcomeBorder,
-                        trailingLabel = welcomeTrailingLabel,
+                        showSwipeHint = isWelcome && welcomeHintPending,
+                        onSwipeHintShown = onWelcomeHintShown,
                         collectionLabels = labels,
                         showCollectionLabels = !filterIsActive,
                         shareEnabled = shareEnabled,
@@ -793,10 +799,11 @@ internal fun SoundsList(
     }
 }
 
-// Welcome dismissal is a low-stakes "got it, move on" interaction — Short keeps it from lingering.
-// User-deleted sounds are destructive and need Long so Undo stays reachable.
-internal fun deletionSnackbarDuration(sound: Sound): SnackbarDuration =
-    if (isWelcomeSticker(sound)) SnackbarDuration.Short else SnackbarDuration.Long
+// Deleting the welcome is now a real, manual, destructive action (it no longer self-destructs —
+// feedback v2.1.0 #1), so it needs Long like any user-deleted sound to keep Undo reachable.
+internal fun deletionSnackbarDuration(
+    @Suppress("UNUSED_PARAMETER") sound: Sound,
+): SnackbarDuration = SnackbarDuration.Long
 
 @Composable
 private fun MySoundsBody(
@@ -816,6 +823,7 @@ private fun MySoundsBody(
     context: Context,
 ) {
     val activeCollection = publicCollections.firstOrNull { it.id == activeFilterId }
+    val welcomeHintPending by viewModel.welcomeHintPending.collectAsStateWithLifecycle()
     val isOnMySounds = selectedTab == AppTab.MY_SOUNDS
     val showFilterEmptyState = isOnMySounds && activeFilterId != null && sounds.isEmpty() && activeCollection != null
     val showWelcomeEmptyState = sounds.isEmpty() && isOnMySounds && !showFilterEmptyState
@@ -873,6 +881,8 @@ private fun MySoundsBody(
                         context.startActivity(LandingActivity.editIntent(context, sound))
                     },
                     onAddToCollection = { sound -> viewModel.requestAssignCollections(sound.id) },
+                    welcomeHintPending = welcomeHintPending,
+                    onWelcomeHintShown = { viewModel.markWelcomeHintShown() },
                 )
         }
     }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -492,7 +492,7 @@ private fun SnackbarEffects(
     }
 
     // Informative, one-shot snackbar shown the first time the welcome audio finishes playing — warm
-    // "it's yours, delete it whenever" message (feedback v2.1.0 #1). No action: the swipe-hint nudge
+    // "it's yours, delete it whenever" message. No action: the swipe-hint nudge
     // teaches deletion; this just reassures. Long so it stays readable.
     LaunchedEffect(Unit) {
         viewModel.welcomeInfoEvent.collect {
@@ -799,8 +799,8 @@ internal fun SoundsList(
     }
 }
 
-// Deleting the welcome is now a real, manual, destructive action (it no longer self-destructs —
-// feedback v2.1.0 #1), so it needs Long like any user-deleted sound to keep Undo reachable.
+// Deleting the welcome is now a real, manual, destructive action (it no longer self-destructs), so
+// it needs Long like any user-deleted sound to keep Undo reachable.
 internal fun deletionSnackbarDuration(
     @Suppress("UNUSED_PARAMETER") sound: Sound,
 ): SnackbarDuration = SnackbarDuration.Long

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
@@ -141,7 +141,7 @@ fun SoundItem(
         }
 
         // One-time swipe-hint nudge: the card peeks the delete background and settles back, teaching
-        // the swipe-to-delete gesture (feedback v2.1.0 #1). Driven by a self-contained Animatable
+        // the swipe-to-delete gesture. Driven by a self-contained Animatable
         // offset rather than the SwipeToDismissBox anchors, which have no public partial-peek API.
         val hintOffsetX = remember { Animatable(0f) }
         val density = LocalDensity.current

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
@@ -4,6 +4,9 @@
  * See LICENSE in the project root for full license information.
  */
 package com.github.barriosnahuel.vossosunboton.ui.home
+import android.provider.Settings
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
@@ -14,6 +17,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -43,19 +47,23 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.ui.AppIcons
 import com.github.barriosnahuel.vossosunboton.ui.haptics.performConfirmHaptic
@@ -64,6 +72,13 @@ import com.github.barriosnahuel.vossosunboton.ui.theme.DISABLED_TRACK_ALPHA
 import com.github.barriosnahuel.vossosunboton.ui.theme.MUTED_TEXT_ALPHA
 import com.github.barriosnahuel.vossosunboton.ui.theme.PLAYING_TINT_ALPHA
 import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
+import kotlinx.coroutines.CancellationException
+import kotlin.math.roundToInt
+
+// One-time swipe-hint nudge (welcome card): how far it peeks and the in/out durations.
+private val WELCOME_HINT_PEEK = 88.dp
+private const val WELCOME_HINT_OUT_MS = 220
+private const val WELCOME_HINT_BACK_MS = 280
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -82,6 +97,11 @@ fun SoundItem(
     isWelcomeVariant: Boolean = false,
     borderOverride: BorderStroke? = null,
     trailingLabel: String? = null,
+    // When true (welcome variant only), the card runs a one-time swipe-hint nudge: it peeks the
+    // delete background and settles back, teaching that the card is swipe-to-delete. [onSwipeHintShown]
+    // fires once it has run (or was skipped for reduced-motion) so it never repeats.
+    showSwipeHint: Boolean = false,
+    onSwipeHintShown: () -> Unit = {},
     collectionLabels: List<String> = emptyList(),
     showCollectionLabels: Boolean = true,
     shareEnabled: Boolean = true,
@@ -119,28 +139,87 @@ fun SoundItem(
                     }
                 }
         }
-        SwipeToDismissBox(
-            state = dismissState,
-            backgroundContent = { SwipeActionBackground(dismissState, canPin = false, canDelete = true) },
-        ) {
-            SoundCard(
-                sound = sound,
-                playbackProgress = playbackProgress,
-                durationMs = durationMs,
-                onPlayClick = onPlayClick,
-                onSeek = onSeek,
-                onShareClick = onShareClick,
-                onPinClick = null,
-                onEditClick = null,
-                onAddToCollection = null,
-                onDelete = onDelete,
-                originLabel = originLabel,
-                borderOverride = borderOverride,
-                trailingLabel = trailingLabel,
-                collectionLabels = collectionLabels,
-                showCollectionLabels = showCollectionLabels,
-                shareEnabled = shareEnabled,
-            )
+
+        // One-time swipe-hint nudge: the card peeks the delete background and settles back, teaching
+        // the swipe-to-delete gesture (feedback v2.1.0 #1). Driven by a self-contained Animatable
+        // offset rather than the SwipeToDismissBox anchors, which have no public partial-peek API.
+        val hintOffsetX = remember { Animatable(0f) }
+        val density = LocalDensity.current
+        val peekPx = remember(density) { with(density) { WELCOME_HINT_PEEK.toPx() } }
+        val hintContext = LocalView.current.context
+        val currentOnHintShown by rememberUpdatedState(onSwipeHintShown)
+        LaunchedEffect(showSwipeHint) {
+            if (!showSwipeHint) return@LaunchedEffect
+            // Wait for the first frame so the node is laid out before animating, mirroring the
+            // FocusRequester incantation documented in CLAUDE.md.
+            withFrameNanos { }
+            val animationsEnabled =
+                Settings.Global.getFloat(
+                    hintContext.contentResolver,
+                    Settings.Global.ANIMATOR_DURATION_SCALE,
+                    1f,
+                ) != 0f
+            try {
+                if (animationsEnabled) {
+                    hintOffsetX.animateTo(-peekPx, tween(WELCOME_HINT_OUT_MS))
+                    hintOffsetX.animateTo(0f, tween(WELCOME_HINT_BACK_MS))
+                }
+                currentOnHintShown()
+            } catch (e: CancellationException) {
+                // Left composition mid-peek — keep the hint pending so it runs again next time.
+                throw e
+            } catch (
+                @Suppress("TooGenericExceptionCaught") e: Throwable,
+            ) {
+                Tracker.track(RuntimeException("Welcome swipe hint nudge failed", e))
+                currentOnHintShown()
+            }
+        }
+
+        Box {
+            // Delete-side background revealed under the card during the peek — mirrors the delete
+            // half of [SwipeActionBackground] (which renders nothing while the state is Settled).
+            if (hintOffsetX.value < 0f) {
+                Box(
+                    modifier =
+                        Modifier
+                            .matchParentSize()
+                            .background(MaterialTheme.colorScheme.errorContainer)
+                            .padding(horizontal = Spacing.LG),
+                    contentAlignment = Alignment.CenterEnd,
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.app_ic_delete),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onErrorContainer,
+                    )
+                }
+            }
+            Box(modifier = Modifier.offset { IntOffset(hintOffsetX.value.roundToInt(), 0) }) {
+                SwipeToDismissBox(
+                    state = dismissState,
+                    backgroundContent = { SwipeActionBackground(dismissState, canPin = false, canDelete = true) },
+                ) {
+                    SoundCard(
+                        sound = sound,
+                        playbackProgress = playbackProgress,
+                        durationMs = durationMs,
+                        onPlayClick = onPlayClick,
+                        onSeek = onSeek,
+                        onShareClick = onShareClick,
+                        onPinClick = null,
+                        onEditClick = null,
+                        onAddToCollection = null,
+                        onDelete = onDelete,
+                        originLabel = originLabel,
+                        borderOverride = borderOverride,
+                        trailingLabel = trailingLabel,
+                        collectionLabels = collectionLabels,
+                        showCollectionLabels = showCollectionLabels,
+                        shareEnabled = shareEnabled,
+                    )
+                }
+            }
         }
         return
     }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -128,6 +128,17 @@ class SoundsViewModel(
     private val _welcomeStickerVisible = MutableStateFlow(false)
     val welcomeStickerVisible: StateFlow<Boolean> = _welcomeStickerVisible.asStateFlow()
 
+    // `true` while the one-time swipe-hint nudge on the welcome card is still eligible to run. The
+    // UI consumes it, runs the peek animation once, and calls [markWelcomeHintShown].
+    private val _welcomeHintPending = MutableStateFlow(false)
+    val welcomeHintPending: StateFlow<Boolean> = _welcomeHintPending.asStateFlow()
+
+    // In-process latch closing the race between [markWelcomeHintShown] (flips the flag on the main
+    // thread, persists async) and a `loadSounds` landing before that write commits — without it, the
+    // recompute below would observe a stale `isHintShown()` and replay the nudge.
+    @Volatile
+    private var welcomeHintConsumed = false
+
     private val _selectedTab = MutableStateFlow(AppTab.MY_SOUNDS)
     val selectedTab: StateFlow<AppTab> = _selectedTab.asStateFlow()
 
@@ -254,6 +265,12 @@ class SoundsViewModel(
     private val _scrollToTopEvent = Channel<Unit>(Channel.BUFFERED)
     val scrollToTopEvent: Flow<Unit> = _scrollToTopEvent.receiveAsFlow()
 
+    // One-shot informative snackbar shown the first time the welcome audio plays to completion —
+    // "it's yours, delete it whenever". Replaces the old self-destruct-on-completion flow (ADR 0003
+    // Channel for one-shot UI events; feedback v2.1.0 #1).
+    private val _welcomeInfoEvent = Channel<Unit>(Channel.BUFFERED)
+    val welcomeInfoEvent: Flow<Unit> = _welcomeInfoEvent.receiveAsFlow()
+
     private val _playbackErrorEvent = Channel<Unit>(Channel.BUFFERED)
     val playbackErrorEvent: Flow<Unit> = _playbackErrorEvent.receiveAsFlow()
 
@@ -295,6 +312,11 @@ class SoundsViewModel(
         // tests that await `isInitialLoadComplete.first { it }` would deadlock.
         viewModelScope.launch(ioDispatcher) {
             try {
+                // One-time migration from the old "ephemeral, self-destruct on completion" model:
+                // resurfaces the welcome for installs that consumed it under the old behavior
+                // (feedback v2.1.0 #1). Runs BEFORE isActive() so the reset takes effect on first
+                // paint. Idempotent: a manual delete under the new model still sticks.
+                welcomeStore.migrateToPersistentIfNeeded()
                 val active = welcomeStore.isActive()
                 _welcomeStickerVisible.value = active
                 if (active && tracker.markFiredOnce("welcome_sticker_shown")) {
@@ -882,9 +904,10 @@ class SoundsViewModel(
         if (shouldUpdateVisibleSounds) {
             val currentSounds = _sounds.value.toMutableList()
             if (isWelcome) {
-                // Demote to the end of MY_SOUNDS — the prime row 0 spot belongs to the user once
-                // they've shown they want this sticker back rather than letting it consume.
+                // Re-insert the welcome and sort it back into place by date — it behaves like any
+                // other audio (feedback v2.1.0 #1). `event.sound` already carries its `dateAdded`.
                 currentSounds.add(event.sound)
+                currentSounds.sortWith(SOUND_ORDER)
             } else {
                 val insertPosition = event.position.coerceAtMost(currentSounds.size)
                 currentSounds.add(insertPosition, event.sound)
@@ -906,10 +929,10 @@ class SoundsViewModel(
             // restore fire-and-forget on IO so the snackbar interaction stays responsive.
             _welcomeStickerVisible.value = true
             restoreWelcomeAsync()
-            tracker.log(AnalyticsEvent.WelcomeStickerUndone)
-        } else {
-            tracker.log(AnalyticsEvent.SoundDeleteUndone)
         }
+        // Welcome is just-another-audio now, so its Undo logs the generic `sound_delete_undone` like
+        // any other (the welcome-specific `welcome_sticker_undone` was pruned — feedback v2.1.0 #1).
+        tracker.log(AnalyticsEvent.SoundDeleteUndone)
     }
 
     fun confirmDelete() {
@@ -1234,25 +1257,26 @@ class SoundsViewModel(
     /**
      * Resolves where the welcome sticker belongs in the visible MY_SOUNDS list. Returns [filtered]
      * unchanged for non-MY_SOUNDS tabs, when the sticker is consumed, or while the snackbar window
-     * is hiding it. Otherwise prepends on a fresh install or appends once the user has undone the
-     * dismissal at least once (the demoted state).
+     * is hiding it. Otherwise the welcome is added to the list and sorted by [SOUND_ORDER] like any
+     * other audio: its [installTs] is its `dateAdded`, so on a fresh install it lands at the top
+     * (newest) and naturally sinks as the Bomper adds their own audios (feedback v2.1.0 #1).
      *
-     * [welcomeIsPendingDismissal] and [wasRestored] are snapshotted at the top of `loadSounds` so
-     * this stays a pure function — easier to test, and avoids issuing extra DataStore reads inside
-     * the `_sounds.update` lambda.
+     * [welcomeIsPendingDismissal] and [installTs] are snapshotted at the top of `loadSounds` so this
+     * stays a pure function — easier to test, and avoids issuing extra DataStore reads inside the
+     * `_sounds.update` lambda.
      */
     private fun positionWelcomeIn(
         filtered: List<Sound>,
         welcomeIsPendingDismissal: Boolean,
-        wasRestored: Boolean,
+        installTs: Long,
     ): List<Sound> {
         val shouldShowWelcome =
             _selectedTab.value == AppTab.MY_SOUNDS &&
                 _welcomeStickerVisible.value &&
                 !welcomeIsPendingDismissal
         if (!shouldShowWelcome) return filtered
-        val welcome = welcomeSticker(getApplication())
-        return if (wasRestored) filtered + welcome else listOf(welcome) + filtered
+        val welcome = welcomeSticker(getApplication(), dateAdded = installTs)
+        return (filtered + welcome).sortedWith(SOUND_ORDER)
     }
 
     private fun deletePersistedSoundAsync(sound: Sound) {
@@ -1296,9 +1320,30 @@ class SoundsViewModel(
             } catch (
                 @Suppress("TooGenericExceptionCaught") e: Throwable,
             ) {
-                // Same shape as `consumeWelcomeAsync` — the in-memory state is already correct;
-                // we only lose the disk persistence of the demoted-position flag.
+                // Same shape as `consumeWelcomeAsync` — the in-memory state is already correct; we
+                // only lose the disk persistence of the re-enabled flag.
                 Tracker.track(RuntimeException("Welcome sticker restore persistence failed", e))
+            }
+        }
+    }
+
+    /**
+     * Called by the UI once the one-time swipe-hint nudge has run on the welcome card. Flips the
+     * in-memory pending flag immediately and persists it fire-and-forget so the nudge never repeats.
+     */
+    fun markWelcomeHintShown() {
+        if (!_welcomeHintPending.value) return
+        welcomeHintConsumed = true
+        _welcomeHintPending.value = false
+        viewModelScope.launch(ioDispatcher) {
+            try {
+                welcomeStore.markHintShown()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (
+                @Suppress("TooGenericExceptionCaught") e: Throwable,
+            ) {
+                Tracker.track(RuntimeException("Welcome sticker hint persistence failed", e))
             }
         }
     }
@@ -1309,17 +1354,16 @@ class SoundsViewModel(
 
     private suspend fun loadSounds() {
         try {
-            val allSounds =
-                repo.sounds
-                    .first()
-                    .sortedWith(
-                        compareByDescending<Sound> { it.isPinned }
-                            .thenByDescending { it.dateAdded ?: Long.MIN_VALUE }
-                            .thenBy { it.name.lowercase() },
-                    )
+            val allSounds = repo.sounds.first().sortedWith(SOUND_ORDER)
             val cachedDurations = repo.durations.first()
-            // Read once per loadSounds — pure function over a snapshotted boolean, easier to test.
-            val welcomeWasRestored = welcomeStore.wasRestored()
+            // Read once per loadSounds — pure function over a snapshotted value, easier to test. The
+            // welcome's install timestamp is its `dateAdded` so it sorts by date with user audios.
+            val welcomeInstallTs = welcomeStore.installTimestamp()
+            // The swipe-hint nudge is eligible while the welcome is showing and the nudge hasn't run.
+            _welcomeHintPending.value =
+                !welcomeHintConsumed &&
+                _welcomeStickerVisible.value &&
+                !welcomeStore.isHintShown()
             _soundDurations.update { current -> cachedDurations + current }
             _hasBundledSounds.value = allSounds.any { it.isBundled() }
             val playingId = _playingSound.value?.id
@@ -1354,7 +1398,7 @@ class SoundsViewModel(
                         // state composable from rendering its "no sounds yet" body for the wrong tab.
                         AppTab.VAULT -> emptyList()
                     }.filter { it.id != deletedId }
-                val withWelcome = positionWelcomeIn(byTab, welcomeIsPendingDismissal, welcomeWasRestored)
+                val withWelcome = positionWelcomeIn(byTab, welcomeIsPendingDismissal, welcomeInstallTs)
                 if (playingId == null) {
                     withWelcome
                 } else {
@@ -1417,11 +1461,18 @@ class SoundsViewModel(
         recomputeVaultAudios()
 
         if (completed && isWelcomeSticker(sound)) {
-            val position = _sounds.value.indexOfFirst { it.id == sound.id }.coerceAtLeast(0)
-            _sounds.update { list -> list.filter { it.id != sound.id } }
-            _welcomeStickerVisible.value = false
-            _deletedSoundEvent.value = DeletedSoundEvent(stoppedSound, position)
-            tracker.log(AnalyticsEvent.WelcomeStickerCompleted)
+            // The welcome no longer self-destructs (feedback v2.1.0 #1) — it stays in the list as a
+            // persistent audio. Only the FIRST completion does anything: log `welcome_sticker_completed`
+            // (gated so unlimited replays don't inflate it — replays are covered by `welcome_sticker_play`),
+            // show the one-shot informative snackbar, and mark the welcome acknowledged. Later
+            // completions are silent.
+            viewModelScope.launch(ioDispatcher) {
+                if (!welcomeStore.isAcknowledged()) {
+                    welcomeStore.markAcknowledged()
+                    tracker.log(AnalyticsEvent.WelcomeStickerCompleted)
+                    _welcomeInfoEvent.trySend(Unit)
+                }
+            }
         }
     }
 
@@ -1455,6 +1506,16 @@ class SoundsViewModel(
 
     companion object {
         private val AUDIO_MILESTONES = listOf(3, 5, 10, 25)
+
+        /**
+         * Canonical My Sounds ordering: pinned first, then most-recent by `dateAdded`, then name.
+         * Shared between the initial repo sort and [positionWelcomeIn] so the persistent welcome
+         * sticker sorts by its `dateAdded` exactly like a user-created audio (feedback v2.1.0 #1).
+         */
+        private val SOUND_ORDER: Comparator<Sound> =
+            compareByDescending<Sound> { it.isPinned }
+                .thenByDescending { it.dateAdded ?: Long.MIN_VALUE }
+                .thenBy { it.name.lowercase() }
 
         val Factory: ViewModelProvider.Factory =
             viewModelFactory {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -267,7 +267,7 @@ class SoundsViewModel(
 
     // One-shot informative snackbar shown the first time the welcome audio plays to completion —
     // "it's yours, delete it whenever". Replaces the old self-destruct-on-completion flow (ADR 0003
-    // Channel for one-shot UI events; feedback v2.1.0 #1).
+    // Channel for one-shot UI events).
     private val _welcomeInfoEvent = Channel<Unit>(Channel.BUFFERED)
     val welcomeInfoEvent: Flow<Unit> = _welcomeInfoEvent.receiveAsFlow()
 
@@ -313,9 +313,9 @@ class SoundsViewModel(
         viewModelScope.launch(ioDispatcher) {
             try {
                 // One-time migration from the old "ephemeral, self-destruct on completion" model:
-                // resurfaces the welcome for installs that consumed it under the old behavior
-                // (feedback v2.1.0 #1). Runs BEFORE isActive() so the reset takes effect on first
-                // paint. Idempotent: a manual delete under the new model still sticks.
+                // resurfaces the welcome for installs that consumed it under the old behavior. Runs
+                // BEFORE isActive() so the reset takes effect on first paint. Idempotent: a manual
+                // delete under the new model still sticks.
                 welcomeStore.migrateToPersistentIfNeeded()
                 val active = welcomeStore.isActive()
                 _welcomeStickerVisible.value = active
@@ -905,7 +905,7 @@ class SoundsViewModel(
             val currentSounds = _sounds.value.toMutableList()
             if (isWelcome) {
                 // Re-insert the welcome and sort it back into place by date — it behaves like any
-                // other audio (feedback v2.1.0 #1). `event.sound` already carries its `dateAdded`.
+                // other audio. `event.sound` already carries its `dateAdded`.
                 currentSounds.add(event.sound)
                 currentSounds.sortWith(SOUND_ORDER)
             } else {
@@ -931,7 +931,7 @@ class SoundsViewModel(
             restoreWelcomeAsync()
         }
         // Welcome is just-another-audio now, so its Undo logs the generic `sound_delete_undone` like
-        // any other (the welcome-specific `welcome_sticker_undone` was pruned — feedback v2.1.0 #1).
+        // any other (the welcome-specific `welcome_sticker_undone` was pruned).
         tracker.log(AnalyticsEvent.SoundDeleteUndone)
     }
 
@@ -1259,7 +1259,7 @@ class SoundsViewModel(
      * unchanged for non-MY_SOUNDS tabs, when the sticker is consumed, or while the snackbar window
      * is hiding it. Otherwise the welcome is added to the list and sorted by [SOUND_ORDER] like any
      * other audio: its [installTs] is its `dateAdded`, so on a fresh install it lands at the top
-     * (newest) and naturally sinks as the Bomper adds their own audios (feedback v2.1.0 #1).
+     * (newest) and naturally sinks as the Bomper adds their own audios.
      *
      * [welcomeIsPendingDismissal] and [installTs] are snapshotted at the top of `loadSounds` so this
      * stays a pure function — easier to test, and avoids issuing extra DataStore reads inside the
@@ -1461,16 +1461,26 @@ class SoundsViewModel(
         recomputeVaultAudios()
 
         if (completed && isWelcomeSticker(sound)) {
-            // The welcome no longer self-destructs (feedback v2.1.0 #1) — it stays in the list as a
+            // The welcome no longer self-destructs — it stays in the list as a
             // persistent audio. Only the FIRST completion does anything: log `welcome_sticker_completed`
             // (gated so unlimited replays don't inflate it — replays are covered by `welcome_sticker_play`),
             // show the one-shot informative snackbar, and mark the welcome acknowledged. Later
             // completions are silent.
             viewModelScope.launch(ioDispatcher) {
-                if (!welcomeStore.isAcknowledged()) {
-                    welcomeStore.markAcknowledged()
-                    tracker.log(AnalyticsEvent.WelcomeStickerCompleted)
-                    _welcomeInfoEvent.trySend(Unit)
+                try {
+                    if (!welcomeStore.isAcknowledged()) {
+                        welcomeStore.markAcknowledged()
+                        tracker.log(AnalyticsEvent.WelcomeStickerCompleted)
+                        _welcomeInfoEvent.trySend(Unit)
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") e: Throwable,
+                ) {
+                    // viewModelScope has no CoroutineExceptionHandler, so an uncaught throw here would
+                    // crash the app. Same defensive shape as consumeWelcomeAsync / markWelcomeHintShown.
+                    Tracker.track(RuntimeException("Welcome sticker acknowledge failed", e))
                 }
             }
         }
@@ -1510,7 +1520,7 @@ class SoundsViewModel(
         /**
          * Canonical My Sounds ordering: pinned first, then most-recent by `dateAdded`, then name.
          * Shared between the initial repo sort and [positionWelcomeIn] so the persistent welcome
-         * sticker sorts by its `dateAdded` exactly like a user-created audio (feedback v2.1.0 #1).
+         * sticker sorts by its `dateAdded` exactly like a user-created audio.
          */
         private val SOUND_ORDER: Comparator<Sound> =
             compareByDescending<Sound> { it.isPinned }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -89,9 +89,9 @@
     <string name="app_my_sounds_empty_body">Una risa, un \"feliz cumple\", el \"estoy llegando\" del que querés. Compartí cualquier audio desde WhatsApp, Telegram o donde sea — se queda guardado y lo escuchás cuando quieras.</string>
 
     <!-- Sticker Cero (variante de bienvenida, fresh install) -->
-    <string name="app_welcome_sticker_title">Un saludo de Nahu</string>
+    <string name="app_welcome_sticker_title">Tu primer audio-abrazo</string>
     <string name="app_welcome_sticker_origin">Del que armó esto</string>
-    <string name="app_welcome_sticker_remaining_format">-%1$s</string>
+    <string name="app_welcome_sticker_info">De mí para vos. Es tuyo: borralo cuando quieras.</string>
     <string name="app_welcome_sticker_feedback_dismissed">¡Hasta luego!</string>
 
     <!-- Vault (colecciones privadas — biométrico por colección) -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,9 +95,9 @@
     <string name="app_my_sounds_empty_body">A laugh, a "happy birthday", an "on my way" from someone who matters. Share any voice note from WhatsApp, Telegram, or wherever — it\'ll wait right here, ready when you are.</string>
 
     <!-- Welcome sticker (Sticker Cero, fresh-install variant) -->
-    <string name="app_welcome_sticker_title">A hello from Nahu</string>
+    <string name="app_welcome_sticker_title">Your first voice-hug</string>
     <string name="app_welcome_sticker_origin">From the maker</string>
-    <string name="app_welcome_sticker_remaining_format">-%1$s</string>
+    <string name="app_welcome_sticker_info">From me to you. It\'s yours — delete it whenever you like.</string>
     <string name="app_welcome_sticker_feedback_dismissed">Catch you around!</string>
 
     <!-- Vault tab (private collections — biometric-gated per collection) -->

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/welcome/WelcomeStickerStoreTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/welcome/WelcomeStickerStoreTest.kt
@@ -85,7 +85,7 @@ internal class WelcomeStickerStoreTest : AbstractRobolectricTest() {
     fun `acknowledged is independent of consumed`() {
         runBlocking {
             // Playing to completion (acknowledged) must NOT remove the welcome (consumed) — the card
-            // stays in the list until the user manually deletes it (feedback v2.1.0 #1).
+            // stays in the list until the user manually deletes it.
             store.markAcknowledged()
 
             assertThat(store.isAcknowledged()).isTrue()

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/welcome/WelcomeStickerStoreTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/welcome/WelcomeStickerStoreTest.kt
@@ -64,35 +64,86 @@ internal class WelcomeStickerStoreTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `wasRestored defaults to false`() {
+    fun `acknowledged defaults to false`() {
         runBlocking {
-            assertThat(store.wasRestored()).isFalse()
+            assertThat(store.isAcknowledged()).isFalse()
         }
     }
 
     @Test
-    fun `restore sets both consumed=false AND wasRestored=true atomically`() {
+    fun `markAcknowledged flips it true and survives a fresh instance`() {
         runBlocking {
-            store.consume()
+            store.markAcknowledged()
 
-            store.restore()
+            assertThat(store.isAcknowledged()).isTrue()
+            // A fresh instance reads the persisted disk value, not the in-memory cache.
+            assertThat(WelcomeStickerStore(context).isAcknowledged()).isTrue()
+        }
+    }
+
+    @Test
+    fun `acknowledged is independent of consumed`() {
+        runBlocking {
+            // Playing to completion (acknowledged) must NOT remove the welcome (consumed) — the card
+            // stays in the list until the user manually deletes it (feedback v2.1.0 #1).
+            store.markAcknowledged()
+
+            assertThat(store.isAcknowledged()).isTrue()
+            assertThat(store.isActive()).isTrue()
+        }
+    }
+
+    @Test
+    fun `hintShown defaults to false and flips true once marked`() {
+        runBlocking {
+            assertThat(store.isHintShown()).isFalse()
+
+            store.markHintShown()
+
+            assertThat(store.isHintShown()).isTrue()
+        }
+    }
+
+    @Test
+    fun `installTimestamp is captured once and stable across reads`() {
+        runBlocking {
+            var clock = 1_000L
+            val timed = WelcomeStickerStore(context, now = { clock })
+
+            val first = timed.installTimestamp()
+            clock = 9_999L
+            val second = timed.installTimestamp()
+            // The timestamp is captured on first read and persisted, so it never moves even though
+            // the clock advanced — the welcome keeps a stable position in the date-sorted list.
+            assertThat(first).isEqualTo(1_000L)
+            assertThat(second).isEqualTo(1_000L)
+        }
+    }
+
+    @Test
+    fun `migrateToPersistentIfNeeded resurfaces a welcome consumed under the old model`() {
+        runBlocking {
+            // Old model: letting it auto-destruct set consumed=true and it vanished forever.
+            store.consume()
+            assertThat(store.isActive()).isFalse()
+
+            store.migrateToPersistentIfNeeded()
 
             assertThat(store.isActive()).isTrue()
-            assertThat(store.wasRestored()).isTrue()
         }
     }
 
     @Test
-    fun `wasRestored is sticky once set`() {
+    fun `migrateToPersistentIfNeeded is idempotent so a later manual delete sticks`() {
         runBlocking {
             store.consume()
-            store.restore()
-            // A subsequent consume must NOT clear wasRestored — the demotion is permanent until
-            // the user manually dismisses again, which marks consumed = true and the flag becomes
-            // moot.
+            store.migrateToPersistentIfNeeded() // resurfaced once
+            // Under the new model the user deletes it on purpose.
             store.consume()
 
-            assertThat(store.wasRestored()).isTrue()
+            store.migrateToPersistentIfNeeded() // must NOT resurrect it again
+
+            assertThat(store.isActive()).isFalse()
         }
     }
 }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/DeletionSnackbarDurationTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/DeletionSnackbarDurationTest.kt
@@ -13,12 +13,14 @@ import org.junit.Test
 
 internal class DeletionSnackbarDurationTest {
     @Test
-    fun `returns Short for the welcome sticker so dismissal feedback is not lingering`() {
+    fun `returns Long for the welcome sticker so Undo is reachable after manual delete`() {
+        // The welcome is now persistent and deleted only manually (feedback v2.1.0 #1), so its
+        // deletion is destructive+undoable and needs Long just like a user-created sound.
         val welcome = testSound(name = "Welcome", rawRes = R.raw.app_welcome_sticker)
 
         val duration = deletionSnackbarDuration(welcome)
 
-        assertThat(duration).isEqualTo(SnackbarDuration.Short)
+        assertThat(duration).isEqualTo(SnackbarDuration.Long)
     }
 
     @Test

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/DeletionSnackbarDurationTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/DeletionSnackbarDurationTest.kt
@@ -14,7 +14,7 @@ import org.junit.Test
 internal class DeletionSnackbarDurationTest {
     @Test
     fun `returns Long for the welcome sticker so Undo is reachable after manual delete`() {
-        // The welcome is now persistent and deleted only manually (feedback v2.1.0 #1), so its
+        // The welcome is now persistent and deleted only manually, so its
         // deletion is destructive+undoable and needs Long just like a user-created sound.
         val welcome = testSound(name = "Welcome", rawRes = R.raw.app_welcome_sticker)
 

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelAnalyticsTest.kt
@@ -412,11 +412,13 @@ internal class SoundsViewModelAnalyticsTest : AbstractRobolectricTest() {
         val welcome = viewModel.sounds.value.first { it.name == welcomeTitle }
 
         viewModel.onPlayerStop(welcome, completed = true)
-
-        // The event now fires from inside the acknowledged-gated coroutine (so replays don't inflate
-        // it) — await the info event it emits right after, then assert the one-time completion log.
+        // Await the info event the gated coroutine emits right after logging, so the first completion
+        // has fully landed before we replay.
         runBlocking { withTimeout(2_000L) { viewModel.welcomeInfoEvent.first() } }
-        fake.assertEmitted("welcome_sticker_completed")
+        // A replay completing again must NOT re-log it — the `acknowledged` flag gates it to once.
+        viewModel.onPlayerStop(welcome, completed = true)
+
+        assertThat(fake.events.count { it.name == "welcome_sticker_completed" }).isEqualTo(1)
     }
 
     @Test
@@ -435,7 +437,7 @@ internal class SoundsViewModelAnalyticsTest : AbstractRobolectricTest() {
 
         viewModel.restoreSound()
 
-        // The welcome-specific `welcome_sticker_undone` was pruned (feedback v2.1.0 #1): the welcome
+        // The welcome-specific `welcome_sticker_undone` was pruned: the welcome
         // is just-another-audio, so its Undo emits the generic event like any other sound.
         fake.assertEmitted("sound_delete_undone")
     }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelAnalyticsTest.kt
@@ -403,7 +403,7 @@ internal class SoundsViewModelAnalyticsTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `onPlayerStop completed=true on welcome logs welcome_sticker_completed`() {
+    fun `onPlayerStop completed=true on welcome logs welcome_sticker_completed once`() {
         val viewModel = givenAViewModel()
         val welcomeTitle =
             ApplicationProvider
@@ -413,24 +413,31 @@ internal class SoundsViewModelAnalyticsTest : AbstractRobolectricTest() {
 
         viewModel.onPlayerStop(welcome, completed = true)
 
+        // The event now fires from inside the acknowledged-gated coroutine (so replays don't inflate
+        // it) — await the info event it emits right after, then assert the one-time completion log.
+        runBlocking { withTimeout(2_000L) { viewModel.welcomeInfoEvent.first() } }
         fake.assertEmitted("welcome_sticker_completed")
     }
 
     @Test
-    fun `restoreSound on welcome logs only welcome_sticker_undone`() {
+    fun `restoreSound on welcome logs the generic sound_delete_undone`() {
+        every { PlayerControllerFactory.instance.forgetSound(any()) } answers { nothing }
         val viewModel = givenAViewModel()
         val welcomeTitle =
             ApplicationProvider
                 .getApplicationContext<android.content.Context>()
                 .getString(R.string.app_welcome_sticker_title)
         val welcome = viewModel.sounds.value.first { it.name == welcomeTitle }
-        viewModel.onPlayerStop(welcome, completed = true)
+        // Manual delete (swipe) is the only path that enqueues a delete event now that completion no
+        // longer self-destructs the welcome.
+        viewModel.deleteSound(welcome)
         fake.events.clear()
 
         viewModel.restoreSound()
 
-        fake.assertEmitted("welcome_sticker_undone")
-        fake.assertNotEmitted("sound_delete_undone")
+        // The welcome-specific `welcome_sticker_undone` was pruned (feedback v2.1.0 #1): the welcome
+        // is just-another-audio, so its Undo emits the generic event like any other sound.
+        fake.assertEmitted("sound_delete_undone")
     }
 
     @Test

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelCollectionsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelCollectionsTest.kt
@@ -36,11 +36,12 @@ internal class SoundsViewModelCollectionsTest : AbstractRobolectricTest() {
             SoundsRepository(ApplicationProvider.getApplicationContext()).clearForTest()
             CollectionsRepository(ApplicationProvider.getApplicationContext()).clearForTest()
             MySoundsFilterStore(ApplicationProvider.getApplicationContext()).clearForTest()
-            // Consume (not clear) the welcome sticker so it does NOT appear on top of the
-            // sound list during these tests. clearForTest() resets the consumed flag, which
-            // re-enables the sticker — exactly the opposite of what we need here.
+            // Keep the welcome sticker off the sound list during these tests. Run the one-time
+            // persistence migration first (so it can't resurrect the welcome), then consume it — a
+            // new-model manual delete that sticks. clearForTest() alone would re-enable it.
             val welcome = WelcomeStickerStore(ApplicationProvider.getApplicationContext())
             welcome.clearForTest()
+            welcome.migrateToPersistentIfNeeded()
             welcome.consume()
         }
         mockkObject(PlayerControllerFactory)

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
@@ -765,9 +765,28 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `welcome sticker is absent when flag is consumed`() {
+    fun `welcome resurfaces after init for an install that consumed it under the old model`() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
         runBlocking {
-            WelcomeStickerStore(ApplicationProvider.getApplicationContext()).consume()
+            // Simulate a v2.1.0 install that let the welcome auto-destruct (consumed=true).
+            WelcomeStickerStore(context).consume()
+        }
+        val viewModel = givenAViewModel()
+        val welcomeTitle = context.getString(R.string.app_welcome_sticker_title)
+
+        // The one-time migration in init clears the stale `consumed` flag and brings it back so the
+        // Bomper who "lost" it without understanding gets it again (feedback v2.1.0 #1).
+        assertThat(viewModel.sounds.value.any { it.name == welcomeTitle }).isTrue()
+    }
+
+    @Test
+    fun `welcome sticker is absent when manually deleted under the new model`() {
+        runBlocking {
+            val store = WelcomeStickerStore(ApplicationProvider.getApplicationContext())
+            // Run the one-time resurrection migration first, so a subsequent delete is a NEW-model
+            // manual delete (which must stick) rather than the old auto-destruct state it resurrects.
+            store.migrateToPersistentIfNeeded()
+            store.consume()
         }
         val viewModel = givenAViewModel()
         val welcomeTitle =
@@ -800,23 +819,24 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `onPlayerStop with completed=true on welcome enqueues delete event and hides sticker`() {
-        val viewModel = givenAViewModel()
-        val welcomeTitle =
-            ApplicationProvider
-                .getApplicationContext<android.content.Context>()
-                .getString(R.string.app_welcome_sticker_title)
+    fun `onPlayerStop completed on welcome keeps it visible and emits the info event once`() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val store = WelcomeStickerStore(context)
+        val viewModel = givenAViewModel(welcomeStore = store)
+        val welcomeTitle = context.getString(R.string.app_welcome_sticker_title)
         val welcome = viewModel.sounds.value.first { it.name == welcomeTitle }
 
         viewModel.onPlayerStop(welcome, completed = true)
 
-        assertThat(
-            viewModel.deletedSoundEvent.value
-                ?.sound
-                ?.name,
-        ).isEqualTo(welcomeTitle)
-        assertThat(viewModel.welcomeStickerVisible.value).isFalse()
-        assertThat(viewModel.sounds.value.none { it.name == welcomeTitle }).isTrue()
+        // The welcome no longer self-destructs (feedback v2.1.0 #1): it stays in the list, no delete
+        // event is enqueued, the informative snackbar fires once, and it is marked acknowledged.
+        assertThat(viewModel.deletedSoundEvent.value).isNull()
+        assertThat(viewModel.welcomeStickerVisible.value).isTrue()
+        assertThat(viewModel.sounds.value.any { it.name == welcomeTitle }).isTrue()
+        runBlocking {
+            assertThat(withTimeoutOrNull(2_000L) { viewModel.welcomeInfoEvent.first() }).isNotNull()
+            assertThat(store.isAcknowledged()).isTrue()
+        }
     }
 
     @Test
@@ -837,39 +857,39 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
 
     @Test
     fun `restoreSound on welcome restores visibility and asks the store to restore`() {
+        every { PlayerControllerFactory.instance.forgetSound(any()) } answers { nothing }
         val welcomeStore = mockk<WelcomeStickerStore>(relaxed = true)
         coEvery { welcomeStore.isActive() } returns true
-        coEvery { welcomeStore.wasRestored() } returns false
         val viewModel = givenAViewModel(welcomeStore = welcomeStore)
         val welcomeTitle =
             ApplicationProvider
                 .getApplicationContext<android.content.Context>()
                 .getString(R.string.app_welcome_sticker_title)
         val welcome = viewModel.sounds.value.first { it.name == welcomeTitle }
-        viewModel.onPlayerStop(welcome, completed = true)
+        // Manual delete (swipe) is the only path that enqueues a delete event now that completion no
+        // longer self-destructs the welcome.
+        viewModel.deleteSound(welcome)
 
         viewModel.restoreSound()
 
         assertThat(viewModel.welcomeStickerVisible.value).isTrue()
         assertThat(viewModel.sounds.value.any { it.name == welcomeTitle }).isTrue()
         // Behavior assertion only — disk persistence is covered by `WelcomeStickerStoreTest`.
-        // The previous version polled a fresh store instance, which raced with the IO write and
-        // could permanently cache a stale read.
         coVerify { welcomeStore.restore() }
     }
 
     @Test
     fun `confirmDelete on welcome calls welcomeStore consume and skips repo delete`() {
+        every { PlayerControllerFactory.instance.forgetSound(any()) } answers { nothing }
         val welcomeStore = mockk<WelcomeStickerStore>(relaxed = true)
         coEvery { welcomeStore.isActive() } returns true
-        coEvery { welcomeStore.wasRestored() } returns false
         val viewModel = givenAViewModel(welcomeStore = welcomeStore)
         val welcomeTitle =
             ApplicationProvider
                 .getApplicationContext<android.content.Context>()
                 .getString(R.string.app_welcome_sticker_title)
         val welcome = viewModel.sounds.value.first { it.name == welcomeTitle }
-        viewModel.onPlayerStop(welcome, completed = true)
+        viewModel.deleteSound(welcome)
 
         viewModel.confirmDelete()
 
@@ -900,7 +920,7 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `restoreSound on welcome inserts at the END not at original position 0`() {
+    fun `restoreSound on welcome re-inserts it sorted by date`() {
         every { PlayerControllerFactory.instance.forgetSound(any()) } answers { nothing }
         val context = ApplicationProvider.getApplicationContext<android.app.Application>()
         runBlocking {
@@ -909,7 +929,8 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
         }
         val viewModel = givenAViewModel()
         val welcomeTitle = context.getString(R.string.app_welcome_sticker_title)
-        // Pre-condition: welcome at row 0, custom at row 1.
+        // Pre-condition: welcome at row 0 — its install timestamp is newer than the custom (whose
+        // file is absent in unit tests, so its dateAdded is null and it sorts last).
         assertThat(
             viewModel.sounds.value
                 .first()
@@ -920,47 +941,42 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
 
         viewModel.restoreSound()
 
-        // Post-condition: welcome demoted to the END, custom now at row 0.
-        assertThat(
-            viewModel.sounds.value
-                .last()
-                .name,
-        ).isEqualTo(welcomeTitle)
+        // Post-condition: welcome is sorted back into its date position (row 0), NOT demoted to the
+        // end — it behaves like any other audio now (feedback v2.1.0 #1).
         assertThat(
             viewModel.sounds.value
                 .first()
                 .name,
-        ).isEqualTo("custom")
+        ).isEqualTo(welcomeTitle)
     }
 
     @Test
-    fun `loadSounds appends welcome at the end when wasRestored is true`() {
-        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+    fun `welcome sticker carries its install timestamp as dateAdded and sorts by date`() {
+        val context = ApplicationProvider.getApplicationContext<android.app.Application>()
+        val store = WelcomeStickerStore(context, now = { 5_000L })
         runBlocking {
-            // Seed store as if a previous Undo happened: restore() flips consumed=false AND
-            // was_restored=true atomically.
-            val store = WelcomeStickerStore(context)
-            store.consume()
-            store.restore()
-            val repo = SoundsRepository(context as android.app.Application)
-            repo.save(testSound("custom-a", "custom-a.mp3"))
-            repo.save(testSound("custom-b", "custom-b.mp3"))
+            SoundsRepository(context).save(testSound("custom", "custom.mp3"))
         }
 
-        val viewModel = givenAViewModel()
+        val viewModel = givenAViewModel(welcomeStore = store)
         val welcomeTitle = context.getString(R.string.app_welcome_sticker_title)
+        val welcome = viewModel.sounds.value.first { it.name == welcomeTitle }
 
-        // Welcome must be at the end, after the user's two custom sounds.
-        assertThat(
-            viewModel.sounds.value
-                .last()
-                .name,
-        ).isEqualTo(welcomeTitle)
+        // The welcome is built with the store's install timestamp as its dateAdded, so it flows
+        // through the same SOUND_ORDER comparator as user audios instead of being force-positioned.
+        assertThat(welcome.dateAdded).isEqualTo(5_000L)
+        // The custom audio has no file on disk (null dateAdded → sorts last), so the dated welcome
+        // leads the list. With real file timestamps (instrumented), a newer audio outranks it.
         assertThat(
             viewModel.sounds.value
                 .first()
                 .name,
-        ).isNotEqualTo(welcomeTitle)
+        ).isEqualTo(welcomeTitle)
+        assertThat(
+            viewModel.sounds.value
+                .last()
+                .name,
+        ).isEqualTo("custom")
     }
 
     @Test

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
@@ -10,6 +10,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.commons.file.getFile
 import com.github.barriosnahuel.vossosunboton.feature.collections.MySoundsFilterStore
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
@@ -775,7 +776,7 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
         val welcomeTitle = context.getString(R.string.app_welcome_sticker_title)
 
         // The one-time migration in init clears the stale `consumed` flag and brings it back so the
-        // Bomper who "lost" it without understanding gets it again (feedback v2.1.0 #1).
+        // Bomper who "lost" it without understanding gets it again.
         assertThat(viewModel.sounds.value.any { it.name == welcomeTitle }).isTrue()
     }
 
@@ -828,7 +829,7 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
 
         viewModel.onPlayerStop(welcome, completed = true)
 
-        // The welcome no longer self-destructs (feedback v2.1.0 #1): it stays in the list, no delete
+        // The welcome no longer self-destructs: it stays in the list, no delete
         // event is enqueued, the informative snackbar fires once, and it is marked acknowledged.
         assertThat(viewModel.deletedSoundEvent.value).isNull()
         assertThat(viewModel.welcomeStickerVisible.value).isTrue()
@@ -837,6 +838,25 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
             assertThat(withTimeoutOrNull(2_000L) { viewModel.welcomeInfoEvent.first() }).isNotNull()
             assertThat(store.isAcknowledged()).isTrue()
         }
+    }
+
+    @Test
+    fun `onPlayerStop completed on welcome tracks a non-fatal instead of crashing when the store fails`() {
+        val welcomeStore = mockk<WelcomeStickerStore>(relaxed = true)
+        coEvery { welcomeStore.isActive() } returns true
+        coEvery { welcomeStore.isAcknowledged() } throws RuntimeException("datastore boom")
+        val viewModel = givenAViewModel(welcomeStore = welcomeStore)
+        val welcomeTitle =
+            ApplicationProvider
+                .getApplicationContext<android.content.Context>()
+                .getString(R.string.app_welcome_sticker_title)
+        val welcome = viewModel.sounds.value.first { it.name == welcomeTitle }
+
+        viewModel.onPlayerStop(welcome, completed = true)
+
+        // viewModelScope has no CoroutineExceptionHandler, so an uncaught throw from the store would
+        // crash the app on completion. The handler must catch it and report a non-fatal instead.
+        verify { Tracker.track(any()) }
     }
 
     @Test
@@ -942,7 +962,7 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
         viewModel.restoreSound()
 
         // Post-condition: welcome is sorted back into its date position (row 0), NOT demoted to the
-        // end — it behaves like any other audio now (feedback v2.1.0 #1).
+        // end — it behaves like any other audio now.
         assertThat(
             viewModel.sounds.value
                 .first()

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelVisibilityTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelVisibilityTest.kt
@@ -348,7 +348,10 @@ internal class SoundsViewModelVisibilityTest : AbstractRobolectricTest() {
     }
 
     private companion object {
-        const val TIMEOUT_MS = 3_000L
+        // Generous headroom for the DataStore → repo → loadSounds → StateFlow chain on a loaded CI
+        // machine (a 3s cap intermittently timed out under load). It only delays the genuine-hang
+        // case; passing awaits return as soon as the awaited state arrives.
+        const val TIMEOUT_MS = 10_000L
         const val SHORT_TIMEOUT_MS = 750L
     }
 }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelVisibilityTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelVisibilityTest.kt
@@ -54,9 +54,12 @@ internal class SoundsViewModelVisibilityTest : AbstractRobolectricTest() {
             CollectionsRepository(context).clearForTest()
             MySoundsFilterStore(context).clearForTest()
             DualHomeCoachStore(context).clearForTest()
-            // Consume (not clear) the welcome sticker so it never sits on top of the asserted list.
+            // Keep the welcome sticker off the asserted list. Run the one-time persistence migration
+            // first so it can't resurrect the welcome, then consume it (a new-model manual delete,
+            // which sticks). clearForTest() alone would re-enable it.
             val welcome = WelcomeStickerStore(context)
             welcome.clearForTest()
+            welcome.migrateToPersistentIfNeeded()
             welcome.consume()
         }
         mockkObject(PlayerControllerFactory)

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/WelcomeStickerScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/WelcomeStickerScreenTest.kt
@@ -8,6 +8,7 @@ package com.github.barriosnahuel.vossosunboton.ui.home
 import android.os.Build
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.longClick
@@ -60,11 +61,13 @@ internal class WelcomeStickerScreenTest : AbstractRobolectricTest() {
             }
         }
 
-        // The welcome no longer self-destructs, so the "-M:SS" countdown is gone (feedback v2.1.0 #1)
-        // — it shows like a normal audio: title, play, and the "from the maker" origin label.
+        // The welcome no longer self-destructs, so the "-M:SS" countdown is gone — it shows like a
+        // normal audio: title, play, and the "from the maker" origin label.
         composeTestRule.onNodeWithText(title).assertIsDisplayed()
         composeTestRule.onNodeWithContentDescription(playLabel).assertIsDisplayed()
         composeTestRule.onNodeWithText(origin).assertIsDisplayed()
+        // And no countdown is synthesized from the 14s duration (the old "-0:14" trailing label).
+        composeTestRule.onAllNodesWithText("-0:14").assertCountEquals(0)
     }
 
     @Test

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/WelcomeStickerScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/WelcomeStickerScreenTest.kt
@@ -35,11 +35,12 @@ internal class WelcomeStickerScreenTest : AbstractRobolectricTest() {
     val composeTestRule = createComposeRule()
 
     @Test
-    fun `welcome sticker variant renders play button and trailing label`() {
+    fun `welcome sticker variant renders title play and maker origin without a countdown`() {
         val context = ApplicationProvider.getApplicationContext<android.content.Context>()
         val sound = welcomeSticker(context)
         val title = context.getString(R.string.app_welcome_sticker_title)
         val playLabel = context.getString(R.string.app_play)
+        val origin = context.getString(R.string.app_welcome_sticker_origin)
 
         composeTestRule.setContent {
             MaterialTheme {
@@ -54,14 +55,48 @@ internal class WelcomeStickerScreenTest : AbstractRobolectricTest() {
                     onPinClick = {},
                     isWelcomeVariant = true,
                     borderOverride = BorderStroke(1.5.dp, MaterialTheme.colorScheme.primaryContainer),
-                    trailingLabel = "-0:14",
+                    originLabel = origin,
                 )
             }
         }
 
+        // The welcome no longer self-destructs, so the "-M:SS" countdown is gone (feedback v2.1.0 #1)
+        // — it shows like a normal audio: title, play, and the "from the maker" origin label.
         composeTestRule.onNodeWithText(title).assertIsDisplayed()
         composeTestRule.onNodeWithContentDescription(playLabel).assertIsDisplayed()
-        composeTestRule.onNodeWithText("-0:14").assertIsDisplayed()
+        composeTestRule.onNodeWithText(origin).assertIsDisplayed()
+    }
+
+    @Test
+    fun `welcome variant swipe-hint nudge runs once and reports it shown`() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val sound = welcomeSticker(context)
+        val title = context.getString(R.string.app_welcome_sticker_title)
+        var hintShownCount = 0
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                SoundItem(
+                    sound = sound,
+                    playbackProgress = null,
+                    durationMs = 14_000,
+                    onPlayClick = {},
+                    onSeek = {},
+                    onShareClick = {},
+                    onDelete = {},
+                    onPinClick = {},
+                    isWelcomeVariant = true,
+                    showSwipeHint = true,
+                    onSwipeHintShown = { hintShownCount++ },
+                )
+            }
+        }
+
+        // The peek animation (or its reduced-motion skip) completes and reports back exactly once so
+        // the nudge never repeats. The card itself stays rendered (nothing was deleted).
+        composeTestRule.waitUntil(timeoutMillis = 5_000L) { hintShownCount == 1 }
+        composeTestRule.onNodeWithText(title).assertIsDisplayed()
+        assertThat(hintShownCount).isEqualTo(1)
     }
 
     @Test

--- a/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsEvent.kt
+++ b/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsEvent.kt
@@ -137,35 +137,33 @@ sealed class AnalyticsEvent(
     object AboutBrandingAudioPlay : AnalyticsEvent(name = "about_branding_audio_play", hasFirstVariant = true)
 
     /**
-     * Welcome sticker (Sticker Cero, fresh-install variant) became visible at the top of MY_SOUNDS.
-     * Gated call-site-side via `tracker.markFiredOnce("welcome_sticker_shown")` so it fires at most
-     * once per install. `hasFirstVariant = false` because the marker is already one-shot.
+     * Welcome sticker (Sticker Cero, fresh-install variant) became visible in MY_SOUNDS. It is now a
+     * persistent, date-sorted audio (feedback v2.1.0 #1), not force-pinned to row 0. Gated call-site
+     * via `tracker.markFiredOnce("welcome_sticker_shown")` so it fires at most once per install.
+     * `hasFirstVariant = false` because the marker is already one-shot.
      */
     object WelcomeStickerShown : AnalyticsEvent(name = "welcome_sticker_shown", hasFirstVariant = false)
 
     /**
-     * User tapped play on the welcome sticker. `hasFirstVariant = true` so the dashboard can tell
-     * a first listen apart from replays (only path to a replay is the Undo flow on the snackbar) —
-     * a useful signal when deciding whether to ship the deferred UPDATE flow.
+     * User tapped play on the welcome sticker. `hasFirstVariant = true` so the dashboard can tell a
+     * first listen apart from replays — useful to gauge affection (do they come back to it) and as
+     * the engagement denominator for the deferred UPDATE flow.
      */
     object WelcomeStickerPlay : AnalyticsEvent(name = "welcome_sticker_play", hasFirstVariant = true)
 
     /**
-     * Welcome audio reached natural end-of-stream. The auto-destruct + Undo snackbar follows.
-     * `hasFirstVariant = true` so a second completion (after Undo + replay) is visible.
+     * Welcome audio reached its natural end for the FIRST time — the "they heard it through" onboarding
+     * milestone (feedback v2.1.0 #1). Gated by the `acknowledged` flag in `SoundsViewModel.onPlayerStop`
+     * so unlimited replays of the now-persistent welcome don't inflate it; replays are measured by
+     * [WelcomeStickerPlay]. `hasFirstVariant = false` because it is already one-shot.
      */
-    object WelcomeStickerCompleted : AnalyticsEvent(name = "welcome_sticker_completed", hasFirstVariant = true)
-
-    /**
-     * User tapped Undo on the welcome auto-destruct snackbar. Suppresses the regular
-     * [SoundDeleteUndone] for this branch to avoid double-counting in dashboards.
-     */
-    object WelcomeStickerUndone : AnalyticsEvent(name = "welcome_sticker_undone", hasFirstVariant = true)
+    object WelcomeStickerCompleted : AnalyticsEvent(name = "welcome_sticker_completed", hasFirstVariant = false)
 
     /**
      * Welcome sticker manually dismissed — swipe-left or long-press → Delete. Distinct from
      * [WelcomeStickerCompleted] (audio reached natural end) so dashboards can compare engagement
-     * (listened all the way) vs impatience (dismissed early).
+     * (listened all the way) vs impatience (dismissed early). Its Undo logs the generic
+     * [SoundDeleteUndone] (welcome is just-another-audio now).
      */
     object WelcomeStickerDismissed : AnalyticsEvent(name = "welcome_sticker_dismissed", hasFirstVariant = true)
 

--- a/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsEvent.kt
+++ b/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsEvent.kt
@@ -138,7 +138,7 @@ sealed class AnalyticsEvent(
 
     /**
      * Welcome sticker (Sticker Cero, fresh-install variant) became visible in MY_SOUNDS. It is now a
-     * persistent, date-sorted audio (feedback v2.1.0 #1), not force-pinned to row 0. Gated call-site
+     * persistent, date-sorted audio, not force-pinned to row 0. Gated call-site
      * via `tracker.markFiredOnce("welcome_sticker_shown")` so it fires at most once per install.
      * `hasFirstVariant = false` because the marker is already one-shot.
      */
@@ -153,7 +153,7 @@ sealed class AnalyticsEvent(
 
     /**
      * Welcome audio reached its natural end for the FIRST time — the "they heard it through" onboarding
-     * milestone (feedback v2.1.0 #1). Gated by the `acknowledged` flag in `SoundsViewModel.onPlayerStop`
+     * milestone. Gated by the `acknowledged` flag in `SoundsViewModel.onPlayerStop`
      * so unlimited replays of the now-persistent welcome don't inflate it; replays are measured by
      * [WelcomeStickerPlay]. `hasFirstVariant = false` because it is already one-shot.
      */

--- a/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsCoverageMatrixTest.kt
+++ b/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsCoverageMatrixTest.kt
@@ -77,7 +77,6 @@ internal class AnalyticsCoverageMatrixTest {
                 "WelcomeStickerShown",
                 "WelcomeStickerPlay",
                 "WelcomeStickerCompleted",
-                "WelcomeStickerUndone",
                 "WelcomeStickerDismissed",
                 "DuplicateNameHintShown",
                 "DuplicateNameHintPlay",


### PR DESCRIPTION
### Summary

1. You open the app for the first time (or update to this version)
2. You see **"Tu primer audio-abrazo"** near the top of My Sounds and tap play

**before:** when the audio finishes, the card self-destructs and disappears. Many people "lost" their welcome without understanding what happened — and once gone, it never came back.
**after:** it stays like any other audio (sorted by date). The first time it finishes, a warm note appears — *"De mí para vos. Es tuyo: borralo cuando quieras."* — and the first time the card shows, a one-time swipe nudge hints you can swipe it away. Anyone who lost it under the old behavior gets it back, once.

### Technical detail

Inverts the Sticker Cero default from *ephemeral* to *persistent* (feedback v2.1.0 #1).

- **`WelcomeStickerStore`** — `consumed` flips only on manual delete now; new `acknowledged`, `hintShown`, `installTimestamp` (the welcome's `dateAdded`); dropped `was_restored`.
- **`SoundsViewModel`** — `onPlayerStop` no longer deletes on completion; marks `acknowledged` once and emits a one-shot `welcomeInfoEvent` (Channel, ADR 0003). `positionWelcomeIn` injects the welcome and sorts by the shared `SOUND_ORDER` (no forced row 0 / demote).
- **`SoundItem`** — one-time swipe-hint nudge via an `Animatable` offset peek (respects reduced-motion).
- **`LandingScreen`** — informative no-action snackbar; countdown label removed.
- **Migration** — `migrateToPersistentIfNeeded()` (guarded, once) resurfaces the welcome for installs that consumed it under the old auto-destruct. Old state can't distinguish auto-destruct from intentional delete, so it's a blanket one-time resurface.
- **Analytics** — `welcome_sticker_completed` gated to fire once (replays → `welcome_sticker_play`); pruned `welcome_sticker_undone` (welcome undo → generic `sound_delete_undone`); no new events (user base < 10).
- **Out of scope** — TalkBack custom actions for swipe (feedback #2); What's New slot flow (v2.6.0-03).

### Code review tips

- **Migration blast radius**: clears `consumed` for *all* existing installs once; the `migrated_persistent` guard must make a later deliberate delete stick (covered in `WelcomeStickerStoreTest` + `SoundsViewModelTest`).
- **Swipe-hint nudge** (`SoundItem.kt`): self-contained `Animatable` overlay because M3 `SwipeToDismissBox` has no public partial-peek API. The **visual is device-only — manual verification suggested**; the functional path (runs once, reports back, reduced-motion skip) is Robolectric-covered.
- **Instrumented flake**: 3 of 4 full cold-boot runs hit the known `AddButtonActivity` StrictMode `InstanceCountViolation` (GC-timing, ADR 0001) — always on AddButton/Collections, **never** on welcome. Unrelated to this diff.

### Already tested

- Unit + lint: covered by CI (detekt/ktlint/spotless/Android Lint + 424 unit tests + ADR & security invariant scripts) — all green locally.
- Instrumented (CI does not run it — ADR 0001): `WelcomeStickerFlowTest` 3/3 green on a clean cold-boot of this exact code; full suite 113/113 green on a clean cold-boot earlier this session; the 3 red re-runs failed **only** on the unrelated `AddButtonActivity` StrictMode GC-timing flake — welcome tests passed in every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
