### PR TITLE
feat(search): move search trigger from FAB to top app bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - A "Share Bomp" option in the top menu lets you recommend the app with a link, so the people you send it to can get it too
 
 ### Changed
+- Search now lives as a magnifier in the top bar, on every tab, instead of a floating button — so you can search your audios any time, even before your collection grows
 - The welcome audio no longer vanishes on its own after it plays — it stays in your list like any other audio, sorted by date, and the first time it finishes a warm note reminds you it's yours to keep or delete whenever you want; a one-time nudge shows you can swipe it away
 - Audios you share now arrive ready to play inline in more chat apps, instead of as a file the other person has to download first
 - Sharing an audio now adds a short, warm invite and a link, so whoever receives it can have Bomp too

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultTabFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultTabFlowTest.kt
@@ -6,7 +6,6 @@
 package com.github.barriosnahuel.vossosunboton.feature.vault
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ActivityScenario
@@ -84,13 +83,10 @@ internal class VaultTabFlowTest : AbstractUiTest() {
     }
 
     @Test
-    fun unlockedVaultShowsTheSearchFab() {
-        // The Vault tab now offers the global Search FAB (it replaced the dedicated "new private
-        // collection" FAB — creating one still lives on the chip row's "+ Nueva"). markVaultOpen
-        // lands us on the body directly, where the FAB shows like on every other tab.
-        // Seed past SEARCH_FAB_MIN_SOUNDS explicitly so the FAB gate is satisfied by the seeded
-        // library alone, not the (uncommitted, best-effort) bundled catalog.
-        TestData.seedCustomSounds(context, count = SOUNDS_FOR_VISIBLE_FAB)
+    fun unlockedVaultShowsTheSearchAction() {
+        // Search lives in the top app bar on every tab. markVaultOpen lands us on the unlocked Vault
+        // body directly, where the search action shows like on every other tab.
+        TestData.seedCustomSounds(context, count = SEEDED_SOUNDS)
         TestData.markVaultOpen()
 
         ActivityScenario.launch(LandingActivity::class.java).use {
@@ -100,20 +96,35 @@ internal class VaultTabFlowTest : AbstractUiTest() {
     }
 
     @Test
-    fun lockedVaultHidesTheSearchFab() {
-        // While the Vault is locked the unlock gate is the whole screen — the Search FAB stays
-        // hidden until unlock, matching the create FAB it replaced (also visible only when unlocked).
+    fun lockedVaultStillShowsTheSearchAction() {
+        // Search moved to the top app bar (persistent chrome), so it stays present even while the
+        // Vault is locked — the unlock gate fills the body, but the bar keeps the search action.
         ActivityScenario.launch(LandingActivity::class.java).use {
             composeRule.awaitNodeWithText(vaultLabel()).performClick()
             composeRule.awaitNodeWithText(unlockCta()).assertIsDisplayed()
             composeRule.waitForIdle()
-            composeRule.onNodeWithContentDescription(searchLabel()).assertDoesNotExist()
+            composeRule.awaitNodeWithContentDescription(searchLabel()).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun searchOpensFromTheLockedVaultTab() {
+        // The search action is newly reachable on the locked Vault tab; tapping it opens the same
+        // full-screen overlay as on any other tab (the overlay keeps its own biometric gate for
+        // vault content, so this entry point exposes nothing private before unlock).
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            composeRule.awaitNodeWithText(vaultLabel()).performClick()
+            composeRule.awaitNodeWithText(unlockCta()).assertIsDisplayed()
+            composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
+            composeRule.awaitNodeWithContentDescription(closeSearchLabel()).assertIsDisplayed()
         }
     }
 
     private fun vaultLabel() = context.getString(R.string.app_navigation_menu_item_vault)
 
     private fun searchLabel() = context.getString(R.string.app_search)
+
+    private fun closeSearchLabel() = context.getString(R.string.app_search_close)
 
     private fun unlockCta() = context.getString(R.string.app_vault_unlock_cta)
 
@@ -124,8 +135,8 @@ internal class VaultTabFlowTest : AbstractUiTest() {
     private fun zrpEmphasis() = context.getString(R.string.app_vault_zrp_headline_emphasis)
 
     private companion object {
-        // Mirrors SEARCH_FAB_MIN_SOUNDS in LandingScreen.kt — seeding this many guarantees the
-        // global library crosses the Search FAB threshold without relying on the bundled catalog.
-        const val SOUNDS_FOR_VISIBLE_FAB = 7
+        // A few searchable sounds so the unlocked Vault body has content — the search action itself
+        // is always present regardless of count.
+        const val SEEDED_SOUNDS = 7
     }
 }

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenFlowTest.kt
@@ -53,7 +53,7 @@ internal class AboutScreenFlowTest : AbstractUiTest() {
         ActivityScenario.launch(LandingActivity::class.java).use {
             openAbout()
             composeRule.onNodeWithContentDescription(backLabel()).performClick()
-            // Overflow menu is the Landing sentinel (absent on About); the Search FAB is unusable here since it is gated on sound count.
+            // Overflow menu is the Landing sentinel — it lives in the home top app bar, absent on About.
             composeRule.awaitNodeWithContentDescription(context.getString(R.string.app_overflow_menu)).assertIsDisplayed()
         }
     }

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/HomeTabFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/HomeTabFlowTest.kt
@@ -140,10 +140,9 @@ internal class HomeTabFlowTest : AbstractUiTest() {
 
     @Test
     fun homeScreenExposesA11yContentDescriptionsForKeyControls() {
-        // 7 mirrors SEARCH_FAB_MIN_SOUNDS in LandingScreen.kt — below that, the Search FAB is
-        // hidden by design, so seeding fewer items would make the searchLabel() assertion fail.
-        // Per-sound controls (play/share/pin) match once per row, so the assertions use onFirst().
-        TestData.seedCustomSounds(context, count = 7)
+        // The search action lives in the top app bar and is always present; the per-sound controls
+        // (play/share/pin) just need at least one row to exist, matched once per row via onFirst().
+        TestData.seedCustomSounds(context, count = 1)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             composeRule.awaitNodeWithContentDescription(searchLabel()).assertHasClickAction()

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlayTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/SearchOverlayTest.kt
@@ -23,27 +23,15 @@ import com.github.barriosnahuel.vossosunboton.WAIT_TIMEOUT_MS
 import com.github.barriosnahuel.vossosunboton.awaitNode
 import com.github.barriosnahuel.vossosunboton.awaitNodeWithContentDescription
 import com.github.barriosnahuel.vossosunboton.awaitNodeWithText
-import com.github.barriosnahuel.vossosunboton.model.data.local.defaultaudios.PackagedAudios
-import org.junit.Assume.assumeTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 internal class SearchOverlayTest : AbstractUiTest() {
     @Test
-    fun searchFabShowsOnMySoundsWhenOnlyTheGlobalCatalogCrossesTheThreshold() {
-        // Regression: the FAB used to gate on the *currently visible tab's* filtered list, so My
-        // Sounds with only a couple of custom sounds hid it — even though search is global and the
-        // bundled Explore catalog (always ≥ SEARCH_FAB_MIN_SOUNDS in debug) is searchable from here.
-        // Seed two custom sounds: My Sounds shows two (below the threshold on its own) while the
-        // global library is well above it. The FAB must be present on My Sounds.
-        assumeTrue(
-            "Needs a bundled catalog large enough that the global library crosses the FAB threshold " +
-                "while My Sounds stays sparse (bundled raw audio is a best-effort, uncommitted copy).",
-            SOUNDS_BELOW_TAB_THRESHOLD + PackagedAudios.get(context).size >= SOUNDS_FOR_VISIBLE_FAB,
-        )
-        TestData.seedCustomSounds(context, count = SOUNDS_BELOW_TAB_THRESHOLD)
-
+    fun searchActionIsPresentInTheTopAppBarOnMySounds() {
+        // Search lives in the top app bar as persistent chrome — present on every tab regardless of
+        // library size. Seed nothing: even an empty My Sounds shows the search action.
         ActivityScenario.launch(LandingActivity::class.java).use {
             composeRule.awaitNodeWithContentDescription(searchLabel()).assertIsDisplayed()
         }
@@ -55,7 +43,7 @@ internal class SearchOverlayTest : AbstractUiTest() {
         // now carries an origin tag. A *private* collection name is the unambiguous probe: it is
         // never a My Sounds filter chip and its audio is hidden from My Sounds, so the name can only
         // surface on the search result's tag (proving the result wiring, not the underlying list).
-        val sounds = TestData.seedCustomSounds(context, count = SOUNDS_FOR_VISIBLE_FAB + 1)
+        val sounds = TestData.seedCustomSounds(context, count = SEEDED_SOUNDS + 1)
         val privateAudio = sounds.last()
         TestData.seedPrivateCollection(context, name = PRIVATE_COLLECTION, audioIds = listOf(privateAudio.id))
         TestData.markVaultOpen()
@@ -68,8 +56,8 @@ internal class SearchOverlayTest : AbstractUiTest() {
     }
 
     @Test
-    fun fabOpensSearchOverlay() {
-        TestData.seedCustomSounds(context, count = SOUNDS_FOR_VISIBLE_FAB)
+    fun searchActionOpensSearchOverlay() {
+        TestData.seedCustomSounds(context, count = SEEDED_SOUNDS)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
@@ -80,7 +68,7 @@ internal class SearchOverlayTest : AbstractUiTest() {
 
     @Test
     fun typingQueryFiltersResultsToMatchingSound() {
-        TestData.seedCustomSounds(context, count = SOUNDS_FOR_VISIBLE_FAB)
+        TestData.seedCustomSounds(context, count = SEEDED_SOUNDS)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
@@ -98,7 +86,7 @@ internal class SearchOverlayTest : AbstractUiTest() {
 
     @Test
     fun queryWithNoMatchShowsZeroResultsMessage() {
-        TestData.seedCustomSounds(context, count = SOUNDS_FOR_VISIBLE_FAB)
+        TestData.seedCustomSounds(context, count = SEEDED_SOUNDS)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
@@ -109,7 +97,7 @@ internal class SearchOverlayTest : AbstractUiTest() {
 
     @Test
     fun trailingClearIconClearsQueryWithoutClosingOverlay() {
-        TestData.seedCustomSounds(context, count = SOUNDS_FOR_VISIBLE_FAB)
+        TestData.seedCustomSounds(context, count = SEEDED_SOUNDS)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
@@ -125,29 +113,29 @@ internal class SearchOverlayTest : AbstractUiTest() {
 
     @Test
     fun backArrowClosesOverlay() {
-        TestData.seedCustomSounds(context, count = SOUNDS_FOR_VISIBLE_FAB)
+        TestData.seedCustomSounds(context, count = SEEDED_SOUNDS)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
             composeRule.awaitNodeWithContentDescription(closeSearchLabel()).performClick()
             composeRule.waitForIdle()
             composeRule.onNodeWithContentDescription(closeSearchLabel()).assertIsNotDisplayed()
-            // FAB returns to view → we are back on Landing.
+            // The top-bar search action returns to view → we are back on Landing.
             composeRule.onNodeWithContentDescription(searchLabel()).assertIsDisplayed()
         }
     }
 
     @Test
     fun systemBackClosesOverlay() {
-        TestData.seedCustomSounds(context, count = SOUNDS_FOR_VISIBLE_FAB)
+        TestData.seedCustomSounds(context, count = SEEDED_SOUNDS)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
             // Wait for overlay to be on screen before pressing back, otherwise pressBack closes the Activity instead.
             composeRule.awaitNodeWithContentDescription(closeSearchLabel()).assertIsDisplayed()
             Espresso.pressBack()
-            // pressBack is deterministic; flush the back-handler recomposition so the FAB is
-            // settled in the next frame before assertIsDisplayed checks visibility.
+            // pressBack is deterministic; flush the back-handler recomposition so the search action
+            // is settled in the next frame before assertIsDisplayed checks visibility.
             composeRule.waitForIdle()
             composeRule.awaitNodeWithContentDescription(searchLabel()).assertIsDisplayed()
         }
@@ -155,7 +143,7 @@ internal class SearchOverlayTest : AbstractUiTest() {
 
     @Test
     fun searchOverlayExposesA11yContentDescriptions() {
-        TestData.seedCustomSounds(context, count = SOUNDS_FOR_VISIBLE_FAB)
+        TestData.seedCustomSounds(context, count = SEEDED_SOUNDS)
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             composeRule.awaitNodeWithContentDescription(searchLabel()).performClick()
@@ -176,14 +164,9 @@ internal class SearchOverlayTest : AbstractUiTest() {
     private fun clearSearchLabel() = context.getString(R.string.app_search_clear)
 
     private companion object {
-        // Matches SEARCH_FAB_MIN_SOUNDS in LandingScreen.kt — the FAB stays hidden until the global
-        // library crosses this threshold, so any test that needs to tap it must seed at least this
-        // many sounds (or rely on the always-present bundled catalog).
-        const val SOUNDS_FOR_VISIBLE_FAB = 7
-
-        // Below the threshold for the My Sounds tab on its own — the FAB only appears because the
-        // global library (these + the bundled Explore catalog) crosses SEARCH_FAB_MIN_SOUNDS.
-        const val SOUNDS_BELOW_TAB_THRESHOLD = 2
+        // A handful of searchable sounds so the overlay has content to filter — search itself is
+        // always reachable from the top app bar regardless of count.
+        const val SEEDED_SOUNDS = 7
 
         // A private collection name: never a My Sounds filter chip, so it can only appear on a
         // search result's origin tag — the unambiguous probe for the collection-tag wiring.

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -84,11 +83,6 @@ import kotlinx.coroutines.launch
 @Composable
 fun LandingScreen(viewModel: SoundsViewModel) {
     val sounds by viewModel.sounds.collectAsState()
-    // Full catalog across every surface (custom + bundled), independent of the visible tab — the
-    // Search FAB gates on this because search itself is global. `sounds` is the tab-filtered list
-    // and would wrongly hide the FAB on a sparse tab (e.g. My Sounds with a couple of audios) while
-    // the rest of the library is searchable.
-    val library by viewModel.library.collectAsState()
     val selectedTab by viewModel.selectedTab.collectAsState()
     val hasBundledSounds by viewModel.hasBundledSounds.collectAsState()
     val playbackProgress by viewModel.playbackProgress.collectAsState()
@@ -169,7 +163,6 @@ fun LandingScreen(viewModel: SoundsViewModel) {
         modifier = if (subScreenOpen) Modifier.clearAndSetSemantics {} else Modifier,
         viewModel = viewModel,
         sounds = sounds,
-        librarySize = library.size,
         selectedTab = selectedTab,
         hasBundledSounds = hasBundledSounds,
         playbackProgress = playbackProgress,
@@ -328,7 +321,6 @@ private fun ScaffoldedLanding(
     modifier: Modifier = Modifier,
     viewModel: SoundsViewModel,
     sounds: List<Sound>,
-    librarySize: Int,
     selectedTab: AppTab,
     hasBundledSounds: Boolean,
     playbackProgress: PlaybackProgress?,
@@ -349,14 +341,11 @@ private fun ScaffoldedLanding(
     onActiveFilterEditClick: (String) -> Unit,
     onImmersivePlay: (Sound) -> Unit,
 ) {
-    // The Search FAB now renders on the Vault tab too, but only once it's unlocked (its audio list
-    // is on screen) — the locked unlock screen stays focused, matching the old create-collection FAB
-    // which was also only visible inside the unlocked Vault.
-    val vaultOpen by VaultSessionState.flow.collectAsState()
     Scaffold(
         modifier = modifier,
         topBar = {
             AppTopBar(
+                onSearchClick = { viewModel.showSearch() },
                 onAboutClick = onAboutClick,
                 onManageCollectionsClick = onManageCollectionsClick,
             )
@@ -378,24 +367,6 @@ private fun ScaffoldedLanding(
             )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
-        floatingActionButton = {
-            // Search spans every surface, so the FAB gates on the global library size (not the
-            // tab-filtered `sounds`) — a sparse current tab must not hide a FAB that searches the
-            // whole catalog. It shows on every tab; on the Vault tab only once unlocked, so the
-            // locked unlock screen stays uncluttered.
-            if ((selectedTab != AppTab.VAULT || vaultOpen) && librarySize >= SEARCH_FAB_MIN_SOUNDS) {
-                FloatingActionButton(
-                    onClick = { viewModel.showSearch() },
-                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.app_ic_search),
-                        contentDescription = stringResource(R.string.app_search),
-                    )
-                }
-            }
-        },
     ) { innerPadding ->
         when (selectedTab) {
             AppTab.VAULT ->
@@ -558,6 +529,7 @@ private fun SnackbarEffects(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun AppTopBar(
+    onSearchClick: () -> Unit,
     onAboutClick: () -> Unit,
     onManageCollectionsClick: () -> Unit,
 ) {
@@ -566,6 +538,12 @@ private fun AppTopBar(
     TopAppBar(
         title = { Text(stringResource(R.string.app_name)) },
         actions = {
+            IconButton(onClick = onSearchClick) {
+                Icon(
+                    painter = painterResource(R.drawable.app_ic_search),
+                    contentDescription = stringResource(R.string.app_search),
+                )
+            }
             IconButton(onClick = { isMenuExpanded = true }) {
                 Icon(
                     painter = painterResource(R.drawable.app_ic_more_vert),
@@ -665,12 +643,6 @@ private fun AppBottomBar(
         }
     }
 }
-
-// 7 is the lower bound of the UX-research "ambiguous band" (7–15 items) where search starts to
-// out-perform scanning on mobile. Below 7, IME open + typing cost > scan time (NN/g "search vs.
-// browse", Baymard on mobile filter thresholds). We anchor at the lower bound because Bomp names
-// are short (fast to scan) and the dominant search task is find-specific, not browse-to-discover.
-private const val SEARCH_FAB_MIN_SOUNDS = 7
 
 private const val DELETE_ANIMATION_DURATION_MS = 300
 private val WELCOME_BORDER_WIDTH = 1.5.dp

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenAnalyticsTest.kt
@@ -110,7 +110,7 @@ internal class LandingScreenAnalyticsTest : AbstractRobolectricTest() {
 
     /**
      * Regression for the assumption documented next to `SoundsViewModel.currentSurface`: while About is the active
-     * destination the FAB and the sound list (the only entry points for `playOrStop` / `share`) must be
+     * destination the search action and the sound list (the only entry points for `playOrStop` / `share`) must be
      * unreachable, so `surface` and the latest `screen_name` cannot disagree.
      */
     @Test
@@ -126,8 +126,9 @@ internal class LandingScreenAnalyticsTest : AbstractRobolectricTest() {
         composeTestRule.onNodeWithText(context.getString(R.string.app_about)).performClick()
         composeTestRule.waitForIdle()
 
-        // About is the active destination — proven by both the screen_view emission and the absence of the FAB
-        // (which is the only entry point into `playOrStop` / `share` from the home shell).
+        // About is the active destination — proven by both the screen_view emission and the absence of the
+        // home shell's chrome. The shell's search action (top app bar) and sound list are the only entry
+        // points into `playOrStop` / `share`, and the open sub-screen clears them from the semantics tree.
         fake.assertScreenView(CanonicalScreenName.ABOUT)
         composeTestRule.onNodeWithContentDescription(context.getString(R.string.app_search)).assertDoesNotExist()
     }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
@@ -15,7 +15,6 @@ import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
 import com.github.barriosnahuel.vossosunboton.model.Sound
-import com.github.barriosnahuel.vossosunboton.testSound
 import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
 import io.mockk.every
 import io.mockk.mockkObject
@@ -86,7 +85,7 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `Search FAB is hidden when the global library is empty`() {
+    fun `Search action is shown in the top app bar even when the library is empty`() {
         val viewModel = givenAViewModel()
 
         composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
@@ -94,33 +93,8 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
         viewModel.injectLibrary(emptyList())
         composeTestRule.waitForIdle()
 
-        composeTestRule.onNodeWithContentDescription("Search").assertDoesNotExist()
-    }
-
-    @Test
-    fun `Search FAB is hidden when the global library has 6 sounds`() {
-        val viewModel = givenAViewModel()
-
-        composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
-        composeTestRule.waitForIdle()
-        viewModel.injectLibrary(stubSounds(count = 6))
-        composeTestRule.waitForIdle()
-
-        composeTestRule.onNodeWithContentDescription("Search").assertDoesNotExist()
-    }
-
-    @Test
-    fun `Search FAB is shown when the global library has 7 sounds`() {
-        val viewModel = givenAViewModel()
-
-        composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
-        composeTestRule.waitForIdle()
-        // `_sounds` (the My Sounds tab list) stays empty here — nothing custom is seeded — so this
-        // also pins the headline behaviour: the FAB shows on an otherwise-empty My Sounds tab once
-        // the *global* library crosses the threshold, which the old per-tab gate would have hidden.
-        viewModel.injectLibrary(stubSounds(count = 7))
-        composeTestRule.waitForIdle()
-
+        // Search now lives in the top app bar as persistent chrome — present on every tab regardless
+        // of library size (it replaced the count-gated Search FAB).
         composeTestRule.onNodeWithContentDescription("Search").assertIsDisplayed()
     }
 
@@ -158,10 +132,9 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
             .let { (it.get(this) as MutableStateFlow<Boolean>).value = value }
     }
 
-    // The Search FAB gates on the global library (allSoundsCache), not the tab-filtered `_sounds` —
-    // search spans every surface. The debug build's loadSounds primes allSoundsCache with the
-    // bundled catalog, so injecting AFTER waitForIdle (once that cascade settles, same reasoning as
-    // injectHasBundledSounds) is the only way to drive the count below the threshold.
+    // Drives the global library (allSoundsCache) to a known value. The debug build's loadSounds
+    // primes allSoundsCache with the bundled catalog, so injecting AFTER waitForIdle (once that
+    // cascade settles, same reasoning as injectHasBundledSounds) is the only way to empty it.
     private fun SoundsViewModel.injectLibrary(value: List<Sound>) {
         SoundsViewModel::class.java
             .getDeclaredField("allSoundsCache")
@@ -169,6 +142,4 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
             // Safe: allSoundsCache is always MutableStateFlow<List<Sound>> — type parameter erased at runtime
             .let { (it.get(this) as MutableStateFlow<List<Sound>>).value = value }
     }
-
-    private fun stubSounds(count: Int): List<Sound> = List(count) { testSound(name = "stub-$it", file = "/tmp/stub-$it.mp3") }
 }


### PR DESCRIPTION
### Summary

1. User opens Bomp
2. Taps the magnifier in the top bar
3. Searches their audios — on any tab

**before:** search was a floating button that only appeared once the library had 7+ audios, and it was hidden on the locked Vault — so early on (and on the Vault) there was no way to search.
**after:** the magnifier lives in the top bar as permanent chrome, present on every tab regardless of how many audios you have.

This is PR1 of the chrome redesign (design "Plan de PRs · 1 release, 0 botones muertos"). It only moves the *trigger*; the full-screen search experience is unchanged. Freeing the floating-button slot sets up the "+" import hub that arrives in PR2.

### Technical detail

Moved the search trigger from the `floatingActionButton` slot into an `IconButton` in `AppTopBar`.

- **`LandingScreen.kt`** — search `IconButton` (`app_ic_search`, `contentDescription = app_search`, `onClick = showSearch()`) added to the top-bar `actions`, before the overflow. The `FloatingActionButton` block, the `SEARCH_FAB_MIN_SOUNDS = 7` threshold, the vault-locked gate, and the now-unused `library`/`librarySize`/`vaultOpen` locals were removed. No FAB renders after this PR.
- **Overflow** unchanged (no "Ajustes" — that's PR5). **Bottom nav / search overlay / biometric vault gate** untouched.
- **Tests** retargeted from the FAB to the top-bar action: `LandingScreenTest`, `SearchOverlayTest`, `HomeTabFlowTest`, `VaultTabFlowTest` (locked-vault assertion flipped + a new "search opens from locked Vault" transition test), plus comment fixes in `LandingScreenAnalyticsTest`/`AboutScreenFlowTest`.

### Code review tips

- **Interpretation (spec vs. conservative):** the design says "lupa … en las 3 tabs", so the ≥7-audios threshold and the locked-Vault gate were dropped — search is now always reachable. Search *behavior* is identical (same overlay). Flag if you'd rather keep a threshold.
- **Locked Vault now shows search** (intentional reversal; `lockedVaultStillShowsTheSearchAction`). The overlay keeps its own biometric gate, so this entry point exposes no private content before unlock (new `searchOpensFromTheLockedVaultTab` covers the path).
- **Baseline Profile:** the startup-path composable changed (FAB out, top-bar icon in). `app/src/main/baseline-prof.txt` still references the old `ScaffoldedLanding` signature → regenerate per CONTRIBUTING § *Baseline Profile* (device step; stale = slightly slower first launch, never broken).
- **Pre-existing instrumented flakes — not from this PR:** 9 tests fail identically on pristine develop, verified with `git checkout e6c4b1b && ./scripts/run-instrumented-tests.sh`.
  <details><summary>the 9 (all in untouched classes)</summary>

  `ActiveFilterHeaderFlowTest` (3), `ManageCollectionsFlowTest.viewCollectionFromManageScreenAppliesTheChipAndSwitchesTab`, `PlayerConcurrencyFlowTest` (2), `VaultShareHiddenTest.audioCrossTaggedInPublicAndPrivateStillShowsShareOnMySounds`, `HomeTabFlowTest.shareButtonEmitsActionSendChooserIntent`, `HomeTabFlowTest.tapPlaySwapsPlayIconToPause`. Same set on my branch and on base — independent of this diff.
  </details>

### Already tested

- Instrumented (cold-boot wrapper, optimized emulator) — changed/added classes green: `SearchOverlayTest` 9/9, `VaultTabFlowTest` 7/7 (incl. the new locked-Vault search tests), `AboutScreenFlowTest` 14/14, and `HomeTabFlowTest`'s edited a11y test. CI does not run the instrumented suite.
