### PR TITLE
feat(share): Share Bomp menu action with attributed link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 ## \[unreleased] (v2.2.0)
 
+### Added
+- A "Share Bomp" option in the top menu lets you recommend the app with a link, so the people you send it to can get it too
+
 ### Changed
 - The welcome audio no longer vanishes on its own after it plays — it stays in your list like any other audio, sorted by date, and the first time it finishes a warm note reminds you it's yours to keep or delete whenever you want; a one-time nudge shows you can swipe it away
 - Audios you share now arrive ready to play inline in more chat apps, instead of as a file the other person has to download first

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareAppIntent.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareAppIntent.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.share
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import com.github.barriosnahuel.vossosunboton.BuildConfig
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
+import com.github.barriosnahuel.vossosunboton.playstore.PlayStoreReferrer
+
+/**
+ * App-recommendation share: a plain `text/plain` message (no audio stream) inviting the recipient to get
+ * Bomp, with an attributed Play link. Unlike the audio caption, a text-only share keeps its body on every
+ * client (including WhatsApp), so this is the higher-reach acquisition surface.
+ */
+object ShareAppIntent {
+    /** Bare `ACTION_SEND` text intent recommending Bomp, carrying the Play referrer for [content]. */
+    fun build(
+        context: Context,
+        content: String,
+    ): Intent {
+        val playUrl = PlayStoreReferrer.playStoreUrl(BuildConfig.APPLICATION_ID, PlayStoreReferrer.MEDIUM_APP, content)
+        return Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, context.getString(R.string.app_share_app_invite, playUrl))
+        }
+    }
+
+    /** Wraps [build] in a chooser and launches it; records a non-fatal if nothing can handle the share. */
+    fun launch(
+        context: Context,
+        content: String,
+    ) {
+        try {
+            context.startActivity(
+                Intent.createChooser(build(context, content), context.getString(R.string.app_share_chooser_title)),
+            )
+        } catch (e: ActivityNotFoundException) {
+            Tracker.track(RuntimeException("No activity available to share the app", e))
+        }
+    }
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareAppIntent.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareAppIntent.kt
@@ -8,7 +8,6 @@ package com.github.barriosnahuel.vossosunboton.feature.share
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
-import com.github.barriosnahuel.vossosunboton.BuildConfig
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.playstore.PlayStoreReferrer
@@ -24,7 +23,7 @@ object ShareAppIntent {
         context: Context,
         content: String,
     ): Intent {
-        val playUrl = PlayStoreReferrer.playStoreUrl(BuildConfig.APPLICATION_ID, PlayStoreReferrer.MEDIUM_APP, content)
+        val playUrl = PlayStoreReferrer.playStoreUrl(PlayStoreReferrer.MEDIUM_APP, content)
         return Intent(Intent.ACTION_SEND).apply {
             type = "text/plain"
             putExtra(Intent.EXTRA_TEXT, context.getString(R.string.app_share_app_invite, playUrl))

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareFeature.kt
@@ -153,12 +153,7 @@ private class ShareFeatureImpl : ShareFeature {
             putExtra(Intent.EXTRA_STREAM, contentUri)
             // Soft install invite + attributed Play link. Clients that keep a caption on audio (Telegram)
             // show it; those that drop it (WhatsApp) just send the audio — no harm either way.
-            val playUrl =
-                PlayStoreReferrer.playStoreUrl(
-                    BuildConfig.APPLICATION_ID,
-                    PlayStoreReferrer.MEDIUM_AUDIO,
-                    PlayStoreReferrer.CONTENT_CAPTION,
-                )
+            val playUrl = PlayStoreReferrer.playStoreUrl(PlayStoreReferrer.MEDIUM_AUDIO, PlayStoreReferrer.CONTENT_CAPTION)
             putExtra(Intent.EXTRA_TEXT, context.getString(R.string.app_share_caption_invite, playUrl))
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/playstore/PlayStoreReferrer.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/playstore/PlayStoreReferrer.kt
@@ -32,15 +32,21 @@ object PlayStoreReferrer {
     private const val PLAY_STORE_DETAILS_URL = "https://play.google.com/store/apps/details"
 
     /**
-     * Play Store URL for [applicationId] with the install referrer for [medium] + [content]. The referrer
+     * The published Play Store package — a fixed external identity, intentionally NOT `BuildConfig.APPLICATION_ID`:
+     * debug/benchmark variants carry an `applicationIdSuffix` (e.g. `.debug`) that points the link at an app that
+     * doesn't exist on the Store. The listing is always this one id, in every build variant.
+     */
+    private const val STORE_PACKAGE_NAME = "com.github.barriosnahuel.vossosunboton"
+
+    /**
+     * Play Store URL for the published listing with the install referrer for [medium] + [content]. The referrer
      * value is URL-encoded (Play requires it encoded, ≤ 512 chars — this stays well under).
      */
     fun playStoreUrl(
-        applicationId: String,
         medium: String,
         content: String,
     ): String {
         val referrer = "utm_source=$SOURCE&utm_medium=$medium&utm_content=$content"
-        return "$PLAY_STORE_DETAILS_URL?id=$applicationId&referrer=${Uri.encode(referrer)}"
+        return "$PLAY_STORE_DETAILS_URL?id=$STORE_PACKAGE_NAME&referrer=${Uri.encode(referrer)}"
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -65,6 +65,7 @@ import com.github.barriosnahuel.vossosunboton.commons.android.analytics.Analytic
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
 import com.github.barriosnahuel.vossosunboton.feature.addbutton.findFragmentActivity
+import com.github.barriosnahuel.vossosunboton.feature.share.ShareAppIntent
 import com.github.barriosnahuel.vossosunboton.feature.share.ShareFeature
 import com.github.barriosnahuel.vossosunboton.feature.vault.requestUnlock
 import com.github.barriosnahuel.vossosunboton.feature.vault.security.BiometricGate
@@ -72,6 +73,7 @@ import com.github.barriosnahuel.vossosunboton.feature.vault.security.BiometricGa
 import com.github.barriosnahuel.vossosunboton.feature.vault.security.VaultSessionState
 import com.github.barriosnahuel.vossosunboton.feature.welcome.isWelcomeSticker
 import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.github.barriosnahuel.vossosunboton.playstore.PlayStoreReferrer
 import com.github.barriosnahuel.vossosunboton.ui.AppIcons
 import com.github.barriosnahuel.vossosunboton.ui.about.AboutScreen
 import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
@@ -560,6 +562,7 @@ private fun AppTopBar(
     onManageCollectionsClick: () -> Unit,
 ) {
     var isMenuExpanded by remember { mutableStateOf(false) }
+    val context = LocalContext.current
     TopAppBar(
         title = { Text(stringResource(R.string.app_name)) },
         actions = {
@@ -585,6 +588,13 @@ private fun AppTopBar(
                     onClick = {
                         isMenuExpanded = false
                         onAboutClick()
+                    },
+                )
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.app_share_app_menu_item)) },
+                    onClick = {
+                        isMenuExpanded = false
+                        ShareAppIntent.launch(context, PlayStoreReferrer.CONTENT_MENU)
                     },
                 )
             }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -3,6 +3,8 @@
 
     <string name="app_share_chooser_title">Compartir vía</string>
     <string name="app_share_caption_invite">Tenelo a un toque cuando quieras escucharlo.\nTu colección de voces, en Bomp 👉 %1$s</string>
+    <string name="app_share_app_menu_item">Compartí Bomp</string>
+    <string name="app_share_app_invite">Mis voces favoritas, siempre a un toque. Esto es Bomp 👉 %1$s</string>
     <string name="app_share_feedback_unshareable">No se pudo compartir este Bomp. Nahu ya se enteró y lo va a investigar.</string>
     <string name="app_share_feedback_no_app_for_audio">No tenés una app para compartir audios. Probá instalando una.</string>
     <string name="app_share_feedback_copy_failed">No pude preparar este Bomp para compartir. Liberá espacio y probá de nuevo — Nahu ya se enteró y lo va a investigar.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,8 @@
 
     <string name="app_share_chooser_title">Share vía</string>
     <string name="app_share_caption_invite">Have it one tap away whenever you want to hear it.\nYour collection of voices, on Bomp 👉 %1$s</string>
+    <string name="app_share_app_menu_item">Share Bomp</string>
+    <string name="app_share_app_invite">My favorite voices, always one tap away. This is Bomp 👉 %1$s</string>
     <string name="app_share_feedback_unshareable">Couldn\'t share this Bomp. Nahu\'s already on it.</string>
     <string name="app_share_feedback_no_app_for_audio">No app on your device can share audio. Try installing one.</string>
     <string name="app_share_feedback_copy_failed">Couldn\'t prepare this Bomp for sharing. Free up some space and try again — Nahu\'s already looking into it.</string>

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareAppIntentTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareAppIntentTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.share
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
+import com.github.barriosnahuel.vossosunboton.playstore.PlayStoreReferrer
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.spyk
+import io.mockk.verify
+import org.junit.Test
+
+internal class ShareAppIntentTest : AbstractRobolectricTest() {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun `build returns an ACTION_SEND text intent`() {
+        val intent = ShareAppIntent.build(context, PlayStoreReferrer.CONTENT_MENU)
+
+        assertThat(intent.action).isEqualTo(Intent.ACTION_SEND)
+        assertThat(intent.type).isEqualTo("text/plain")
+    }
+
+    @Test
+    fun `build carries the invite text with no audio stream`() {
+        val intent = ShareAppIntent.build(context, PlayStoreReferrer.CONTENT_MENU)
+
+        assertThat(intent.getStringExtra(Intent.EXTRA_TEXT)).contains("Bomp")
+        assertThat(intent.extras?.containsKey(Intent.EXTRA_STREAM)).isFalse()
+    }
+
+    @Test
+    fun `build carries the app menu referrer`() {
+        val intent = ShareAppIntent.build(context, PlayStoreReferrer.CONTENT_MENU)
+
+        assertThat(intent.getStringExtra(Intent.EXTRA_TEXT))
+            .contains("utm_source%3Dbomp%26utm_medium%3Dapp%26utm_content%3Dmenu")
+    }
+
+    @Test
+    fun `build carries the about referrer when shared from About`() {
+        val intent = ShareAppIntent.build(context, PlayStoreReferrer.CONTENT_ABOUT)
+
+        assertThat(intent.getStringExtra(Intent.EXTRA_TEXT))
+            .contains("utm_source%3Dbomp%26utm_medium%3Dapp%26utm_content%3Dabout")
+    }
+
+    @Test
+    fun `launch records a non-fatal when no activity can handle the share`() {
+        val mockedContext = spyk(ApplicationProvider.getApplicationContext<Context>())
+        every { mockedContext.startActivity(any()) } throws ActivityNotFoundException("no app handles text share")
+
+        ShareAppIntent.launch(mockedContext, PlayStoreReferrer.CONTENT_MENU)
+
+        verify(exactly = 1) { Tracker.track(any()) }
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareAppIntentTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/share/ShareAppIntentTest.kt
@@ -46,6 +46,16 @@ internal class ShareAppIntentTest : AbstractRobolectricTest() {
     }
 
     @Test
+    fun `build links to the published listing, not the debug variant id`() {
+        val intent = ShareAppIntent.build(context, PlayStoreReferrer.CONTENT_MENU)
+
+        val text = intent.getStringExtra(Intent.EXTRA_TEXT)
+        assertThat(text).contains("id=com.github.barriosnahuel.vossosunboton&")
+        // This test runs against the debug variant; the link must never carry its `.debug` applicationIdSuffix.
+        assertThat(text).doesNotContain(".debug")
+    }
+
+    @Test
     fun `build carries the about referrer when shared from About`() {
         val intent = ShareAppIntent.build(context, PlayStoreReferrer.CONTENT_ABOUT)
 

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/playstore/PlayStoreReferrerTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/playstore/PlayStoreReferrerTest.kt
@@ -11,25 +11,26 @@ import org.junit.Test
 
 /** Robolectric because [PlayStoreReferrer] uses `android.net.Uri.encode`. */
 internal class PlayStoreReferrerTest : AbstractRobolectricTest() {
-    private val applicationId = "com.github.barriosnahuel.vossosunboton"
-
     @Test
-    fun `playStoreUrl points at the app details page for the given application id`() {
-        val url = PlayStoreReferrer.playStoreUrl(applicationId, PlayStoreReferrer.MEDIUM_AUDIO, PlayStoreReferrer.CONTENT_CAPTION)
+    fun `playStoreUrl points at the published listing, never the build variant id`() {
+        val url = PlayStoreReferrer.playStoreUrl(PlayStoreReferrer.MEDIUM_AUDIO, PlayStoreReferrer.CONTENT_CAPTION)
 
-        assertThat(url).startsWith("https://play.google.com/store/apps/details?id=$applicationId&referrer=")
+        assertThat(url).startsWith("https://play.google.com/store/apps/details?id=com.github.barriosnahuel.vossosunboton&referrer=")
+        // Regression guard: debug/benchmark variants must not leak their applicationIdSuffix (e.g. `.debug`)
+        // into the Store link — that would point at an app that doesn't exist on the Play Store.
+        assertThat(url).doesNotContain(".debug")
     }
 
     @Test
     fun `playStoreUrl encodes the audio caption referrer`() {
-        val url = PlayStoreReferrer.playStoreUrl(applicationId, PlayStoreReferrer.MEDIUM_AUDIO, PlayStoreReferrer.CONTENT_CAPTION)
+        val url = PlayStoreReferrer.playStoreUrl(PlayStoreReferrer.MEDIUM_AUDIO, PlayStoreReferrer.CONTENT_CAPTION)
 
         assertThat(url).contains("referrer=utm_source%3Dbomp%26utm_medium%3Daudio%26utm_content%3Dcaption")
     }
 
     @Test
     fun `playStoreUrl encodes the app menu referrer`() {
-        val url = PlayStoreReferrer.playStoreUrl(applicationId, PlayStoreReferrer.MEDIUM_APP, PlayStoreReferrer.CONTENT_MENU)
+        val url = PlayStoreReferrer.playStoreUrl(PlayStoreReferrer.MEDIUM_APP, PlayStoreReferrer.CONTENT_MENU)
 
         assertThat(url).contains("referrer=utm_source%3Dbomp%26utm_medium%3Dapp%26utm_content%3Dmenu")
     }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
@@ -121,6 +122,17 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
         composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithContentDescription("Search").assertIsDisplayed()
+    }
+
+    @Test
+    fun `overflow menu offers the share-app action`() {
+        val viewModel = givenAViewModel()
+
+        composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithContentDescription("More options").performClick()
+        composeTestRule.onNodeWithText("Share Bomp").assertIsDisplayed()
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
### Summary
You can now recommend Bomp straight from the app.

1. Open the top-right overflow menu.
2. Tap **Compartí Bomp**.
3. Pick a chat app and send.

**before:** there was no in-app way to pass the app along; the only acquisition path was sharing an audio (whose caption WhatsApp silently drops).
**after:** a deliberate "Share Bomp" action sends a text + link that **survives WhatsApp** (text-only shares aren't dropped) — the higher-reach acquisition surface in es-AR.

### Technical detail
- **`LandingScreen` overflow menu** — new last item firing a `text/plain` `ACTION_SEND` (no audio stream).
- **`ShareAppIntent`** (new) — `build()` (testable: action/type/referrer) + `launch()` (chooser + `ActivityNotFoundException → Tracker.track`). Reuses `PlayStoreReferrer` with `utm_medium=app`, `utm_content=menu`.
- Strings via `stringResource` (en + es-AR), DNA-aligned ("Compartí Bomp", heart-first, no "compartí con amigos").

### Code review tips
- **Interpretation:** menu item is **text-only**, matching its icon-less siblings (Manage collections, About) — consistency over the task's "add an icon" suggestion; a leading icon next to a text label would be decorative anyway (`contentDescription = null`).
- **About placement deferred:** `PlayStoreReferrer.CONTENT_ABOUT` exists and is unit-tested, but the About-screen entry is **not** wired yet (kept this PR menu-only / low-risk). Easy follow-up.
- Stacked on #1207 (reuses `PlayStoreReferrer`). Review/merge T1 → T2 → T3.
- Functional UI change → run `./scripts/run-instrumented-tests.sh` locally before merge (CircleCI doesn't run it).

### Already tested
- `./gradlew check -x test` + `./gradlew test` green locally after rebase; new `ShareAppIntentTest` (incl. the no-activity error path) + a `LandingScreenTest` menu smoke test pass.
