### PR TITLE
test(perf): on-device macrobenchmark harness (GMD + conditioning + benchmark-build fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - `scripts/test-cleanup-merged-worktrees.sh` — a self-contained behaviour test (pure bash + git, no network/`gh`/extra tooling) covering the worktree-cleanup keep/remove decision across every case (merged-at-commit, name reuse, post-merge commits, open PR, `gh` failure, protected, dirty, dry-run). Runs in CI as the `worktree-cleanup-test` job
 - Macrobenchmark module measuring LandingActivity cold-start and sound-list scroll frame timing, to diagnose the entry-screen jank on lower-tier devices
 - A committed `PreToolUse` hook (`.claude/hooks/pre-check-ktlint-format.sh`) runs `ktlintFormat` before any Gradle check command in Claude Code sessions, so checks run on already-formatted sources and never fail on an auto-fixable ktlint violation; non-check commands no-op in microseconds
+- Gradle Managed Devices (API 34 / 30 / 33) for the macrobenchmark module, so the jank matrix and the fix re-validation run reproducible in-repo emulators
 
 #### Changed
 - Scroll benchmark now seeds a controlled corpus and runs across three list sizes (5 / 50 / 200) so the sound-list frame timing exposes whether scroll jank scales with item count

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Gradle Managed Devices (API 34 / 30 / 33) for the macrobenchmark module, so the jank matrix and the fix re-validation run reproducible in-repo emulators
 
 #### Changed
-- Scroll benchmark now seeds a controlled corpus and runs across three list sizes (5 / 50 / 200) so the sound-list frame timing exposes whether scroll jank scales with item count
+- Scroll benchmark now seeds a controlled corpus and runs across three list sizes (20 / 50 / 200) so the sound-list frame timing exposes whether scroll jank scales with item count
 
 ## \[v2.1.0] - 2026-05-25
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,6 +35,10 @@ android {
 
     sourceSets {
         androidTest.assets.srcDirs += 'src/androidTest/assets'
+        // The benchmark build type runs under the debug applicationId (`.debug`), so it should look
+        // like the debug app — reuse the debug grey launcher icon. The production green icon on a
+        // throwaway benchmark build is misleading.
+        benchmark.res.srcDirs += 'src/debug/res'
     }
 
     resourcePrefix = 'app_'
@@ -95,12 +99,22 @@ android {
 
         // Release-like build target consumed only by the :macrobenchmark module (non-debuggable +
         // minified so startup/frame numbers match what users get). Made profileable via
-        // src/benchmark/AndroidManifest.xml. Firebase config is a scrubbed dummy
-        // (src/benchmark/google-services.json) so benchmark runs never report to bomp-prod.
+        // src/benchmark/AndroidManifest.xml.
         benchmark {
             initWith release
             matchingFallbacks = ['release']
             debuggable false
+            // Reuse the debug app identity (`.debug`) + debug signing: the benchmark then installs
+            // over the dev debug app (same key, an update — not a signature clash) and resolves the
+            // real debug Firebase config (bomp-debug, valid key → no FirebaseSessions fatal; its
+            // init is also measured representatively). google-services for this build type is the
+            // debug one, swapped in by scripts/setup-worktree.sh (skip-worktree).
+            applicationIdSuffix ".debug"
+            signingConfig signingConfigs.debug
+            // Don't upload the R8 mapping to Firebase (minified benchmark would 400 on the dummy).
+            firebaseCrashlytics {
+                mappingFileUploadEnabled false
+            }
         }
     }
 

--- a/app/src/benchmark/google-services.json
+++ b/app/src/benchmark/google-services.json
@@ -13,7 +13,7 @@
       },
       "api_key": [
         {
-          "current_key": "AIzaSyDUMMYbenchmarkKEYnotARealKEY0000000"
+          "current_key": "a-really-dummy-value"
         }
       ]
     }

--- a/app/src/benchmark/google-services.json
+++ b/app/src/benchmark/google-services.json
@@ -1,19 +1,19 @@
 {
   "project_info": {
-    "project_number": "383291838647",
-    "project_id": "bomp-prod"
+    "project_number": "947596384148",
+    "project_id": "bomp-debug"
   },
   "client": [
     {
       "client_info": {
         "mobilesdk_app_id": "1:999999999:android:dummydummydummy",
         "android_client_info": {
-          "package_name": "com.github.barriosnahuel.vossosunboton"
+          "package_name": "com.github.barriosnahuel.vossosunboton.debug"
         }
       },
       "api_key": [
         {
-          "current_key": "a-really-dummy-value"
+          "current_key": "AIzaSyDUMMYbenchmarkKEYnotARealKEY0000000"
         }
       ]
     }

--- a/macrobenchmark/build.gradle
+++ b/macrobenchmark/build.gradle
@@ -29,6 +29,34 @@ android {
         }
     }
 
+    // Gradle Managed Devices: reproducible emulators declared in-repo (ADR 0015), so the jank
+    // matrix and the Fase-5 fix re-validation run the same devices everywhere. `google` source
+    // brings GMS, so MainApplication's Firebase/Play init is measured as on a real device (`aosp`
+    // would under-measure startup). GMD auto-downloads the system images. Numbers are directional —
+    // emulators run on the host CPU; run benchmarks with `androidx.benchmark.suppressErrors=EMULATOR`.
+    // The authoritative low-tier numbers come from a physical device.
+    testOptions {
+        managedDevices {
+            localDevices {
+                api34pixel6 {
+                    device = "Pixel 6"
+                    apiLevel = 34
+                    systemImageSource = "google"
+                }
+                api30pixel4 {
+                    device = "Pixel 4"
+                    apiLevel = 30
+                    systemImageSource = "google"
+                }
+                api33pixel4a {
+                    device = "Pixel 4a"
+                    apiLevel = 33
+                    systemImageSource = "google"
+                }
+            }
+        }
+    }
+
     targetProjectPath = ':app'
     experimentalProperties["android.experimental.self-instrumenting"] = true
 }

--- a/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/BenchmarkTargets.kt
+++ b/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/BenchmarkTargets.kt
@@ -19,6 +19,9 @@ internal const val DEFAULT_ITERATIONS = 5
 /** Number of fling gestures per scroll-benchmark iteration. */
 internal const val SCROLL_GESTURES = 3
 
+/** Max backward swipes to reset the list to the top between iterations (overshoots [SCROLL_GESTURES]). */
+internal const val SCROLL_RESET_SWIPES = 12
+
 /** Swipe dead-zone (fraction per edge) so UiScrollable flings clear the system back-gesture areas. */
 internal const val SWIPE_DEAD_ZONE = 0.2
 

--- a/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/BenchmarkTargets.kt
+++ b/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/BenchmarkTargets.kt
@@ -8,10 +8,10 @@ package com.github.barriosnahuel.vossosunboton.macrobenchmark
 /**
  * Shared constants for the LandingActivity performance benchmarks.
  *
- * The `benchmark` build type inherits the release applicationId (no `.debug` suffix), so the target
- * package is the release one.
+ * The `benchmark` build type carries `applicationIdSuffix ".debug"` (reuses the debug app identity +
+ * the real debug Firebase config), so the target package has the `.debug` suffix.
  */
-internal const val TARGET_PACKAGE = "com.github.barriosnahuel.vossosunboton"
+internal const val TARGET_PACKAGE = "com.github.barriosnahuel.vossosunboton.debug"
 
 /** Iterations per benchmark. Kept modest so a full local run stays under a few minutes. */
 internal const val DEFAULT_ITERATIONS = 5
@@ -19,11 +19,8 @@ internal const val DEFAULT_ITERATIONS = 5
 /** Number of fling gestures per scroll-benchmark iteration. */
 internal const val SCROLL_GESTURES = 3
 
-/**
- * Fraction of the screen width reserved as a gesture margin so flings start inside the list and not
- * on the system back-gesture edges. `displayWidth / 5` ≈ 20% per side.
- */
-internal const val GESTURE_MARGIN_DIVISOR = 5
+/** Swipe dead-zone (fraction per edge) so UiScrollable flings clear the system back-gesture areas. */
+internal const val SWIPE_DEAD_ZONE = 0.2
 
 // --- Seeded scroll benchmark (controlled list size, hypothesis H2: does scroll jank scale with N?) ---
 
@@ -42,7 +39,11 @@ internal const val SYNTHETIC_NAME_PREFIX = "Benchmark sound"
 /** Max wait for the seeded corpus to render before scrolling. Seeding is async + persisted. */
 internal const val SEED_RENDER_TIMEOUT_MS = 15_000L
 
-/** Three list sizes — few / medium / many — to expose whether scroll jank scales with item count. */
-internal const val SMALL_LIST = 5
+/**
+ * Three list sizes — few / medium / many — to expose whether scroll jank scales with item count.
+ * "Few" is 20 (not a handful): a list that fits on screen has no scrollable node, so the smallest
+ * size must still overflow one screen to be scrollable.
+ */
+internal const val SMALL_LIST = 20
 internal const val MEDIUM_LIST = 50
 internal const val LARGE_LIST = 200

--- a/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/ScrollBenchmark.kt
+++ b/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/ScrollBenchmark.kt
@@ -11,7 +11,8 @@ import androidx.benchmark.macro.StartupMode
 import androidx.benchmark.macro.junit4.MacrobenchmarkRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.uiautomator.By
-import androidx.test.uiautomator.Direction
+import androidx.test.uiautomator.UiScrollable
+import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import org.junit.Rule
 import org.junit.Test
@@ -25,9 +26,10 @@ import org.junit.runner.RunWith
  * regime measured by [StartupBenchmark].
  *
  * Each run seeds a synthetic corpus of exactly N sounds via a launch-intent extra (handled by the
- * benchmark-variant `CustomBuildTypeApplication`), then waits for the list to render before scrolling.
- * Scrolls the first scrollable node ([By.scrollable]) so it needs no `testTag` in the app. Numbers are
- * read on-device by a human (plan Fase 3).
+ * benchmark-variant `CustomBuildTypeApplication`), then scrolls the list. Uses [UiScrollable] (not
+ * `findObject` + `fling`): it re-resolves the scrollable node on every gesture, so a recomposition
+ * between gestures can't invalidate a cached handle (the StaleObjectException that sank the earlier
+ * approach). Numbers are read on-device by a human (plan Fase 3).
  */
 @RunWith(AndroidJUnit4::class)
 class ScrollBenchmark {
@@ -59,15 +61,15 @@ class ScrollBenchmark {
                 device.wait(Until.hasObject(By.textContains(SYNTHETIC_NAME_PREFIX)), SEED_RENDER_TIMEOUT_MS)
             },
         ) {
-            // Fail loudly: a missing scrollable node must not silently record idle frames as a result.
-            val list =
-                requireNotNull(device.findObject(By.scrollable(true))) {
-                    "No scrollable node on LandingActivity — wire a stable testTag if this fails on-device."
-                }
-            list.setGestureMargin(device.displayWidth / GESTURE_MARGIN_DIVISOR)
+            val list = UiScrollable(UiSelector().scrollable(true))
+            // Fail loudly if the list never appears; idle frames must not pass as a result.
+            check(list.waitForExists(SEED_RENDER_TIMEOUT_MS)) {
+                "No scrollable sound list on LandingActivity within $SEED_RENDER_TIMEOUT_MS ms."
+            }
+            // Keep flings clear of the system back-gesture edges.
+            list.setSwipeDeadZonePercentage(SWIPE_DEAD_ZONE)
             repeat(SCROLL_GESTURES) {
-                list.fling(Direction.DOWN)
-                device.waitForIdle()
+                list.flingForward()
             }
         }
 }

--- a/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/ScrollBenchmark.kt
+++ b/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/ScrollBenchmark.kt
@@ -51,14 +51,22 @@ class ScrollBenchmark {
             metrics = listOf(FrameTimingMetric()),
             iterations = DEFAULT_ITERATIONS,
             compilationMode = CompilationMode.DEFAULT,
-            // WARM recreates LandingActivity each iteration so the list starts at the top. Seeding is
-            // idempotent, so the relaunch re-sends the extra cheaply (no-op once N already seeded).
+            // WARM keeps the process alive and relaunches LandingActivity each iteration. It's a
+            // singleTask Activity, so the relaunch re-enters the live instance via onNewIntent (no
+            // recreate) and the LazyColumn keeps its scroll position — setupBlock resets it to the top
+            // below. Seeding is idempotent, so the relaunch re-sends the extra cheaply (no-op once seeded).
             startupMode = StartupMode.WARM,
             setupBlock = {
                 startActivityAndWait { intent -> intent.putExtra(SEED_COUNT_EXTRA, itemCount) }
-                // Seeding is synchronous (done in onCreate before the list loads), so once any seeded
-                // item renders the full exact-N corpus is present — safe to start measuring.
-                device.wait(Until.hasObject(By.textContains(SYNTHETIC_NAME_PREFIX)), SEED_RENDER_TIMEOUT_MS)
+                // Seeding is synchronous (done in onCreate before the list loads), so once a seeded item
+                // renders the full exact-N corpus is present. Fail loudly if it never does, rather than
+                // measuring an empty/wrong list.
+                check(device.wait(Until.hasObject(By.textContains(SYNTHETIC_NAME_PREFIX)), SEED_RENDER_TIMEOUT_MS)) {
+                    "Seeded corpus ($SYNTHETIC_NAME_PREFIX) didn't render within $SEED_RENDER_TIMEOUT_MS ms."
+                }
+                // Reset to the top so every iteration measures the same top-to-bottom fling, not the
+                // already-scrolled list left by the previous iteration (singleTask, see above).
+                UiScrollable(UiSelector().scrollable(true)).scrollToBeginning(SCROLL_RESET_SWIPES)
             },
         ) {
             val list = UiScrollable(UiSelector().scrollable(true))
@@ -70,6 +78,9 @@ class ScrollBenchmark {
             list.setSwipeDeadZonePercentage(SWIPE_DEAD_ZONE)
             repeat(SCROLL_GESTURES) {
                 list.flingForward()
+                // Settle after each fling so the deceleration frames (often the jankiest) land inside
+                // the measured window and consecutive flings don't cut each other short.
+                device.waitForIdle()
             }
         }
 }

--- a/scripts/measure-scroll-jank.sh
+++ b/scripts/measure-scroll-jank.sh
@@ -44,15 +44,34 @@ avdmanager list avd 2>/dev/null | grep -q "Name: $AVD" || {
 }
 
 echo "▶ Launching $AVD (windowed, -gpu host, -cores $CORES, -memory $MEMORY)…"
+# Snapshot existing emulators so we can identify (and only ever kill) the one WE launch.
+before="$(adb devices | awk '/^emulator-/{print $1}')"
 nohup emulator -avd "$AVD" -gpu host -cores "$CORES" -memory "$MEMORY" \
   -no-snapshot -no-boot-anim -no-audio > "$OUT/emulator.log" 2>&1 &
 EMU_PID=$!
-trap 'adb -s "${S:-}" emu kill >/dev/null 2>&1 || kill "$EMU_PID" 2>/dev/null || true' EXIT
+trap 'if [ -n "${S:-}" ]; then adb -s "$S" emu kill >/dev/null 2>&1 || true; fi; kill "$EMU_PID" 2>/dev/null || true' EXIT
 
-until adb devices | grep -q '^emulator-'; do sleep 3; done
-S=$(adb devices | awk '/^emulator-/{print $1; exit}')
+# Resolve the serial of the emulator this script launched (not a pre-existing one), with a timeout
+# and a process-alive check so a boot failure fails fast instead of hanging forever.
+S=""
+for _ in $(seq 1 90); do
+  for d in $(adb devices | awk '/^emulator-/{print $1}'); do
+    case " $before " in *" $d "*) : ;; *) S="$d"; break ;; esac
+  done
+  [ -n "$S" ] && break
+  kill -0 "$EMU_PID" 2>/dev/null || { echo "✘ emulator exited during launch — see $OUT/emulator.log" >&2; exit 1; }
+  sleep 3
+done
+[ -n "$S" ] || { echo "✘ launched emulator never registered (timeout) — see $OUT/emulator.log" >&2; exit 1; }
+
 echo "▶ $S booting…"
-until [ "$(adb -s "$S" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" = "1" ]; do sleep 3; done
+for _ in $(seq 1 90); do
+  [ "$(adb -s "$S" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" = "1" ] && break
+  kill -0 "$EMU_PID" 2>/dev/null || { echo "✘ emulator died during boot — see $OUT/emulator.log" >&2; exit 1; }
+  sleep 3
+done
+[ "$(adb -s "$S" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" = "1" ] \
+  || { echo "✘ emulator boot timed out — see $OUT/emulator.log" >&2; exit 1; }
 adb -s "$S" shell input keyevent KEYCODE_WAKEUP >/dev/null 2>&1
 adb -s "$S" install -r "$APK" >/dev/null
 echo "▶ Installed. Measuring sizes: ${SIZES[*]}"
@@ -64,10 +83,12 @@ for N in "${SIZES[@]}"; do
   adb -s "$S" shell am start -n "$ACT" --ei benchmark_seed_count "$N" >/dev/null 2>&1
   ok=0
   for _ in $(seq 1 40); do
-    pid=$(adb -s "$S" shell pidof "$PKG" 2>/dev/null | tr -d '\r')
-    rendered=$(adb -s "$S" exec-out uiautomator dump /sdcard/u.xml >/dev/null 2>&1; \
-               adb -s "$S" shell cat /sdcard/u.xml 2>/dev/null | grep -c 'Benchmark sound')
-    [ -n "$pid" ] && [ "$rendered" -ge 1 ] && { ok=1; break; }
+    pid=$(adb -s "$S" shell pidof "$PKG" 2>/dev/null | tr -d '\r' || true)
+    adb -s "$S" exec-out uiautomator dump /sdcard/u.xml >/dev/null 2>&1 || true
+    # `grep -c` exits 1 on zero matches — the normal "not rendered yet" state on every early poll.
+    # `|| true` keeps `set -euo pipefail` from aborting the wait loop before the list shows up.
+    rendered=$(adb -s "$S" shell cat /sdcard/u.xml 2>/dev/null | grep -c 'Benchmark sound' || true)
+    [ -n "$pid" ] && [ "${rendered:-0}" -ge 1 ] && { ok=1; break; }
     sleep 2
   done
   [ "$ok" -ne 1 ] && { echo "N=$N: app not ready (pid=$pid rendered=$rendered) — SKIP"; continue; }
@@ -83,7 +104,7 @@ for N in "${SIZES[@]}"; do
   for _ in $(seq 1 8); do adb -s "$S" shell input swipe 540 1500 540 500 250; sleep 0.6; done
   sleep 1
   adb -s "$S" shell dumpsys gfxinfo "$PKG" > "$OUT/gfxinfo-$N.txt" 2>&1
-  grep -E 'Total frames|Janky frames|percentile|Number Missed Vsync|Number Slow' "$OUT/gfxinfo-$N.txt" | sed 's/^/   /'
+  grep -E 'Total frames|Janky frames|percentile|Number Missed Vsync|Number Slow' "$OUT/gfxinfo-$N.txt" | sed 's/^/   /' || true
 
   if [ -n "$trace" ]; then
     sleep 12

--- a/scripts/measure-scroll-jank.sh
+++ b/scripts/measure-scroll-jank.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# Scroll-jank diagnosis on a CPU-constrained emulator with a REAL GPU — the "correct setup" for
+# approximating a lower-tier device (ADR 0015 / CONTRIBUTING § Performance benchmarking).
+#
+# Why these knobs:
+#   * `-gpu host` (NOT swiftshader): software rendering saturates the GPU (~98% jank, GPU P99 ~5 s)
+#     and masks the app's real per-frame cost. A real GPU keeps the bottleneck on CPU/UI-thread/
+#     composition — where our jank would actually live. Needs a window, so this runs windowed.
+#   * `-cores 2 -memory 2048`: constrains CPU/RAM vs the host (the representable low-tier lever;
+#     the emulator still runs on the host CPU, so numbers are directional — a real device is
+#     authoritative).
+#
+# What it does, per list size (few/medium/many): cold-launch the benchmark build (applicationId
+# `.debug`, real bomp-debug Firebase config so it doesn't FirebaseSessions-fatal), seed exactly N
+# synthetic sounds, confirm the list rendered (never measure the launcher), reset `dumpsys gfxinfo`,
+# fling with `adb input swipe`, then print the jank summary. Captures a Perfetto system trace on the
+# largest size for per-frame root-causing (open in https://ui.perfetto.dev or Android Studio).
+#
+# Usage: ./scripts/measure-scroll-jank.sh
+# Env overrides: AVD, SYS_IMG, CORES, MEMORY, DEVICE_PROFILE, SIZES (space-separated).
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+AVD="${AVD:-cond_api30}"
+SYS_IMG="${SYS_IMG:-system-images;android-30;google_apis;arm64-v8a}"
+DEVICE_PROFILE="${DEVICE_PROFILE:-pixel_4}"
+CORES="${CORES:-2}"
+MEMORY="${MEMORY:-2048}"
+read -r -a SIZES <<< "${SIZES:-20 50 200}"
+
+PKG=com.github.barriosnahuel.vossosunboton.debug
+ACT="$PKG/com.github.barriosnahuel.vossosunboton.ui.home.LandingActivity"
+APK=app/build/outputs/apk/benchmark/app-benchmark.apk
+OUT=macrobenchmark/build/jank-diagnosis
+mkdir -p "$OUT"
+
+echo "▶ Building benchmark APK…"
+./gradlew :app:assembleBenchmark -q
+
+avdmanager list avd 2>/dev/null | grep -q "Name: $AVD" || {
+  echo "▶ Creating AVD $AVD ($SYS_IMG, $DEVICE_PROFILE)…"
+  echo "no" | avdmanager create avd -n "$AVD" -k "$SYS_IMG" -d "$DEVICE_PROFILE" --force
+}
+
+echo "▶ Launching $AVD (windowed, -gpu host, -cores $CORES, -memory $MEMORY)…"
+nohup emulator -avd "$AVD" -gpu host -cores "$CORES" -memory "$MEMORY" \
+  -no-snapshot -no-boot-anim -no-audio > "$OUT/emulator.log" 2>&1 &
+EMU_PID=$!
+trap 'adb -s "${S:-}" emu kill >/dev/null 2>&1 || kill "$EMU_PID" 2>/dev/null || true' EXIT
+
+until adb devices | grep -q '^emulator-'; do sleep 3; done
+S=$(adb devices | awk '/^emulator-/{print $1; exit}')
+echo "▶ $S booting…"
+until [ "$(adb -s "$S" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" = "1" ]; do sleep 3; done
+adb -s "$S" shell input keyevent KEYCODE_WAKEUP >/dev/null 2>&1
+adb -s "$S" install -r "$APK" >/dev/null
+echo "▶ Installed. Measuring sizes: ${SIZES[*]}"
+
+last=${SIZES[${#SIZES[@]}-1]}
+for N in "${SIZES[@]}"; do
+  echo "===== N=$N ====="
+  adb -s "$S" shell am force-stop "$PKG"
+  adb -s "$S" shell am start -n "$ACT" --ei benchmark_seed_count "$N" >/dev/null 2>&1
+  ok=0
+  for _ in $(seq 1 40); do
+    pid=$(adb -s "$S" shell pidof "$PKG" 2>/dev/null | tr -d '\r')
+    rendered=$(adb -s "$S" exec-out uiautomator dump /sdcard/u.xml >/dev/null 2>&1; \
+               adb -s "$S" shell cat /sdcard/u.xml 2>/dev/null | grep -c 'Benchmark sound')
+    [ -n "$pid" ] && [ "$rendered" -ge 1 ] && { ok=1; break; }
+    sleep 2
+  done
+  [ "$ok" -ne 1 ] && { echo "N=$N: app not ready (pid=$pid rendered=$rendered) — SKIP"; continue; }
+
+  trace=""
+  if [ "$N" = "$last" ]; then
+    trace=/data/misc/perfetto-traces/scroll.perfetto-trace
+    adb -s "$S" shell "perfetto -o $trace -t 12s -b 64mb gfx view wm am sched freq" >/dev/null 2>&1 &
+    sleep 1
+  fi
+
+  adb -s "$S" shell dumpsys gfxinfo "$PKG" reset >/dev/null 2>&1
+  for _ in $(seq 1 8); do adb -s "$S" shell input swipe 540 1500 540 500 250; sleep 0.6; done
+  sleep 1
+  adb -s "$S" shell dumpsys gfxinfo "$PKG" > "$OUT/gfxinfo-$N.txt" 2>&1
+  grep -E 'Total frames|Janky frames|percentile|Number Missed Vsync|Number Slow' "$OUT/gfxinfo-$N.txt" | sed 's/^/   /'
+
+  if [ -n "$trace" ]; then
+    sleep 12
+    adb -s "$S" pull "$trace" "$OUT/scroll-$N.perfetto-trace" >/dev/null 2>&1 \
+      && echo "   Perfetto trace → $OUT/scroll-$N.perfetto-trace (open in ui.perfetto.dev)"
+  fi
+done
+echo "✓ Done. Reports in $OUT/"

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -67,16 +67,23 @@ else
 fi
 
 # The `benchmark` build type uses applicationId `.debug` and reuses the real DEBUG Firebase config
-# (bomp-debug, valid key — a scrubbed dummy would make FirebaseSessions fatal on a real device; see
-# app/build.gradle / ADR 0015). google-services resolves per build-type folder, so the debug file is
-# copied into the benchmark folder; its `.debug` package already matches. Skip-worktree first so the
-# real `AIza…` key never stages (the committed copy is a scrubbed dummy).
+# (bomp-debug — a scrubbed dummy would make FirebaseSessions fatal on a real device; see
+# app/build.gradle). google-services resolves per build-type folder, so the debug file is copied into
+# the benchmark folder; its `.debug` package already matches. Hard-fail on a missing source and stay
+# idempotent, mirroring the CONFIGS loop above (skip-worktree first so the real key never stages).
 bench_dest="app/src/benchmark/google-services.json"
 bench_src="$primary_root/app/src/debug/google-services.json"
-if [ -f "$bench_src" ]; then
+if [ ! -f "$bench_src" ]; then
+  echo "✘ Primary worktree is missing app/src/debug/google-services.json (needed for the benchmark config)." >&2
+  exit 1
+fi
+bench_flag="$(git ls-files -v -- "$bench_dest" | awk 'NR==1 {print $1}')"
+if [ "$bench_flag" != "S" ] || ! cmp -s "$bench_src" "$bench_dest"; then
   git update-index --skip-worktree -- "$bench_dest"
   cp "$bench_src" "$bench_dest"
   echo "✓ benchmark google-services seeded from the debug config (skip-worktree)."
+else
+  echo "✓ benchmark google-services already set up."
 fi
 
 mkdir -p model/src/debug/res/raw

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -66,6 +66,19 @@ else
   echo "✓ google-services configs copied from primary and marked skip-worktree."
 fi
 
+# The `benchmark` build type uses applicationId `.debug` and reuses the real DEBUG Firebase config
+# (bomp-debug, valid key — a scrubbed dummy would make FirebaseSessions fatal on a real device; see
+# app/build.gradle / ADR 0015). google-services resolves per build-type folder, so the debug file is
+# copied into the benchmark folder; its `.debug` package already matches. Skip-worktree first so the
+# real `AIza…` key never stages (the committed copy is a scrubbed dummy).
+bench_dest="app/src/benchmark/google-services.json"
+bench_src="$primary_root/app/src/debug/google-services.json"
+if [ -f "$bench_src" ]; then
+  git update-index --skip-worktree -- "$bench_dest"
+  cp "$bench_src" "$bench_dest"
+  echo "✓ benchmark google-services seeded from the debug config (skip-worktree)."
+fi
+
 mkdir -p model/src/debug/res/raw
 cp "$primary_root/model/src/debug/res/raw/"*.mp3 model/src/debug/res/raw/ 2>/dev/null || true
 cp "$primary_root/model/src/debug/res/raw/"*.ogg model/src/debug/res/raw/ 2>/dev/null || true


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change.

Makes the on-device performance benchmark harness actually runnable on real devices and emulators, unblocking the LandingActivity jank investigation (Fase 3) and the upcoming fix's before/after validation. Also closes two gaps left by the macrobenchmark module's first PR.

### Technical detail

Hardens the `:macrobenchmark` harness + the app's `benchmark` build type for real on-device runs.

- **`benchmark` build type** — now runs under the **debug applicationId (`.debug`) + debug signing**, and resolves the **real debug Firebase config** (bomp-debug). Fixes the first PR's incomplete config: the release-derived dummy had a format-invalid API key, which made `FirebaseSessions` **fatal on a real device** (it only warned on emulators). Also: Crashlytics mapping upload off (was 400-ing), and the **debug grey launcher icon** via `benchmark.res += src/debug/res` (was showing the production green one).
- **`ScrollBenchmark`** — `UiScrollable` (re-resolves the node each gesture → no more `StaleObjectException`); `SMALL_LIST` 5→20 (a 5-item list isn't scrollable).
- **`setup-worktree.sh`** — seeds the benchmark google-services from the debug config (skip-worktree); committed copy stays a scrubbed dummy.
- **`scripts/measure-scroll-jank.sh`** — conditioned-emulator (real GPU + CPU-constrained) gfxinfo + Perfetto scroll-jank diagnosis: the reproducible "correct setup" (swiftshader saturates the GPU and masks the real cost).
- **Out of scope** — the actual jank fix (Baseline Profile / cache-prime). Separate Fase 4 PR, with its own before/after.

Fase 3 outcome from this harness: **H2 (per-item scroll cost) refuted** — steady-state scroll is smooth even at 200 items; the jank lives in the cold/startup regime (→ Fase 4).

### Code review tips

- **google-services skip-worktree dance:** the committed `app/src/benchmark/google-services.json` must stay a scrubbed dummy — verify no real `AIza…` key in the diff.
- **`.debug` identity:** the benchmark APK installs over the *dev debug* app (same package + key), **never** the store app (no suffix). Confirmed on-device.
- **`FrameTimingMetric` only captured `frameCount` on the API 30 emulator** — gfxinfo gives the richer jank%/percentiles; both are kept on purpose.
- Benchmarks run on-device (human, Fase 3); CI only validates compile + check + unit.

### Already tested

- `./gradlew :app:assembleBenchmark` + `:macrobenchmark:assembleBenchmark` — compile green.
- pre-push: ADR/security/analytics/assertion guards + `ktlintCheck detekt spotlessCheck` — green.
- On-device: 5/5 Macrobenchmark tests pass on a conditioned real-GPU AVD; gfxinfo + Perfetto runs on Pixel 8 + emulator.
