### PR TITLE
feat(share): concrete audio MIME so shares play inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 ### Changed
 - The welcome audio no longer vanishes on its own after it plays — it stays in your list like any other audio, sorted by date, and the first time it finishes a warm note reminds you it's yours to keep or delete whenever you want; a one-time nudge shows you can swipe it away
+- Audios you share now arrive ready to play inline in more chat apps, instead of as a file the other person has to download first
 
 ### For nerds 🤓
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
@@ -108,7 +108,10 @@ private class ShareFeatureImpl : ShareFeature {
                     sound.rawRes,
                     surface,
                 )
-                ShareIntentOutcome.Success(buildShareIntent(resolution.value), surface)
+                // getType() reads the platform MIME map from disk, so build the intent on IO — otherwise the
+                // debug StrictMode disk-read guard crashes when prepareShareIntent resumes on the main thread.
+                val intent = withContext(Dispatchers.IO) { buildShareIntent(applicationContext, resolution.value) }
+                ShareIntentOutcome.Success(intent, surface)
             }
         }
     }
@@ -137,10 +140,15 @@ private class ShareFeatureImpl : ShareFeature {
         return null
     }
 
-    private fun buildShareIntent(contentUri: Uri): Intent =
+    private fun buildShareIntent(
+        context: Context,
+        contentUri: Uri,
+    ): Intent =
         Intent().apply {
             action = Intent.ACTION_SEND
-            type = "audio/*"
+            // A concrete MIME (e.g. audio/mpeg) makes some clients (Telegram) render the inline audio player
+            // instead of a generic "file to download"; `audio/*` stays only as the last-resort fallback.
+            type = resolveAudioMimeType(context.contentResolver.getType(contentUri), contentUri.lastPathSegment)
             putExtra(Intent.EXTRA_STREAM, contentUri)
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         }
@@ -228,4 +236,39 @@ private class ShareFeatureImpl : ShareFeature {
             val feedback: Int,
         ) : ShareOutcome<Nothing>()
     }
+}
+
+private const val WILDCARD_AUDIO_MIME = "audio/*"
+
+/**
+ * Audio MIME by lowercase file extension. Covers the formats Bomp actually stores: bundled `mp3`s plus
+ * whatever the user imports via the share sheet — notably WhatsApp voice notes (`opus`).
+ */
+private val AUDIO_MIME_BY_EXTENSION =
+    mapOf(
+        "mp3" to "audio/mpeg",
+        "opus" to "audio/opus",
+        "ogg" to "audio/ogg",
+        "m4a" to "audio/mp4",
+        "aac" to "audio/aac",
+        "wav" to "audio/wav",
+    )
+
+/**
+ * Resolves the MIME type to attach to the share intent. Prefers [resolverType] (from
+ * `ContentResolver.getType`) when it is a concrete audio type; otherwise derives it from [fileName]'s
+ * extension, falling back to the [WILDCARD_AUDIO_MIME] wildcard.
+ *
+ * The fallback is SDK-agnostic on purpose: `ContentResolver.getType` / `MimeTypeMap` can return `null` (or a
+ * non-audio `application/octet-stream`) for `.opus` on older API levels, so we never trust a non-audio answer.
+ */
+internal fun resolveAudioMimeType(
+    resolverType: String?,
+    fileName: String?,
+): String {
+    if (resolverType != null && resolverType.startsWith("audio/")) {
+        return resolverType
+    }
+    val extension = fileName?.substringAfterLast('.', "").orEmpty().lowercase()
+    return AUDIO_MIME_BY_EXTENSION[extension] ?: WILDCARD_AUDIO_MIME
 }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareMimeTypeTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareMimeTypeTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.share
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pure unit tests for [resolveAudioMimeType]. No Robolectric: the resolution is plain string logic, and
+ * the SDK-dependent gap it guards (`ContentResolver.getType` returning null/octet-stream for `.opus` on
+ * older API levels) is exercised here by feeding those exact inputs — deterministic at any SDK.
+ */
+internal class ShareMimeTypeTest {
+    @Test
+    fun `resolveAudioMimeType keeps the resolver type when it is a concrete audio type`() {
+        assertThat(resolveAudioMimeType("audio/mpeg", "any.mp3")).isEqualTo("audio/mpeg")
+    }
+
+    @Test
+    fun `resolveAudioMimeType falls back to the extension when the resolver returns null`() {
+        assertThat(resolveAudioMimeType(null, "voice-note.opus")).isEqualTo("audio/opus")
+    }
+
+    @Test
+    fun `resolveAudioMimeType ignores a non-audio resolver type and uses the extension`() {
+        assertThat(resolveAudioMimeType("application/octet-stream", "voice-note.opus")).isEqualTo("audio/opus")
+    }
+
+    @Test
+    fun `resolveAudioMimeType maps every supported audio extension`() {
+        assertThat(resolveAudioMimeType(null, "a.mp3")).isEqualTo("audio/mpeg")
+        assertThat(resolveAudioMimeType(null, "a.ogg")).isEqualTo("audio/ogg")
+        assertThat(resolveAudioMimeType(null, "a.m4a")).isEqualTo("audio/mp4")
+        assertThat(resolveAudioMimeType(null, "a.aac")).isEqualTo("audio/aac")
+        assertThat(resolveAudioMimeType(null, "a.wav")).isEqualTo("audio/wav")
+    }
+
+    @Test
+    fun `resolveAudioMimeType is case-insensitive on the extension`() {
+        assertThat(resolveAudioMimeType(null, "RECORDING.MP3")).isEqualTo("audio/mpeg")
+    }
+
+    @Test
+    fun `resolveAudioMimeType returns the wildcard for an unknown extension`() {
+        assertThat(resolveAudioMimeType(null, "mystery.xyz")).isEqualTo("audio/*")
+    }
+
+    @Test
+    fun `resolveAudioMimeType returns the wildcard when the name has no extension`() {
+        assertThat(resolveAudioMimeType(null, "noextension")).isEqualTo("audio/*")
+    }
+
+    @Test
+    fun `resolveAudioMimeType returns the wildcard when both inputs are null`() {
+        assertThat(resolveAudioMimeType(null, null)).isEqualTo("audio/*")
+    }
+}


### PR DESCRIPTION
### Summary
Audios you share land better on the other side.

1. You share an audio from Bomp to a chat app.

**before:** in some apps (e.g. Telegram) it arrives as a generic "file to download" — the other person taps it and gets asked to pick a player.
**after:** it arrives as an inline, tap-to-play audio (with title).

### Technical detail
- **`ShareFeature.buildShareIntent`** — sends the file's real MIME via `ContentResolver.getType(contentUri)` instead of the hardcoded wildcard `audio/*`.
- **`resolveAudioMimeType` helper** — when the resolver returns `null` or a non-audio type, derives the MIME from an extension map (`mp3, opus, ogg, m4a, aac, wav`), then falls back to `audio/*` last. Covers the known `.opus → null` gap on API 23–25.
- Manually verified on a Pixel 8: Telegram now renders the inline player + title; WhatsApp keeps inline playback (no regression).

### Code review tips
- **ADR 0013 interpretation:** the fallback branches on a `null` `getType()`, **not** on `Build.VERSION.SDK_INT` — so per ADR 0013 (multi-SDK matrices are only for real `SDK_INT` branches) I used a deterministic pure-helper test (`ShareMimeTypeTest`) instead of a `@Config(sdk=[…])` matrix. Flagging because the original task suggested a multi-SDK test.
- `audio/*` inside a KDoc would open a nested block comment (`/*`) — kept MIME literals out of doc comments on purpose.
- Functional change to the share flow → run `./scripts/run-instrumented-tests.sh` locally before merge (CircleCI doesn't run it).

### Already tested
- `./gradlew check -x test` + `./gradlew test` green locally after rebase onto develop; new `ShareMimeTypeTest` (8 cases) + existing `ShareFeatureTest` pass.
