### PR TITLE
build(test): cold-boot instrumented emulator with host GPU + more CPU/RAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 #### Changed
 - Scroll benchmark now seeds a controlled corpus and runs across three list sizes (20 / 50 / 200) so the sound-list frame timing exposes whether scroll jank scales with item count
+- The instrumented UI test wrapper now cold-boots the emulator with host-GPU rendering and widened CPU/RAM (`-gpu host -cores 6 -memory 4096`, env-overridable), so the suite runs faster and less flaky than on the software-rendered AVD defaults
 
 ## \[v2.1.0] - 2026-05-25
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,7 +239,7 @@ Instrumented UI/functional tests live under `app/src/androidTest/`. They drive a
 ./scripts/run-instrumented-tests.sh
 ```
 
-The wrapper cold-boots the AVD with wiped userdata, waits for it, then runs `./gradlew :app:connectedDebugAndroidTest` against that emulator only (it pins the serial, so a physical device attached at the same time is ignored).
+The wrapper cold-boots the AVD with wiped userdata, waits for it, then runs `./gradlew :app:connectedDebugAndroidTest` against that emulator only (it pins the serial, so a physical device attached at the same time is ignored). The cold boot launches with `-gpu host` and widened resources (`-cores 6 -memory 4096`) so the guest renders on the host GPU instead of in software — faster and less flaky than the AVD defaults. Override per run with `EMULATOR_GPU` (use `auto` if `host` misbehaves on your machine), `EMULATOR_CORES`, `EMULATOR_MEMORY`.
 
 **Always go through the wrapper — do not run `./gradlew :app:connectedDebugAndroidTest` against an already-running emulator.** A warm emulator degrades across back-to-back runs (`system_server` watchdog ANRs, hundreds of skipped frames), which surfaces as `ComposeTimeoutException` / `ComposeNotIdleException` flakes or an outright `Process crashed`. A cold boot resets that — a clean run finishes in ~3 min; a degraded one takes 15+ min or never completes. Rationale: [ADR 0001 § *Cold boot per run*](docs/adr/0001-local-ui-test-suite.md).
 

--- a/docs/adr/0001-local-ui-test-suite.md
+++ b/docs/adr/0001-local-ui-test-suite.md
@@ -104,6 +104,15 @@ it kills the AVD, relaunches it with `-no-snapshot -wipe-data`, waits for boot, 
 the suite — repeating the cold boot before each pass when `RUNS` > 1. Do **not** invoke
 `./gradlew :app:connectedDebugAndroidTest` directly against an already-running emulator.
 
+The cold boot also passes `-gpu host -cores 6 -memory 4096`, overriding the AVD's
+`hardware-qemu.ini` so the guest renders on the host GPU (MoltenVK/Vulkan on Apple Silicon)
+instead of in software and stops starving on too few cores/RAM — the standard AVD defaults
+(software GPU, ~2-4 cores, 2 GB) are a primary contributor to the very watchdog ANRs and
+frozen frames this cold boot fights. All three are env-overridable (`EMULATOR_GPU`,
+`EMULATOR_CORES`, `EMULATOR_MEMORY`); fall back to `EMULATOR_GPU=auto` if `host` misbehaves on
+a given machine. `-no-audio` is deliberately *not* added: this is a soundboard whose suite
+exercises playback, so the guest keeps its audio device.
+
 The wrapper resets *guest* (emulator) state — it cannot reset *host* state. The emulator is
 a VM, and a saturated host (high load average from other heavy work, or from running the
 suite dozens of times back-to-back) makes even a freshly booted guest janky enough to flake

--- a/scripts/run-instrumented-tests.sh
+++ b/scripts/run-instrumented-tests.sh
@@ -26,7 +26,8 @@
 #   RUNS=3 ./scripts/run-instrumented-tests.sh
 #       three runs, each preceded by its own cold boot (use to hunt flakes)
 #
-# Environment overrides: AVD_NAME, RUNS, EMULATOR_PORT, BOOT_TIMEOUT_SECONDS.
+# Environment overrides: AVD_NAME, RUNS, EMULATOR_PORT, BOOT_TIMEOUT_SECONDS,
+# EMULATOR_GPU, EMULATOR_CORES, EMULATOR_MEMORY.
 #
 # Requires the Android SDK CLI on PATH (emulator, adb) and the AVD created by
 # ./scripts/setup-test-emulator.sh.
@@ -38,6 +39,16 @@ RUNS="${RUNS:-1}"
 EMULATOR_PORT="${EMULATOR_PORT:-5554}"
 BOOT_TIMEOUT_SECONDS="${BOOT_TIMEOUT_SECONDS:-300}"
 EMULATOR_SERIAL="emulator-${EMULATOR_PORT}"
+
+# Hardware/GPU knobs for the cold boot. The defaults stop the AVD from rendering
+# in software and starving on too few cores/RAM (the main source of the watchdog
+# ANRs / frozen frames the cold boot already fights). See docs/adr/0001 § Cold boot.
+#   EMULATOR_GPU=host : host GPU (MoltenVK/Vulkan on Apple Silicon); "auto" is the safe fallback.
+#   EMULATOR_CORES    : virtual CPU cores (AVD default is typically 2-4).
+#   EMULATOR_MEMORY   : guest RAM in MB (AVD default is typically 2048).
+EMULATOR_GPU="${EMULATOR_GPU:-host}"
+EMULATOR_CORES="${EMULATOR_CORES:-6}"
+EMULATOR_MEMORY="${EMULATOR_MEMORY:-4096}"
 
 # Auto-discover the Android SDK and prepend its tool dirs to PATH (mirrors
 # scripts/setup-test-emulator.sh) so the script works with only cmdline-tools on PATH.
@@ -94,9 +105,14 @@ cold_boot_emulator() {
   # -no-snapshot  : ignore any saved snapshot and don't save one on exit — boot from scratch
   # -wipe-data    : reset userdata, the part that accumulates the cruft this wrapper exists to avoid
   # -no-boot-anim : shave a few seconds off the boot
+  # -gpu/-cores/-memory : override the AVD's hardware-qemu.ini so the guest renders on the host
+  #   GPU and gets enough CPU/RAM (defaults above). No -no-audio: this is a soundboard and the
+  #   suite exercises playback, so the guest keeps its audio device.
   # stdout/stderr -> $EMULATOR_LOG so a failed boot is diagnosable instead of silent.
   nohup emulator -avd "$AVD_NAME" -port "$EMULATOR_PORT" \
-    -no-snapshot -wipe-data -no-boot-anim >"$EMULATOR_LOG" 2>&1 &
+    -no-snapshot -wipe-data -no-boot-anim \
+    -gpu "$EMULATOR_GPU" -cores "$EMULATOR_CORES" -memory "$EMULATOR_MEMORY" \
+    >"$EMULATOR_LOG" 2>&1 &
 
   ANDROID_SERIAL="$EMULATOR_SERIAL" adb wait-for-device
   local waited=0


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change. Speeds up and de-flakes the **local** instrumented UI suite (`./scripts/run-instrumented-tests.sh`), so the inner loop for any Composable/ViewModel/navigation change is faster and less prone to false `ComposeTimeout` failures.

- The cold boot was launching the AVD on its stock hardware profile — **software GPU, ~2-4 cores, 2 GB RAM** — so Compose renders in software and the guest starves. That's a primary contributor to the very watchdog ANRs / frozen frames the cold boot already exists to fight.
- Now boots with `-gpu host -cores 6 -memory 4096`, all env-overridable. On Apple Silicon `-gpu host` uses MoltenVK/Vulkan over Metal (per the official emulator-acceleration docs).

### Technical detail

Adds three hardware knobs to the cold boot in `scripts/run-instrumented-tests.sh`, plus the rationale in the doc that owns it.

- **`scripts/run-instrumented-tests.sh`** — new env-overridable vars `EMULATOR_GPU` (default `host`), `EMULATOR_CORES` (`6`), `EMULATOR_MEMORY` (`4096`); appended `-gpu/-cores/-memory` to the `emulator` invocation. Verified against `emulator -help-gpu`: the flag *"override the mode of GPU emulation indicated by the AVD's hardware-qemu.ini"*, so it takes effect **without recreating the AVD**.
- **Kept unchanged on purpose:** `-no-snapshot -wipe-data -no-boot-anim` (ADR 0001 cold-boot invariant), serial pinning, boot poll, the `RUNS` loop.
- **Deliberately NOT added:** `-no-audio` — this is a soundboard whose suite exercises playback; killing the guest audio device could alter those tests, and the benefit on macOS is marginal.
- **Out of scope (untouched):** `scripts/measure-scroll-jank.sh` and `macrobenchmark/` constrain resources on purpose to measure low-tier jank; `setup-test-emulator.sh` / `config.ini` (boot flags win, no recreation needed).
- **Docs:** ADR 0001 § *Cold boot per run* gets the rationale (refines, does not supersede); CONTRIBUTING.md § *Run the full suite* documents the flags + overrides.

### Code review tips

- The chosen values (`6` cores / `4096` MB) are tuned for an 8-core / 16 GB Apple Silicon host; they're env-overridable so other machines can dial down. `EMULATOR_GPU=auto` is the documented fallback if `host` ever misbehaves on a given GPU/driver.
- **Manual verification suggested (human, local):** the actual speed/flakiness win can only be observed by running the suite against a real GPU. CircleCI does not run this suite (ADR 0001) and the headless CI box has no AVD/GPU, so end-to-end timing is not assertable in CI by design.
- Residual risk: if some emulator version still honored `hw.gpu.enabled=no` despite `-gpu host`, the log would show a software renderer — `grep -i gpu` the emulator log; the guaranteed fix would then be setting `hw.gpu.enabled=yes`/`mode=host` at AVD creation. Considered low given the documented override semantics.

### Already tested

- Shell syntax (`bash -n scripts/run-instrumented-tests.sh`): clean.
- ADR/security grep guards (`check-adr-invariants.sh`, `check-security-test-count.sh`): green locally and re-run by CircleCI.