### PR TITLE
test(perf): macrobenchmark harness for LandingActivity jank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 ### Changed
 - The welcome audio no longer vanishes on its own after it plays — it stays in your list like any other audio, sorted by date, and the first time it finishes a warm note reminds you it's yours to keep or delete whenever you want; a one-time nudge shows you can swipe it away
 
+### For nerds 🤓
+
+#### Added
+- Macrobenchmark module measuring LandingActivity cold-start and sound-list scroll frame timing, to diagnose the entry-screen jank on lower-tier devices
+
 ## \[v2.1.0] - 2026-05-25
 
 ### Added

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,6 +92,16 @@ android {
                 debugSymbolLevel 'FULL'
             }
         }
+
+        // Release-like build target consumed only by the :macrobenchmark module (non-debuggable +
+        // minified so startup/frame numbers match what users get). Made profileable via
+        // src/benchmark/AndroidManifest.xml. Firebase config is a scrubbed dummy
+        // (src/benchmark/google-services.json) so benchmark runs never report to bomp-prod.
+        benchmark {
+            initWith release
+            matchingFallbacks = ['release']
+            debuggable false
+        }
     }
 
     buildFeatures {

--- a/app/src/benchmark/AndroidManifest.xml
+++ b/app/src/benchmark/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Makes the non-debuggable `benchmark` build type profileable so the :macrobenchmark module can
+  ~ capture traces on a real device (Macrobenchmark requires the target to be debuggable OR
+  ~ profileable; benchmark is debuggable=false). Scoped to this source set so release stays
+  ~ unaffected. The attribute is ignored below API 29.
+  -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application>
+        <profileable
+            android:shell="true"
+            tools:targetApi="29" />
+    </application>
+</manifest>

--- a/app/src/benchmark/google-services.json
+++ b/app/src/benchmark/google-services.json
@@ -1,0 +1,21 @@
+{
+  "project_info": {
+    "project_number": "383291838647",
+    "project_id": "bomp-prod"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:999999999:android:dummydummydummy",
+        "android_client_info": {
+          "package_name": "com.github.barriosnahuel.vossosunboton"
+        }
+      },
+      "api_key": [
+        {
+          "current_key": "a-really-dummy-value"
+        }
+      ]
+    }
+  ]
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,8 @@ truth                     = "1.4.5"
 mockk                     = "1.14.11"
 espresso                  = "3.7.0"
 uiautomator               = "2.3.0"
+benchmarkMacro            = "1.4.1"
+androidxTestExtJunit      = "1.2.1"
 
 [libraries]
 # ---------- Build-script classpath ----------
@@ -108,3 +110,7 @@ espresso-core                     = { module = "androidx.test.espresso:espresso-
 espresso-intents                  = { module = "androidx.test.espresso:espresso-intents",       version.ref = "espresso" }
 espresso-accessibility            = { module = "androidx.test.espresso:espresso-accessibility", version.ref = "espresso" }
 androidx-uiautomator              = { module = "androidx.test.uiautomator:uiautomator",         version.ref = "uiautomator" }
+androidx-test-ext-junit           = { module = "androidx.test.ext:junit",                       version.ref = "androidxTestExtJunit" }
+
+# ---------- Macrobenchmark (performance harness, :macrobenchmark module only) ----------
+androidx-benchmark-macro-junit4   = { module = "androidx.benchmark:benchmark-macro-junit4",     version.ref = "benchmarkMacro" }

--- a/macrobenchmark/build.gradle
+++ b/macrobenchmark/build.gradle
@@ -1,0 +1,48 @@
+apply plugin: 'com.android.test'
+apply from: "$project.rootProject.projectDir/linters.gradle"
+
+android {
+    namespace = 'com.github.barriosnahuel.vossosunboton.macrobenchmark'
+
+    compileSdkVersion "android-37.0"
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
+    }
+
+    defaultConfig {
+        // minSdk 28: Macrobenchmark needs a profileable/debuggable target and is most reliable on
+        // API 28+. The app itself stays at minSdk 23; this only constrains where benchmarks run.
+        minSdkVersion 28
+        targetSdkVersion 37
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        // Matches the app's `benchmark` build type. Debuggable so the test harness (not the app
+        // under test) installs and runs; signed with the debug key for local/CI use.
+        benchmark {
+            debuggable true
+            signingConfig signingConfigs.debug
+            matchingFallbacks = ['release']
+        }
+    }
+
+    targetProjectPath = ':app'
+    experimentalProperties["android.experimental.self-instrumenting"] = true
+}
+
+// Only build the `benchmark` variant; skip the default `debug` variant (it would target the app's
+// debuggable build and produce meaningless numbers).
+androidComponents {
+    beforeVariants(selector().all()) { variant ->
+        variant.enable = variant.buildType == 'benchmark'
+    }
+}
+
+dependencies {
+    implementation libs.androidx.test.ext.junit
+    implementation libs.androidx.uiautomator
+    implementation libs.androidx.benchmark.macro.junit4
+}

--- a/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/BenchmarkTargets.kt
+++ b/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/BenchmarkTargets.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.macrobenchmark
+
+/**
+ * Shared constants for the LandingActivity performance benchmarks.
+ *
+ * The `benchmark` build type inherits the release applicationId (no `.debug` suffix), so the target
+ * package is the release one.
+ */
+internal const val TARGET_PACKAGE = "com.github.barriosnahuel.vossosunboton"
+
+/** Iterations per benchmark. Kept modest so a full local run stays under a few minutes. */
+internal const val DEFAULT_ITERATIONS = 5
+
+/** Number of fling gestures per scroll-benchmark iteration. */
+internal const val SCROLL_GESTURES = 3
+
+/**
+ * Fraction of the screen width reserved as a gesture margin so flings start inside the list and not
+ * on the system back-gesture edges. `displayWidth / 5` ≈ 20% per side.
+ */
+internal const val GESTURE_MARGIN_DIVISOR = 5

--- a/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/ScrollBenchmark.kt
+++ b/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/ScrollBenchmark.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.macrobenchmark
+
+import androidx.benchmark.macro.CompilationMode
+import androidx.benchmark.macro.FrameTimingMetric
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.Direction
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Frame timing while scrolling the sound list on LandingActivity.
+ *
+ * Targets the interaction regime of the jank investigation, which production data flags as the worst
+ * bucket (~39% slow frames + the only frozen frames during mid-length sessions) — separate from the
+ * startup regime measured by [StartupBenchmark].
+ *
+ * Scrolls via the first scrollable node ([By.scrollable]) so it needs no `testTag` wiring in the
+ * app. If the soundboard later exposes a stable test tag, target it directly for robustness.
+ * Numbers are read on-device by a human (plan Fase 3).
+ */
+@RunWith(AndroidJUnit4::class)
+class ScrollBenchmark {
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @Test
+    fun scrollSoundsList() =
+        benchmarkRule.measureRepeated(
+            packageName = TARGET_PACKAGE,
+            metrics = listOf(FrameTimingMetric()),
+            iterations = DEFAULT_ITERATIONS,
+            compilationMode = CompilationMode.DEFAULT,
+            setupBlock = { startActivityAndWait() },
+        ) {
+            val list = device.findObject(By.scrollable(true)) ?: return@measureRepeated
+            list.setGestureMargin(device.displayWidth / GESTURE_MARGIN_DIVISOR)
+            repeat(SCROLL_GESTURES) {
+                list.fling(Direction.DOWN)
+                device.waitForIdle()
+            }
+        }
+}

--- a/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/ScrollBenchmark.kt
+++ b/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/ScrollBenchmark.kt
@@ -7,6 +7,7 @@ package com.github.barriosnahuel.vossosunboton.macrobenchmark
 
 import androidx.benchmark.macro.CompilationMode
 import androidx.benchmark.macro.FrameTimingMetric
+import androidx.benchmark.macro.StartupMode
 import androidx.benchmark.macro.junit4.MacrobenchmarkRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.uiautomator.By
@@ -38,9 +39,17 @@ class ScrollBenchmark {
             metrics = listOf(FrameTimingMetric()),
             iterations = DEFAULT_ITERATIONS,
             compilationMode = CompilationMode.DEFAULT,
+            // WARM recreates LandingActivity each iteration so the list starts at the top. Without it
+            // the singleTask activity is reused with the process alive, leaving the list bottomed-out
+            // after iteration 1 — later flings would hit an idle screen and fake good frame numbers.
+            startupMode = StartupMode.WARM,
             setupBlock = { startActivityAndWait() },
         ) {
-            val list = device.findObject(By.scrollable(true)) ?: return@measureRepeated
+            // Fail loudly: a missing scrollable node must not silently record idle frames as a result.
+            val list =
+                requireNotNull(device.findObject(By.scrollable(true))) {
+                    "No scrollable node on LandingActivity — wire a stable testTag if this fails on-device."
+                }
             list.setGestureMargin(device.displayWidth / GESTURE_MARGIN_DIVISOR)
             repeat(SCROLL_GESTURES) {
                 list.fling(Direction.DOWN)

--- a/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/StartupBenchmark.kt
+++ b/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/StartupBenchmark.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.macrobenchmark
+
+import androidx.benchmark.macro.CompilationMode
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.StartupTimingMetric
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Cold-start timing for LandingActivity (the app's launcher / entry screen).
+ *
+ * Reproduces the startup regime of the jank investigation: production Firebase Performance shows
+ * ~573 ms cold start on an Android-11 OnePlus 8Pro vs 33–84 ms on current flagships. Run the same
+ * benchmark on a flagship and on a throttled / older device to quantify that gap.
+ *
+ * Two compilation modes bracket the real-world spread without a Baseline Profile yet:
+ *  - [CompilationMode.None]: no AOT — worst case, closest to a fresh install / cold ART.
+ *  - [CompilationMode.DEFAULT]: typical post-install state.
+ *
+ * Numbers are read on-device by a human (plan Fase 3); this class only defines the measurement.
+ */
+@RunWith(AndroidJUnit4::class)
+class StartupBenchmark {
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @Test
+    fun startupNoCompilation() = measureStartup(CompilationMode.None())
+
+    @Test
+    fun startupDefaultCompilation() = measureStartup(CompilationMode.DEFAULT)
+
+    private fun measureStartup(compilationMode: CompilationMode) =
+        benchmarkRule.measureRepeated(
+            packageName = TARGET_PACKAGE,
+            metrics = listOf(StartupTimingMetric()),
+            iterations = DEFAULT_ITERATIONS,
+            startupMode = StartupMode.COLD,
+            compilationMode = compilationMode,
+        ) {
+            pressHome()
+            startActivityAndWait()
+        }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 include ':model',
         ':commons_file',
         ':commons_android',
-        ':app'
+        ':app',
+        ':macrobenchmark'


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change.

Unblocks the root-cause phase of the LandingActivity jank investigation. Production Firebase Performance shows the entry screen at 24.8% slow frames, concentrated on mid-tier + Android 11 devices — but the BigQuery export can't attribute jank to a code path or even a phase. This harness reproduces the **startup** and **scroll** regimes on-device so the cause can be traced and a fix validated (investigation plan Fase 3/5).

### Technical detail

New performance-measurement harness; nothing ships to users.

- **`:macrobenchmark` module** (`com.android.test`, AGP-9 built-in Kotlin) — `StartupBenchmark` (cold start, `CompilationMode.None` vs `DEFAULT` to bracket the spread without a Baseline Profile yet) and `ScrollBenchmark` (`FrameTimingMetric` over the sound list).
- **`:app` `benchmark` build type** — `initWith release` (minified, non-debuggable) so numbers match what users get; made **profileable** via `src/benchmark/AndroidManifest.xml` so Macrobenchmark can trace a non-debuggable target.
- **Firebase** — `src/benchmark/google-services.json` is a **scrubbed dummy** (copied from the committed release dummy); benchmark runs never report to `bomp-prod` and no real keys are committed.
- **Version catalog** — `benchmark-macro-junit4` 1.4.1, `test.ext:junit` 1.2.1.
- **Out of scope** — Baseline Profile generation (follow-up); actually running the benchmarks (on-device, Fase 3).

### Code review tips

- Benchmarks run **on-device only** (Fase 3); CI just compiles them — they are not (and can't be) run headless.
- `ScrollBenchmark` targets the first `By.scrollable(true)` node (no app `testTag`); may want a stable tag for robustness when run on-device.
- `benchmark` build type inherits the **release** signingConfig (falls back to the debug keystore on CI/local without the real key).
- Touches `gradle/libs.versions.toml` + `app/build.gradle`; the sibling `feat/jankstats-debug-attribution` PR also edits these → minor merge friction, no logical conflict.

### Already tested

- `:macrobenchmark:assembleBenchmark`: green local (CI does not build the benchmark variant)
