### PR TITLE
test(perf): seed corpus + scroll benchmark across 3 list sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - `scripts/test-cleanup-merged-worktrees.sh` — a self-contained behaviour test (pure bash + git, no network/`gh`/extra tooling) covering the worktree-cleanup keep/remove decision across every case (merged-at-commit, name reuse, post-merge commits, open PR, `gh` failure, protected, dirty, dry-run). Runs in CI as the `worktree-cleanup-test` job
 - Macrobenchmark module measuring LandingActivity cold-start and sound-list scroll frame timing, to diagnose the entry-screen jank on lower-tier devices
 
+#### Changed
+- Scroll benchmark now seeds a controlled corpus and runs across three list sizes (5 / 50 / 200) so the sound-list frame timing exposes whether scroll jank scales with item count
+
 ## \[v2.1.0] - 2026-05-25
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ But, before going deeper I suggest you to take a look to the [opensource.guide](
 - [Continuous integration](#continuous-integration-)
 - [Sources of truth for platform decisions](#sources-of-truth-for-platform-decisions-)
 - [Testing](#testing-)
+- [Performance benchmarking](#performance-benchmarking-)
 - [Gradle upgrade](#gradle-upgrade)
 - [Firebase config file](#firebase-config-file-)
 - [Backup & restore testing](#backup--restore-testing-)
@@ -263,6 +264,23 @@ composeRule.awaitNode(hasSetTextAction()).performTextInput(name)
 ```
 
 Bare `waitForIdle()` / `waitUntil { onAllNodes(...).isNotEmpty() }` is still correct after deterministic actions (`performClick`, `pressBack`), before negative assertions (`assertCountEquals(0)`), before `.onFirst()` chains, and when the matcher would multi-match (the helpers' terminal `onNode*` throws on multi-match). The one-line rule also lives in `CLAUDE.md` § *Local UI test suite*.
+
+## Performance benchmarking 📈
+
+The `:macrobenchmark` module (`com.android.test`, AndroidX Macrobenchmark) measures LandingActivity's cold start and sound-list scroll on a **real device or emulator** — the on-device half of the entry-screen jank investigation (Firebase Performance flags the regimes; these reproduce them with numbers). It targets the app's release-like `benchmark` build type (non-debuggable, minified, profileable), so the numbers track what users get — not the debug build. Architecture + rationale (why synchronous atomic seeding, why not real files, relationship to ADR 0004): [ADR 0015](docs/adr/0015-macrobenchmark-seeding-architecture.md).
+
+### Run it
+
+```bash
+./gradlew :macrobenchmark:connectedBenchmarkAndroidTest
+```
+
+Needs a connected device/emulator (API 28+; metrics are most reliable on API 29+, where the build is profileable). Results land in `macrobenchmark/build/outputs/connected_android_test_additional_output/` (JSON + Perfetto traces), with a summary in the Gradle output. In Android Studio, run a benchmark class from the gutter. CircleCI does not run benchmarks (no device), same as the instrumented suite (§ *Local UI test suite*).
+
+### What it measures
+
+- **`StartupBenchmark`** — cold start, `CompilationMode.None` vs `DEFAULT` (brackets the AOT effect without a Baseline Profile yet).
+- **`ScrollBenchmark`** — `FrameTimingMetric` while flinging the sound list at **5 / 50 / 200** items, to expose whether scroll jank scales with list size (hypothesis H2). The list is seeded to exactly N synthetic sounds via a launch-intent extra handled by the benchmark build type's `CustomBuildTypeApplication` (a release-like override; never reaches release or debug). Seeding is synchronous and atomic so the measured scroll always traverses exactly N — see [ADR 0015](docs/adr/0015-macrobenchmark-seeding-architecture.md).
 
 ## Platform upgrades
 ### API Level

--- a/app/src/benchmark/java/com/github/barriosnahuel/vossosunboton/CustomBuildTypeApplication.kt
+++ b/app/src/benchmark/java/com/github/barriosnahuel/vossosunboton/CustomBuildTypeApplication.kt
@@ -30,10 +30,14 @@ internal abstract class CustomBuildTypeApplication : Application() {
 
     /**
      * Seeds exactly [count][SEED_COUNT_EXTRA] synthetic sounds (each stamped with a duration so rows
-     * render like a real audio). Done **synchronously** in `onCreate`, before the ViewModel's first
-     * load, so the measured scroll never sees a stale or half-seeded list — `replaceSyntheticCorpus`
-     * is a single atomic write, so this is cheap. Runs only in the benchmark build (release-like, no
-     * StrictMode); inert for the startup benchmark, which doesn't pass the extra.
+     * render like a real audio), via the single atomic `replaceSyntheticCorpus`.
+     *
+     * Runs **synchronously** (`runBlocking`) from `LandingActivity.onCreate`. The benchmark launch
+     * intent carries no data URI, so `handleDeeplink` early-returns without touching the lazy
+     * ViewModel — meaning the seed write completes before composition instantiates the VM and reads
+     * the store. The measured scroll therefore always sees exactly N, never a stale or half-seeded
+     * list. (A reactive `repo.sounds` collector in the VM is a second safety net if a read ever beat
+     * the write.) Benchmark build only (release-like, no StrictMode); inert for the startup benchmark.
      */
     fun seedDebugSoundsIfRequested(intent: Intent) {
         val count = intent.getIntExtra(SEED_COUNT_EXTRA, 0)

--- a/app/src/benchmark/java/com/github/barriosnahuel/vossosunboton/CustomBuildTypeApplication.kt
+++ b/app/src/benchmark/java/com/github/barriosnahuel/vossosunboton/CustomBuildTypeApplication.kt
@@ -19,7 +19,7 @@ import timber.log.Timber
  * benchmark to control the list size (the scroll-jank-vs-N question, H2).
  *
  * This overrides the release source set's `CustomBuildTypeApplication` for the benchmark variant;
- * the synthetic seeding never reaches release or debug.
+ * the synthetic seeding never reaches release or debug. Architecture + rationale: ADR 0015.
  */
 internal abstract class CustomBuildTypeApplication : Application() {
     override fun onCreate() {

--- a/app/src/benchmark/java/com/github/barriosnahuel/vossosunboton/CustomBuildTypeApplication.kt
+++ b/app/src/benchmark/java/com/github/barriosnahuel/vossosunboton/CustomBuildTypeApplication.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton
+
+import android.app.Application
+import android.content.Intent
+import com.github.barriosnahuel.vossosunboton.commons.android.error.ErrorTrackerTree
+import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.github.barriosnahuel.vossosunboton.model.data.manager.SoundsRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * Build-type specifics for the `benchmark` variant: release-like (no StrictMode, no debug seeding
+ * corpus), plus an on-demand synthetic-corpus seeder used **only** by the :macrobenchmark scroll
+ * benchmark to control the list size (the scroll-jank-vs-N question, H2).
+ *
+ * The `benchmark` variant overrides the release source set's [CustomBuildTypeApplication]; the
+ * synthetic seeding never reaches release or debug. Triggered via [SEED_COUNT_EXTRA] on the launch
+ * intent — kept in sync with the benchmark in :macrobenchmark.
+ */
+internal abstract class CustomBuildTypeApplication : Application() {
+    private val seedScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onCreate() {
+        Timber.plant(ErrorTrackerTree())
+
+        super.onCreate()
+    }
+
+    /**
+     * Seeds exactly [count][SEED_COUNT_EXTRA] synthetic sounds (idempotent: a no-op when the corpus
+     * already has that many, so repeated benchmark iterations don't re-pay the cost). Fire-and-forget;
+     * the benchmark waits for the list to render before measuring.
+     */
+    fun seedDebugSoundsIfRequested(intent: Intent) {
+        val count = intent.getIntExtra(SEED_COUNT_EXTRA, 0)
+        if (count <= 0) {
+            return
+        }
+        seedScope.launch { seedSyntheticSounds(count) }
+    }
+
+    private suspend fun seedSyntheticSounds(count: Int) {
+        val repo = SoundsRepository(this)
+        val existing = repo.sounds.first().filter { it.id.startsWith(SYNTHETIC_ID_PREFIX) }
+        if (existing.size == count) {
+            return
+        }
+        existing.forEach { repo.delete(it) }
+        repeat(count) { index ->
+            repo.save(Sound("$SYNTHETIC_ID_PREFIX$index", "$SYNTHETIC_NAME_PREFIX $index", "$SYNTHETIC_ID_PREFIX$index.dat"))
+        }
+    }
+}
+
+/** Launch-intent extra carrying how many synthetic sounds to seed. Keep in sync with :macrobenchmark. */
+const val SEED_COUNT_EXTRA = "benchmark_seed_count"
+
+/** Display-name prefix the benchmark waits on to confirm seeding rendered. Keep in sync with :macrobenchmark. */
+const val SYNTHETIC_NAME_PREFIX = "Benchmark sound"
+
+private const val SYNTHETIC_ID_PREFIX = "benchmark:"

--- a/app/src/benchmark/java/com/github/barriosnahuel/vossosunboton/CustomBuildTypeApplication.kt
+++ b/app/src/benchmark/java/com/github/barriosnahuel/vossosunboton/CustomBuildTypeApplication.kt
@@ -10,11 +10,7 @@ import android.content.Intent
 import com.github.barriosnahuel.vossosunboton.commons.android.error.ErrorTrackerTree
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.model.data.manager.SoundsRepository
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 
 /**
@@ -22,13 +18,10 @@ import timber.log.Timber
  * corpus), plus an on-demand synthetic-corpus seeder used **only** by the :macrobenchmark scroll
  * benchmark to control the list size (the scroll-jank-vs-N question, H2).
  *
- * The `benchmark` variant overrides the release source set's [CustomBuildTypeApplication]; the
- * synthetic seeding never reaches release or debug. Triggered via [SEED_COUNT_EXTRA] on the launch
- * intent — kept in sync with the benchmark in :macrobenchmark.
+ * This overrides the release source set's `CustomBuildTypeApplication` for the benchmark variant;
+ * the synthetic seeding never reaches release or debug.
  */
 internal abstract class CustomBuildTypeApplication : Application() {
-    private val seedScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-
     override fun onCreate() {
         Timber.plant(ErrorTrackerTree())
 
@@ -36,27 +29,24 @@ internal abstract class CustomBuildTypeApplication : Application() {
     }
 
     /**
-     * Seeds exactly [count][SEED_COUNT_EXTRA] synthetic sounds (idempotent: a no-op when the corpus
-     * already has that many, so repeated benchmark iterations don't re-pay the cost). Fire-and-forget;
-     * the benchmark waits for the list to render before measuring.
+     * Seeds exactly [count][SEED_COUNT_EXTRA] synthetic sounds (each stamped with a duration so rows
+     * render like a real audio). Done **synchronously** in `onCreate`, before the ViewModel's first
+     * load, so the measured scroll never sees a stale or half-seeded list — `replaceSyntheticCorpus`
+     * is a single atomic write, so this is cheap. Runs only in the benchmark build (release-like, no
+     * StrictMode); inert for the startup benchmark, which doesn't pass the extra.
      */
     fun seedDebugSoundsIfRequested(intent: Intent) {
         val count = intent.getIntExtra(SEED_COUNT_EXTRA, 0)
         if (count <= 0) {
             return
         }
-        seedScope.launch { seedSyntheticSounds(count) }
-    }
-
-    private suspend fun seedSyntheticSounds(count: Int) {
-        val repo = SoundsRepository(this)
-        val existing = repo.sounds.first().filter { it.id.startsWith(SYNTHETIC_ID_PREFIX) }
-        if (existing.size == count) {
-            return
-        }
-        existing.forEach { repo.delete(it) }
-        repeat(count) { index ->
-            repo.save(Sound("$SYNTHETIC_ID_PREFIX$index", "$SYNTHETIC_NAME_PREFIX $index", "$SYNTHETIC_ID_PREFIX$index.dat"))
+        val sounds =
+            (0 until count).map { index ->
+                Sound("$SYNTHETIC_ID_PREFIX$index", "$SYNTHETIC_NAME_PREFIX $index", "$SYNTHETIC_ID_PREFIX$index.dat")
+            }
+        runBlocking {
+            SoundsRepository(this@CustomBuildTypeApplication)
+                .replaceSyntheticCorpus(SYNTHETIC_ID_PREFIX, sounds, SYNTHETIC_DURATION_MS)
         }
     }
 }
@@ -68,3 +58,6 @@ const val SEED_COUNT_EXTRA = "benchmark_seed_count"
 const val SYNTHETIC_NAME_PREFIX = "Benchmark sound"
 
 private const val SYNTHETIC_ID_PREFIX = "benchmark:"
+
+/** A plausible audio length so each seeded row renders a duration like a real sound. */
+private const val SYNTHETIC_DURATION_MS = 3_000

--- a/docs/adr/0015-macrobenchmark-seeding-architecture.md
+++ b/docs/adr/0015-macrobenchmark-seeding-architecture.md
@@ -1,0 +1,101 @@
+# ADR 0015 — Macrobenchmark module + benchmark-variant synthetic corpus seeding
+
+- **Status:** Accepted
+- **Date:** 2026-06-07
+- **Supersedes:** —
+
+## Context
+
+The LandingActivity jank investigation needs **on-device, repeatable** measurement: Firebase
+Performance reports the entry screen at ~24.8% slow frames but cannot attribute jank to a code path
+or a phase. A `:macrobenchmark` module (`com.android.test`) was added (#1201) with a cold-start
+`StartupTimingMetric` and a scroll `FrameTimingMetric`, targeting the app's release-like `benchmark`
+build type so numbers match what users get.
+
+The scroll benchmark must answer hypothesis **H2 — does scroll jank scale with the number of
+sounds?** That needs a **controlled corpus of exactly N** (few / medium / many). Seeding N synthetic
+sounds into the release-like `benchmark` build ran into three non-obvious constraints (each caused a
+real bug caught in review before merge):
+
+1. **`SoundsRepository.delete()` is disk-coupled** — it removes a row from the store only if the
+   audio file was deleted from disk. File-less synthetic rows can never satisfy that, so a
+   per-item `save`/`delete` seeder can grow the corpus but never **shrink** it. With JUnit's
+   hash-based method order, a "5-item" run could then measure a stale 200-item list.
+2. **Incremental seeding pollutes the metric** — N separate `save()` writes emit N times, recomposing
+   the list mid-measurement and mixing seeding work into the frame timing.
+3. **The scroll render never reads the file** — the row renders from the *cached* duration map and the
+   `isBundled()` branch (a non-null `file` already routes to the "custom sound" path). So real audio
+   files do **not** make the render measurement more faithful; only a populated cached duration does.
+
+The debug source set already has a seeder (`DebugSoundSeeder`/`DebugSeedCorpus`), but it is not
+compiled into the `benchmark` build type, seeds a fixed corpus (not a parameterised N), and the debug
+build's `debuggable=true` would distort the numbers.
+
+## Decision drivers
+
+1. **Release-like numbers.** Measure on the non-debuggable, minified `benchmark` build, not debug.
+2. **Deterministic exact-N before measurement.** The measured scroll must traverse exactly N items,
+   with no stale or half-seeded state and no seeding work overlapping the metric.
+3. **Render fidelity.** Seeded rows must do the same per-frame work as a real sound (which is cached
+   duration + the custom-sound branch — not file I/O).
+4. **Minimal blast radius, zero production-data risk.** No `src/debug` changes (the screenshot corpus
+   depends on it); nothing reaches release; benchmark runs never touch `bomp-prod` Firebase.
+
+## Decision
+
+- The `:macrobenchmark` module targets the app's **`benchmark`** build type (`initWith release`,
+  non-debuggable, profileable via `app/src/benchmark/AndroidManifest.xml`). Firebase config for that
+  build type is a **scrubbed dummy** (`app/src/benchmark/google-services.json`) so benchmark runs
+  never report to `bomp-prod`.
+- Seeding is triggered by a launch-intent extra and handled by the **benchmark build type's**
+  `CustomBuildTypeApplication` (`app/src/benchmark/…`), which overrides the release source set's
+  no-op `seedDebugSoundsIfRequested` seam — reusing the same `(application as? …)` seam
+  `LandingActivity` already calls. The synthetic seeding therefore exists only in the benchmark APK.
+- Seeding runs **synchronously** (`runBlocking`) in `onCreate`. Because the benchmark launch intent
+  carries no data URI, `handleDeeplink` early-returns without instantiating the lazy ViewModel, so
+  the seed write completes before composition creates the VM and reads the store — the measured
+  scroll always sees exactly N.
+- Persistence goes through a new atomic primitive
+  **`SoundsRepository.replaceSyntheticCorpus(idPrefix, sounds, durationMs)`**: one `mutate` replaces
+  every id-prefixed row with exactly the given list, stamping each with `durationMs`. One write ⇒
+  exact-N (idempotent, shrinkable), a single recomposition (no metric pollution), and — since sounds
+  and their cached duration share one DataStore key — populated durations (render fidelity).
+
+**Rejected alternatives:**
+- *Real files for synthetic rows* — the scroll render never reads the file, so this adds I/O and
+  file-path coupling without improving fidelity; its only effect would be making the disk-coupled
+  `delete()` work, which the atomic primitive makes moot.
+- *Target the debug build* — `debuggable=true` distorts the numbers and forces a test-module variant
+  matrix (two target applicationIds).
+- *Per-item `save()` + `delete()`* — cannot shrink (constraint 1) and pollutes the metric
+  (constraint 2).
+
+## Consequences
+
+- The scroll benchmark answers H2 with release-like numbers across 5 / 50 / 200 items.
+- `SoundsRepository` gains one **public, benchmark-only** method. It is intentionally **not**
+  `@VisibleForTesting(otherwise = NONE)` (unlike `clearForTest` / `setRawJsonForTest`): the caller is
+  the benchmark build type in `:app`, a different module, where Lint would reject a test-restricted
+  symbol. The grep guard below replaces that compile-time fence.
+- `runBlocking` appears in `app/src/benchmark`. **This does not extend [ADR 0004](0004-datastore-sync-api-cache-prime.md).** ADR 0004's
+  "do not generalize" scoped exception governs **production** `runBlocking` (`src/main`, enforced by a
+  grep over `MAIN_DIRS`). `src/benchmark` is benchmark infra, never shipped, and outside that scope —
+  a separate context, not a new entry on 0004's allowlist.
+- The seed runs on the main thread in `onCreate`, but only in the `benchmark` build and only during
+  setup (unmeasured); the startup benchmark passes no extra, so it is unaffected.
+
+## Invariants
+
+Enforced by `scripts/check-adr-invariants.sh` (CircleCI job `adr-invariants`):
+
+- **`replaceSyntheticCorpus` is benchmark-only.** Its single declaration lives in
+  `model/src/main/.../SoundsRepository.kt` and its only call-site is `app/src/benchmark`; the model
+  unit test exercises it. Any reference from another production/debug/release source set fails the
+  check — that fence stands in for the `@VisibleForTesting` one Lint can't provide cross-module.
+
+## Cross-references
+
+- `CLAUDE.md` § *Project-specific overrides → Threading* and [ADR 0004](0004-datastore-sync-api-cache-prime.md) (the production `runBlocking` rule this is **not** an exception to).
+- `CONTRIBUTING.md` § *Performance benchmarking* (how to run).
+- AndroidX Macrobenchmark: https://developer.android.com/topic/performance/benchmarking/macrobenchmark-overview
+- PRs #1201 (module + startup/scroll harness) and #1203 (seeded scroll across list sizes).

--- a/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/BenchmarkTargets.kt
+++ b/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/BenchmarkTargets.kt
@@ -24,3 +24,25 @@ internal const val SCROLL_GESTURES = 3
  * on the system back-gesture edges. `displayWidth / 5` ≈ 20% per side.
  */
 internal const val GESTURE_MARGIN_DIVISOR = 5
+
+// --- Seeded scroll benchmark (controlled list size, hypothesis H2: does scroll jank scale with N?) ---
+
+/**
+ * Launch-intent extra carrying how many synthetic sounds to seed. Must match `SEED_COUNT_EXTRA` in
+ * the app's benchmark-variant `CustomBuildTypeApplication`.
+ */
+internal const val SEED_COUNT_EXTRA = "benchmark_seed_count"
+
+/**
+ * Display-name prefix of seeded sounds; the benchmark waits for one to render before scrolling. Must
+ * match `SYNTHETIC_NAME_PREFIX` in the app's benchmark-variant `CustomBuildTypeApplication`.
+ */
+internal const val SYNTHETIC_NAME_PREFIX = "Benchmark sound"
+
+/** Max wait for the seeded corpus to render before scrolling. Seeding is async + persisted. */
+internal const val SEED_RENDER_TIMEOUT_MS = 15_000L
+
+/** Three list sizes — few / medium / many — to expose whether scroll jank scales with item count. */
+internal const val SMALL_LIST = 5
+internal const val MEDIUM_LIST = 50
+internal const val LARGE_LIST = 200

--- a/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/ScrollBenchmark.kt
+++ b/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/ScrollBenchmark.kt
@@ -12,20 +12,22 @@ import androidx.benchmark.macro.junit4.MacrobenchmarkRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.Direction
+import androidx.test.uiautomator.Until
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
- * Frame timing while scrolling the sound list on LandingActivity.
+ * Frame timing while scrolling the sound list on LandingActivity, across three controlled list sizes
+ * (few / medium / many). Production data flags the interaction regime as the worst bucket (~39% slow
+ * frames + the only frozen frames during mid-length sessions); comparing the sizes shows whether that
+ * jank scales with item count (hypothesis H2 — per-item composition cost), separate from the startup
+ * regime measured by [StartupBenchmark].
  *
- * Targets the interaction regime of the jank investigation, which production data flags as the worst
- * bucket (~39% slow frames + the only frozen frames during mid-length sessions) — separate from the
- * startup regime measured by [StartupBenchmark].
- *
- * Scrolls via the first scrollable node ([By.scrollable]) so it needs no `testTag` wiring in the
- * app. If the soundboard later exposes a stable test tag, target it directly for robustness.
- * Numbers are read on-device by a human (plan Fase 3).
+ * Each run seeds a synthetic corpus of exactly N sounds via a launch-intent extra (handled by the
+ * benchmark-variant `CustomBuildTypeApplication`), then waits for the list to render before scrolling.
+ * Scrolls the first scrollable node ([By.scrollable]) so it needs no `testTag` in the app. Numbers are
+ * read on-device by a human (plan Fase 3).
  */
 @RunWith(AndroidJUnit4::class)
 class ScrollBenchmark {
@@ -33,17 +35,28 @@ class ScrollBenchmark {
     val benchmarkRule = MacrobenchmarkRule()
 
     @Test
-    fun scrollSoundsList() =
+    fun scrollSmallList() = measureScroll(SMALL_LIST)
+
+    @Test
+    fun scrollMediumList() = measureScroll(MEDIUM_LIST)
+
+    @Test
+    fun scrollLargeList() = measureScroll(LARGE_LIST)
+
+    private fun measureScroll(itemCount: Int) =
         benchmarkRule.measureRepeated(
             packageName = TARGET_PACKAGE,
             metrics = listOf(FrameTimingMetric()),
             iterations = DEFAULT_ITERATIONS,
             compilationMode = CompilationMode.DEFAULT,
-            // WARM recreates LandingActivity each iteration so the list starts at the top. Without it
-            // the singleTask activity is reused with the process alive, leaving the list bottomed-out
-            // after iteration 1 — later flings would hit an idle screen and fake good frame numbers.
+            // WARM recreates LandingActivity each iteration so the list starts at the top. Seeding is
+            // idempotent, so the relaunch re-sends the extra cheaply (no-op once N already seeded).
             startupMode = StartupMode.WARM,
-            setupBlock = { startActivityAndWait() },
+            setupBlock = {
+                startActivityAndWait { intent -> intent.putExtra(SEED_COUNT_EXTRA, itemCount) }
+                // Seeding is async + persisted; wait until a seeded item renders before measuring.
+                device.wait(Until.hasObject(By.textContains(SYNTHETIC_NAME_PREFIX)), SEED_RENDER_TIMEOUT_MS)
+            },
         ) {
             // Fail loudly: a missing scrollable node must not silently record idle frames as a result.
             val list =

--- a/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/ScrollBenchmark.kt
+++ b/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/ScrollBenchmark.kt
@@ -54,7 +54,8 @@ class ScrollBenchmark {
             startupMode = StartupMode.WARM,
             setupBlock = {
                 startActivityAndWait { intent -> intent.putExtra(SEED_COUNT_EXTRA, itemCount) }
-                // Seeding is async + persisted; wait until a seeded item renders before measuring.
+                // Seeding is synchronous (done in onCreate before the list loads), so once any seeded
+                // item renders the full exact-N corpus is present — safe to start measuring.
                 device.wait(Until.hasObject(By.textContains(SYNTHETIC_NAME_PREFIX)), SEED_RENDER_TIMEOUT_MS)
             },
         ) {

--- a/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepository.kt
+++ b/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepository.kt
@@ -84,6 +84,27 @@ class SoundsRepository(
         }
     }
 
+    /**
+     * Benchmark seeding primitive: in a single atomic write, replaces every sound whose id starts
+     * with [idPrefix] with [sounds], each stamped with [durationMs] (sounds and their cached duration
+     * share one DataStore key, so this populates both — rows render their duration like a real audio).
+     *
+     * One write means a deterministic exact-N state: idempotent, shrinkable, and a single
+     * recomposition (no per-item churn polluting frame timing). Non-prefixed sounds are untouched.
+     * The only caller is the `benchmark` build type's seeder; never used by production flows.
+     */
+    suspend fun replaceSyntheticCorpus(
+        idPrefix: String,
+        sounds: List<Sound>,
+        durationMs: Int,
+    ) {
+        sounds.forEach { validateName(it.name) }
+        mutate { current ->
+            current.filterNot { it.id.startsWith(idPrefix) } +
+                sounds.map { it.toStored(previous = null).copy(durationMs = durationMs) }
+        }
+    }
+
     suspend fun savePin(
         id: String,
         name: String,

--- a/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepository.kt
+++ b/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepository.kt
@@ -91,7 +91,8 @@ class SoundsRepository(
      *
      * One write means a deterministic exact-N state: idempotent, shrinkable, and a single
      * recomposition (no per-item churn polluting frame timing). Non-prefixed sounds are untouched.
-     * The only caller is the `benchmark` build type's seeder; never used by production flows.
+     * The only caller is the `benchmark` build type's seeder; never used by production flows — see
+     * ADR 0015, with the benchmark-only call-site enforced by `scripts/check-adr-invariants.sh`.
      */
     suspend fun replaceSyntheticCorpus(
         idPrefix: String,

--- a/model/src/test/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepositoryTest.kt
+++ b/model/src/test/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepositoryTest.kt
@@ -70,6 +70,8 @@ internal class SoundsRepositoryTest : AbstractRobolectricTest() {
 
             assertThat(repo.sounds.first().filter { it.id.startsWith("benchmark:") }).hasSize(1)
             assertThat(repo.sounds.first().any { it.id == "custom:keep" }).isTrue()
+            // Cached durations of the dropped rows are gone too (durations derive from the stored list).
+            assertThat(repo.durations.first().keys).containsExactly("benchmark:0")
         }
 
     @Test

--- a/model/src/test/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepositoryTest.kt
+++ b/model/src/test/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepositoryTest.kt
@@ -54,6 +54,25 @@ internal class SoundsRepositoryTest : AbstractRobolectricTest() {
         }
 
     @Test
+    fun `replaceSyntheticCorpus sets exactly N with duration, can shrink, and preserves other sounds`() =
+        runTest {
+            repo.save(testSound("keep", "keep.mp3"))
+
+            val three = (0 until 3).map { Sound("benchmark:$it", "Benchmark $it", "benchmark:$it.dat") }
+            repo.replaceSyntheticCorpus("benchmark:", three, durationMs = 1234)
+
+            assertThat(repo.sounds.first().filter { it.id.startsWith("benchmark:") }).hasSize(3)
+            assertThat(repo.durations.first()["benchmark:0"]).isEqualTo(1234)
+
+            // Shrink to 1 — what the disk-coupled delete() could not do for file-less synthetic rows.
+            val one = listOf(Sound("benchmark:0", "Benchmark 0", "benchmark:0.dat"))
+            repo.replaceSyntheticCorpus("benchmark:", one, durationMs = 1234)
+
+            assertThat(repo.sounds.first().filter { it.id.startsWith("benchmark:") }).hasSize(1)
+            assertThat(repo.sounds.first().any { it.id == "custom:keep" }).isTrue()
+        }
+
+    @Test
     fun `save then clear then sounds emits no custom sounds`() =
         runTest {
             repo.save(testSound("bell", "bell.mp3"))

--- a/scripts/check-adr-invariants.sh
+++ b/scripts/check-adr-invariants.sh
@@ -192,6 +192,26 @@ if [ "$CLAUDE_MD_SIZE" -gt "$CLAUDE_MD_FAIL" ]; then
 fi
 
 # ============================================================================
+# ADR 0015 — docs/adr/0015-macrobenchmark-seeding-architecture.md
+# Invariant: replaceSyntheticCorpus is a benchmark-only seeding primitive. It is
+# declared in SoundsRepository (model/src/main) and called only from the
+# benchmark build type (app/src/benchmark); the model unit test exercises it.
+# Any other production/debug/release reference fails — this grep stands in for
+# the @VisibleForTesting fence Lint can't provide for a cross-module caller.
+# ============================================================================
+rogue_seed=$(
+    grep -rln --include="*.kt" 'replaceSyntheticCorpus' \
+        app commons_android commons_file model 2>/dev/null \
+        | grep -vE '/src/benchmark/|/src/test/|/src/androidTest/' \
+        | grep -vE 'model/src/main/.*/SoundsRepository\.kt$' || true
+)
+if [ -n "$rogue_seed" ]; then
+    fail "ADR 0015 broken: replaceSyntheticCorpus referenced outside the benchmark seeder:
+$rogue_seed
+It is a benchmark-only primitive — only app/src/benchmark may call it (declared in SoundsRepository, tested in model/src/test). Supersede ADR 0015 or move the call site."
+fi
+
+# ============================================================================
 if [ "$errors" -gt 0 ]; then
     echo
     echo "$errors ADR invariant(s) violated. See messages above for which ADR(s) to revisit." >&2


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change.

Sharpens the scroll arm of the LandingActivity jank investigation. The scroll benchmark used to run on the default bundled list (too short to scroll meaningfully), so it couldn't answer the key question: does the entry-screen scroll jank — the worst bucket in production (~39% slow + the only frozen frames mid-session) — scale with the number of sounds? Now it measures the same scroll across **5 / 50 / 200** items, so the slope tells us whether per-item composition cost (H2) is the culprit.

### Technical detail

Follow-up to the `:macrobenchmark` module (#1201). Numbers are read on-device (plan Fase 3); CI only compiles + check + unit.

- **`ScrollBenchmark`** — three `@Test`s over a shared `measureScroll(n)`; each seeds N via a launch-intent extra, waits for a seeded item to render, measures `FrameTimingMetric`. `StartupMode.WARM` resets to top each iteration.
- **`SoundsRepository.replaceSyntheticCorpus(idPrefix, sounds, durationMs)`** — new atomic seeding primitive: one `mutate` sets exactly N prefixed sounds (shrinkable, idempotent) and stamps each with a duration (sounds + cached duration share one DataStore key) so rows render like a real audio. Unit-tested. Public but benchmark-only (model has no per-build-type variant); never called by production flows.
- **Seeding (A-lite)** — a benchmark-variant `app/src/benchmark/.../CustomBuildTypeApplication.kt` (release-like; overrides release's no-op) calls the primitive **synchronously** in `onCreate`, before the ViewModel loads, so the measured scroll never sees a stale/partial list. `runBlocking` is fine here: benchmark variant only (no StrictMode), and `src/benchmark` is outside the ADR-0004 grep scope.

### Code review tips

- **Earlier self-review caught two measurement-invalidating bugs, now fixed:** `delete()` is disk-coupled so file-less synthetic rows were never removed (corpus couldn't shrink; hash-ordered `@Test`s could make a small-N run measure a large list); and the first-item render gate let measurement start mid-seed. Both gone via the atomic primitive + synchronous pre-load seed.
- The scroll render never reads the file (cached duration + `isBundled()` branch), so synthetic rows need no real files; the stamped duration is what makes the row faithful.
- `SEED_COUNT_EXTRA` / `SYNTHETIC_NAME_PREFIX` duplicated across `:app` and `:macrobenchmark` (no shared module), kept in sync via comments.
- New public repo method is unguarded (no clean per-variant scoping in `:model`); documented as benchmark-only.

### Already tested

- `:macrobenchmark:assembleBenchmark`: green local (CI does not build the benchmark variant)
