### PR TITLE
docs(adr): align ADR 0015 alternatives with repo `## Options considered` convention

### DIFF
--- a/docs/adr/0015-macrobenchmark-seeding-architecture.md
+++ b/docs/adr/0015-macrobenchmark-seeding-architecture.md
@@ -61,13 +61,14 @@ build's `debuggable=true` would distort the numbers.
   exact-N (idempotent, shrinkable), a single recomposition (no metric pollution), and — since sounds
   and their cached duration share one DataStore key — populated durations (render fidelity).
 
-**Rejected alternatives:**
-- *Real files for synthetic rows* — the scroll render never reads the file, so this adds I/O and
+## Options considered (and rejected)
+
+- **Real files for synthetic rows** — the scroll render never reads the file, so this adds I/O and
   file-path coupling without improving fidelity; its only effect would be making the disk-coupled
   `delete()` work, which the atomic primitive makes moot.
-- *Target the debug build* — `debuggable=true` distorts the numbers and forces a test-module variant
+- **Target the debug build** — `debuggable=true` distorts the numbers and forces a test-module variant
   matrix (two target applicationIds).
-- *Per-item `save()` + `delete()`* — cannot shrink (constraint 1) and pollutes the metric
+- **Per-item `save()` + `delete()`** — cannot shrink (constraint 1) and pollutes the metric
   (constraint 2).
 
 ## Consequences


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change. ADR-0015 was the lone outlier formatting its rejected alternatives as an inline **Rejected alternatives:** sub-heading inside `## Decision`; this brings it in line with the rest of the records so the ADR set reads consistently for anyone auditing decisions.

### Technical detail

Reformat ADR-0015's alternatives to the repo's canonical shape.

- **`0015-macrobenchmark-seeding-architecture.md`** — promote the inline `**Rejected alternatives:**` block out of `## Decision` into a top-level `## Options considered (and rejected)` section, placed between `## Decision` and `## Consequences`.
- **Convention match** — 11 of the ADRs use a top-level `## Options considered` heading; only 0015 deviated. Placement + the `(and rejected)` suffix mirror the closest sibling, ADR-0016 (same batch/author), whose section also sits after `## Decision`.
- **Wording unchanged** — same three items, only the markdown shape changed (italic lead-ins → bold, matching 0016's bullet style). No content edited.

### Code review tips

- Pure docs/markdown move; the three rejected items reference the chosen primitive ("which the atomic primitive makes moot"), so they stay after `## Decision` rather than before it (0014/0013/0010 put theirs before Decision — 0016's after-Decision placement is the right fit here).
- `scripts/check-adr-invariants.sh` passes locally — the guard checks production invariants named by ADRs, not heading layout, so this reformat doesn't touch it.

### Already tested

CI covers it (`adr-invariants`); ran `scripts/check-adr-invariants.sh` locally — green.