### PR TITLE
feat(import): + FAB opens import Hub bottom sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 ## \[unreleased] (v2.2.0)
 
 ### Added
+- A "+" button on My Bomps opens a sheet to bring in a new Bomp — pick any audio from your device and it becomes yours; recording your own is coming soon
 - A "Share Bomp" option in the top menu lets you recommend the app with a link, so the people you send it to can get it too
 
 ### Changed

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/HubImportFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/HubImportFlowTest.kt
@@ -47,7 +47,7 @@ internal class HubImportFlowTest : AbstractUiTest() {
     fun importRowLaunchesSystemAudioPicker() {
         // Stub the picker as cancelled — the design says a cancel returns the user silently to where
         // they were. We only assert the GetContent intent was fired with the audio MIME filter.
-        intending(hasAction(Intent.ACTION_GET_CONTENT))
+        intending(hasAction(Intent.ACTION_OPEN_DOCUMENT))
             .respondWith(Instrumentation.ActivityResult(Activity.RESULT_CANCELED, null))
 
         ActivityScenario.launch(LandingActivity::class.java).use {
@@ -55,7 +55,7 @@ internal class HubImportFlowTest : AbstractUiTest() {
             composeRule.awaitNodeWithText(importLabel()).performClick()
             composeRule.waitForIdle()
 
-            intended(hasAction(Intent.ACTION_GET_CONTENT))
+            intended(hasAction(Intent.ACTION_OPEN_DOCUMENT))
         }
     }
 
@@ -63,7 +63,7 @@ internal class HubImportFlowTest : AbstractUiTest() {
     fun pickingAnAudioLaunchesAddButtonActivity() {
         // Picker returns a content URI → the Hub forwards it to AddButtonActivity (Create). Stub both
         // hops so neither the system picker nor the Create screen actually open.
-        intending(hasAction(Intent.ACTION_GET_CONTENT))
+        intending(hasAction(Intent.ACTION_OPEN_DOCUMENT))
             .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, Intent().setData(PICKED_AUDIO)))
         intending(hasComponent(hasClassName(ADD_BUTTON_ACTIVITY)))
             .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, null))

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/HubImportFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/HubImportFlowTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home
+
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.Intents.intending
+import androidx.test.espresso.intent.matcher.ComponentNameMatchers.hasClassName
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.barriosnahuel.vossosunboton.AbstractUiTest
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithContentDescription
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithText
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * The + FAB → import Hub → system audio picker → AddButtonActivity chain (PR2). Each tappable thing
+ * added in this PR has a live destination; the picker and the onward launch are stubbed via
+ * Espresso-Intents so the suite never opens the real system picker or the heavy Create screen.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class HubImportFlowTest : AbstractUiTest() {
+    @Test
+    fun fabOpensImportHub() {
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            composeRule.awaitNodeWithContentDescription(fabLabel()).performClick()
+
+            composeRule.awaitNodeWithText(hubTitle()).assertIsDisplayed()
+            composeRule.awaitNodeWithText(importLabel()).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun importRowLaunchesSystemAudioPicker() {
+        // Stub the picker as cancelled — the design says a cancel returns the user silently to where
+        // they were. We only assert the GetContent intent was fired with the audio MIME filter.
+        intending(hasAction(Intent.ACTION_GET_CONTENT))
+            .respondWith(Instrumentation.ActivityResult(Activity.RESULT_CANCELED, null))
+
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            composeRule.awaitNodeWithContentDescription(fabLabel()).performClick()
+            composeRule.awaitNodeWithText(importLabel()).performClick()
+            composeRule.waitForIdle()
+
+            intended(hasAction(Intent.ACTION_GET_CONTENT))
+        }
+    }
+
+    @Test
+    fun pickingAnAudioLaunchesAddButtonActivity() {
+        // Picker returns a content URI → the Hub forwards it to AddButtonActivity (Create). Stub both
+        // hops so neither the system picker nor the Create screen actually open.
+        intending(hasAction(Intent.ACTION_GET_CONTENT))
+            .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, Intent().setData(PICKED_AUDIO)))
+        intending(hasComponent(hasClassName(ADD_BUTTON_ACTIVITY)))
+            .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, null))
+
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            composeRule.awaitNodeWithContentDescription(fabLabel()).performClick()
+            composeRule.awaitNodeWithText(importLabel()).performClick()
+            composeRule.waitForIdle()
+
+            intended(hasComponent(hasClassName(ADD_BUTTON_ACTIVITY)))
+        }
+    }
+
+    @Test
+    fun fabExposesA11yLabelAndClickAction() {
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            composeRule.awaitNodeWithContentDescription(fabLabel()).assertHasClickAction()
+        }
+    }
+
+    private fun fabLabel() = context.getString(R.string.app_hub_fab_description)
+
+    private fun hubTitle() = context.getString(R.string.app_hub_title)
+
+    private fun importLabel() = context.getString(R.string.app_hub_import)
+
+    companion object {
+        private val PICKED_AUDIO: Uri = Uri.parse("content://test/picked-audio.mp3")
+        private const val ADD_BUTTON_ACTIVITY =
+            "com.github.barriosnahuel.vossosunboton.feature.addbutton.AddButtonActivity"
+    }
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivity.kt
@@ -5,6 +5,7 @@
  */
 package com.github.barriosnahuel.vossosunboton.feature.addbutton
 
+import android.content.Context
 import android.content.Intent
 import android.graphics.Color
 import android.net.Uri
@@ -65,7 +66,10 @@ class AddButtonActivity : FragmentActivity() {
             finish()
             return
         }
-        launchCreateAddButtonMode(uri)
+        // Default to share: the manifest ACTION_SEND filter carries no source extra. The in-app
+        // import Hub sets SOURCE_IMPORT via createIntent so the funnel is attributed honestly.
+        val source = intent.getStringExtra(EXTRA_SOURCE) ?: SOURCE_SHARE
+        launchCreateAddButtonMode(uri, source)
     }
 
     private fun launchEditAddButtonMode(sound: Sound) {
@@ -82,23 +86,48 @@ class AddButtonActivity : FragmentActivity() {
         AnalyticsTrackerProvider.get(this).logScreen(CanonicalScreenName.EDIT_SOUND)
     }
 
-    private fun launchCreateAddButtonMode(uri: Uri) {
+    private fun launchCreateAddButtonMode(
+        uri: Uri,
+        source: String,
+    ) {
         setContent {
             AppTheme {
                 AddButtonScreen(
                     context = this,
                     mode = AddButtonMode.Create(uri),
+                    source = source,
                     onSaved = { finish() },
                     onNavigateUp = { finish() },
                 )
             }
         }
-        val extras = Bundle().apply { putString("source", SOURCE_SHARE) }
+        val extras = Bundle().apply { putString("source", source) }
         AnalyticsTrackerProvider.get(this).logScreen(CanonicalScreenName.ADD_SOUND, extras)
     }
 
     companion object {
-        /** Source param for `screen_view {add_sound}` and `sound_add`. Today every Create flow comes from share. */
+        /** Source param for `screen_view {add_sound}` and `sound_add`: the surface that opened Create. */
         const val SOURCE_SHARE = "share"
+        const val SOURCE_IMPORT = "import"
+
+        private const val EXTRA_SOURCE = "com.github.barriosnahuel.vossosunboton.extra.SOURCE"
+
+        /**
+         * Builds an explicit intent to start the Create flow from an audio [uri] the user picked
+         * in-app (the import Hub). [Intent.FLAG_GRANT_READ_URI_PERMISSION] + [Intent.setData]
+         * forward the SAF read grant to this Activity so the copy at save time can read the stream
+         * even if the launching screen is killed first. The URI still flows through the same inbound
+         * validator (`AddButtonFeature`) as the share-sheet path — see CLAUDE.md § Security boundaries.
+         */
+        fun createIntent(
+            context: Context,
+            uri: Uri,
+        ): Intent =
+            Intent(context, AddButtonActivity::class.java).apply {
+                data = uri
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                putExtra(Intent.EXTRA_STREAM, uri)
+                putExtra(EXTRA_SOURCE, SOURCE_IMPORT)
+            }
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
@@ -94,6 +94,9 @@ import kotlinx.coroutines.withContext
 fun AddButtonScreen(
     context: Context,
     mode: AddButtonMode,
+    // Surface that opened this Create flow, forwarded to the `sound_add` event. Defaults to share
+    // (the manifest ACTION_SEND path); the import Hub passes SOURCE_IMPORT. Ignored in Edit mode.
+    source: String = AddButtonActivity.SOURCE_SHARE,
     onSaved: (String) -> Unit,
     onNavigateUp: () -> Unit,
 ) {
@@ -203,7 +206,7 @@ fun AddButtonScreen(
                             ).await()
                     if (feedbackId == R.string.app_addbutton_feedback_saved_ok) {
                         stopActivePreviewPlayback()
-                        trackSoundAdd(context, trimmedName, tracker)
+                        trackSoundAdd(context, trimmedName, source, tracker)
                         saveOutcome = SaveOutcome.Success(trimmedName)
                     } else {
                         pendingErrorReason = mapFeedbackToReason(feedbackId)
@@ -515,12 +518,13 @@ private fun mapFeedbackToReason(
 private suspend fun trackSoundAdd(
     context: Context,
     trimmedName: String,
+    source: String,
     tracker: AnalyticsTracker,
 ) {
     val totalSounds = SoundsRepository(context).sounds.first().size
     tracker.log(
         AnalyticsEvent.SoundAdd(
-            source = AddButtonActivity.SOURCE_SHARE,
+            source = source,
             nameLength = trimmedName.length,
             nameWordCount = trimmedName.split(WORD_SPLIT_REGEX).count(),
             nameHitLimit = trimmedName.length == MAX_NAME_LENGTH,

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/ImportHubSheet.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/ImportHubSheet.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
+import kotlinx.coroutines.launch
+
+// Dim applied to the inert "Grabar" row's icon + text. Standard Material disabled opacity; a
+// disabled control is exempt from the WCAG 1.4.3 contrast minimum (§ Accessibility). The acid
+// "Pronto" badge stays at full strength so it reads as "coming", not "broken".
+private const val HUB_DISABLED_ALPHA = 0.38f
+private val HUB_ICON_TILE = 44.dp
+private val HUB_TILE_RADIUS = 12.dp
+
+/**
+ * The import Hub — a [ModalBottomSheet] opened by the + FAB on My Bomps. Two paths: a live
+ * "import audio from your device" row ([onImport]) and a visible-but-inert "record" row badged
+ * "Soon" (its destination is a later release; designing it now means enabling it later won't
+ * reshape the sheet). The "see how it works" row is intentionally absent until onboarding exists.
+ *
+ * Presentational only: the caller dismisses on [onImport]/[onDismiss] and owns the file picker.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ImportHubSheet(
+    onImport: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val scope = rememberCoroutineScope()
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surface,
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = Spacing.XL, vertical = Spacing.LG),
+            verticalArrangement = Arrangement.spacedBy(Spacing.SM),
+        ) {
+            Text(
+                text = stringResource(R.string.app_hub_title),
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = stringResource(R.string.app_hub_subtitle),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(Spacing.SM))
+            HubRow(
+                iconPainter = painterResource(R.drawable.app_ic_add),
+                title = stringResource(R.string.app_hub_import),
+                subtitle = stringResource(R.string.app_hub_import_sub),
+                tileColor = MaterialTheme.colorScheme.primaryContainer,
+                iconColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                // Animate the sheet closed before handing off, mirroring CollectionSheetHost /
+                // InlineCollectionCreateSheet — the host then clears state + launches the picker.
+                onClick = {
+                    scope.launch {
+                        sheetState.hide()
+                        onImport()
+                    }
+                },
+            )
+            HubRow(
+                iconPainter = painterResource(R.drawable.app_ic_mic),
+                title = stringResource(R.string.app_hub_record),
+                subtitle = stringResource(R.string.app_hub_record_sub),
+                tileColor = MaterialTheme.colorScheme.surfaceVariant,
+                iconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                badge = stringResource(R.string.app_hub_record_badge),
+                onClick = null,
+            )
+        }
+    }
+}
+
+@Composable
+private fun HubRow(
+    iconPainter: Painter,
+    title: String,
+    subtitle: String,
+    tileColor: Color,
+    iconColor: Color,
+    onClick: (() -> Unit)?,
+    badge: String? = null,
+) {
+    val enabled = onClick != null
+    val contentAlpha = if (enabled) 1f else HUB_DISABLED_ALPHA
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(HUB_TILE_RADIUS))
+                .then(
+                    if (enabled) {
+                        Modifier.clickable(onClick = onClick)
+                    } else {
+                        // Merge so the title/subtitle/badge form one node TalkBack announces as
+                        // disabled — a bare semantics{} wrapper would leave them separate and unmarked.
+                        Modifier.semantics(mergeDescendants = true) { disabled() }
+                    },
+                ).padding(vertical = Spacing.SM),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Spacing.MD),
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .size(HUB_ICON_TILE)
+                    .clip(RoundedCornerShape(HUB_TILE_RADIUS))
+                    .background(tileColor),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                painter = iconPainter,
+                contentDescription = null,
+                tint = iconColor.copy(alpha = contentAlpha),
+            )
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = contentAlpha),
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = contentAlpha),
+            )
+        }
+        if (badge != null) {
+            Text(
+                text = badge,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                modifier =
+                    Modifier
+                        .clip(RoundedCornerShape(percent = 50))
+                        .background(MaterialTheme.colorScheme.primaryContainer)
+                        .padding(horizontal = Spacing.MD, vertical = Spacing.XS),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/ImportHubSheet.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/ImportHubSheet.kt
@@ -91,8 +91,8 @@ internal fun ImportHubSheet(
                 subtitle = stringResource(R.string.app_hub_import_sub),
                 tileColor = MaterialTheme.colorScheme.primaryContainer,
                 iconColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                // Animate the sheet closed before handing off, mirroring CollectionSheetHost /
-                // InlineCollectionCreateSheet — the host then clears state + launches the picker.
+                // Animate the sheet closed before handing off, mirroring InlineCollectionCreateSheet
+                // (sheetState.hide() then the callback) — the host then clears state + launches the picker.
                 onClick = {
                     scope.launch {
                         sheetState.hide()

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -246,9 +246,13 @@ fun LandingScreen(viewModel: SoundsViewModel) {
 
     if (isHubVisible) {
         ImportHubSheet(
+            // Guard on isHubVisible so a double-tap on the import row (both taps land before the
+            // sheet's hide animation recomposes it away) launches the picker once, not twice.
             onImport = {
-                isHubVisible = false
-                importPicker.launch("audio/*")
+                if (isHubVisible) {
+                    isHubVisible = false
+                    importPicker.launch("audio/*")
+                }
             },
             onDismiss = { isHubVisible = false },
         )
@@ -692,7 +696,7 @@ private const val DELETE_ANIMATION_DURATION_MS = 300
 private val WELCOME_BORDER_WIDTH = 1.5.dp
 
 // Reserve room below the last card on My Bomps so it scrolls clear of the + FAB (56dp FAB + margin).
-// Other surfaces keep the default Spacing.SM — same mechanism the Vault tab uses for its ExtendedFAB.
+// Other surfaces keep the default Spacing.SM.
 private val FAB_LIST_BOTTOM_PADDING = 88.dp
 
 @Composable

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -116,12 +116,15 @@ fun LandingScreen(viewModel: SoundsViewModel) {
     // Import Hub open state. Saveable so an Activity recreate (rotation, theme, system kill) while
     // the sheet is open does not silently rewind the user back to the list (§ Stateful Composables).
     var isHubVisible by rememberSaveable { mutableStateOf(false) }
-    // System file picker for the Hub's "import audio" path. GetContent = import-a-copy: we copy the
-    // audio at save time, so transient read access is the right contract; cancel returns null → no-op,
-    // no message. The picked content URI reaches AddButtonActivity through the same inbound validator
-    // as the share sheet — AddButtonActivity.createIntent forwards the read grant to that Activity.
+    // System file picker for the Hub's "import audio" path. OpenDocument(arrayOf("audio/*")) opens the
+    // full SAF browser filtered to audio (non-audio files are not selectable) — better at surfacing
+    // on-device audio across OEMs than GetContent's "Recent" view. We copy the audio at save time, so we
+    // never take persistable permission; cancel returns null → no-op, no message. The picked content URI
+    // reaches AddButtonActivity through the same inbound validator as the share sheet — createIntent
+    // forwards the read grant to that Activity. (App-private media like WhatsApp voice notes is not
+    // browsable by any SAF picker on Android 11+; that content arrives via the share sheet instead.)
     val importPicker =
-        rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+        rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
             uri?.let { context.startActivity(AddButtonActivity.createIntent(context, it)) }
         }
 
@@ -251,7 +254,7 @@ fun LandingScreen(viewModel: SoundsViewModel) {
             onImport = {
                 if (isHubVisible) {
                     isHubVisible = false
-                    importPicker.launch("audio/*")
+                    importPicker.launch(arrayOf("audio/*"))
                 }
             },
             onDismiss = { isHubVisible = false },

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -8,6 +8,8 @@
 package com.github.barriosnahuel.vossosunboton.ui.home
 import android.content.Context
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.core.spring
@@ -26,6 +28,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -63,6 +66,7 @@ import com.github.barriosnahuel.vossosunboton.commons.android.analytics.Analytic
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsSource
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
+import com.github.barriosnahuel.vossosunboton.feature.addbutton.AddButtonActivity
 import com.github.barriosnahuel.vossosunboton.feature.addbutton.findFragmentActivity
 import com.github.barriosnahuel.vossosunboton.feature.share.ShareAppIntent
 import com.github.barriosnahuel.vossosunboton.feature.share.ShareFeature
@@ -108,6 +112,18 @@ fun LandingScreen(viewModel: SoundsViewModel) {
     // overlay survives an Activity recreate (rotation, theme, system kill); the host re-resolves
     // the Sound from `library` on the way back.
     var immersiveListenSoundId by rememberSaveable { mutableStateOf<String?>(null) }
+
+    // Import Hub open state. Saveable so an Activity recreate (rotation, theme, system kill) while
+    // the sheet is open does not silently rewind the user back to the list (§ Stateful Composables).
+    var isHubVisible by rememberSaveable { mutableStateOf(false) }
+    // System file picker for the Hub's "import audio" path. GetContent = import-a-copy: we copy the
+    // audio at save time, so transient read access is the right contract; cancel returns null → no-op,
+    // no message. The picked content URI reaches AddButtonActivity through the same inbound validator
+    // as the share sheet — AddButtonActivity.createIntent forwards the read grant to that Activity.
+    val importPicker =
+        rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+            uri?.let { context.startActivity(AddButtonActivity.createIntent(context, it)) }
+        }
 
     LaunchedEffect(selectedTab, isAboutVisible, manageRequest, isSearchVisible) {
         val name =
@@ -188,6 +204,7 @@ fun LandingScreen(viewModel: SoundsViewModel) {
             immersiveListenSoundId = sound.id
             if (!sound.isPlaying) viewModel.playOrStop(sound)
         },
+        onCreateClick = { isHubVisible = true },
     )
 
     // Exactly one sub-screen overlays the list at a time (About wins over Manage, preserving the
@@ -226,6 +243,16 @@ fun LandingScreen(viewModel: SoundsViewModel) {
 
     com.github.barriosnahuel.vossosunboton.feature.collections
         .CollectionDeleteDialog(viewModel = viewModel)
+
+    if (isHubVisible) {
+        ImportHubSheet(
+            onImport = {
+                isHubVisible = false
+                importPicker.launch("audio/*")
+            },
+            onDismiss = { isHubVisible = false },
+        )
+    }
 
     if (isSearchVisible) {
         SearchOverlayHost(
@@ -340,6 +367,7 @@ private fun ScaffoldedLanding(
     onManageCollectionsClick: () -> Unit,
     onActiveFilterEditClick: (String) -> Unit,
     onImmersivePlay: (Sound) -> Unit,
+    onCreateClick: () -> Unit,
 ) {
     Scaffold(
         modifier = modifier,
@@ -349,6 +377,22 @@ private fun ScaffoldedLanding(
                 onAboutClick = onAboutClick,
                 onManageCollectionsClick = onManageCollectionsClick,
             )
+        },
+        // FAB only on My Bomps (design "regla por tab"): Explore is a consumption surface and Vault's
+        // job is to listen — both stay FAB-less. The single + opens the import Hub.
+        floatingActionButton = {
+            if (selectedTab == AppTab.MY_SOUNDS) {
+                FloatingActionButton(
+                    onClick = onCreateClick,
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.app_ic_add),
+                        contentDescription = stringResource(R.string.app_hub_fab_description),
+                    )
+                }
+            }
         },
         bottomBar = {
             // Vault is always visible (spec § 2.1) — no `hasBundledSounds` gating. The Explore
@@ -647,6 +691,10 @@ private fun AppBottomBar(
 private const val DELETE_ANIMATION_DURATION_MS = 300
 private val WELCOME_BORDER_WIDTH = 1.5.dp
 
+// Reserve room below the last card on My Bomps so it scrolls clear of the + FAB (56dp FAB + margin).
+// Other surfaces keep the default Spacing.SM — same mechanism the Vault tab uses for its ExtendedFAB.
+private val FAB_LIST_BOTTOM_PADDING = 88.dp
+
 @Composable
 internal fun SoundsList(
     sounds: List<Sound>,
@@ -854,6 +902,7 @@ private fun MySoundsBody(
                     listState = listState,
                     collectionsByAudio = collectionsByAudio,
                     allCollections = allCollections,
+                    bottomContentPadding = if (isOnMySounds) FAB_LIST_BOTTOM_PADDING else Spacing.SM,
                     filterIsActive = selectedTab == AppTab.MY_SOUNDS && activeFilterId != null,
                     onPlayClick = { sound -> viewModel.playOrStop(sound) },
                     onSeek = { positionMs -> viewModel.seekTo(positionMs) },

--- a/app/src/main/res/drawable/app_ic_mic.xml
+++ b/app/src/main/res/drawable/app_ic_mic.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,14c1.66,0 2.99,-1.34 2.99,-3L15,5c0,-1.66 -1.34,-3 -3,-3S9,3.34 9,5v6c0,1.66 1.34,3 3,3zM17.3,11c0,3 -2.54,5.1 -5.3,5.1S6.7,14 6.7,11L5,11c0,3.41 2.72,6.23 6,6.72L11,21h2v-3.28c3.28,-0.48 6,-3.3 6,-6.72h-1.7z" />
+</vector>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -216,4 +216,14 @@
     <string name="app_addbutton_collections_private_unprotected_hint">Tus colecciones del Baúl aparecen acá porque este teléfono no tiene huella ni bloqueo de pantalla.</string>
     <string name="app_addbutton_collections_new_chip">+ Nueva colección</string>
     <string name="app_addbutton_collections_new_private_chip">+ Nuevo Baúl</string>
+
+    <!-- Import Hub (the + FAB on My Bomps opens this bottom sheet) -->
+    <string name="app_hub_fab_description">Sumar un Bomp</string>
+    <string name="app_hub_title">¿Cómo la sumás?</string>
+    <string name="app_hub_subtitle">Una voz se guarda y la tenés cerca, para escucharla cuando quieras.</string>
+    <string name="app_hub_import">Importar audio del dispositivo</string>
+    <string name="app_hub_import_sub">Notas de voz, grabaciones, lo que ya tengas guardado.</string>
+    <string name="app_hub_record">Grabar tu primer Bomp</string>
+    <string name="app_hub_record_sub">Apretá y hablá. Lo estamos cocinando.</string>
+    <string name="app_hub_record_badge">Pronto</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,4 +222,14 @@
     <string name="app_addbutton_collections_private_unprotected_hint">Your Vault shows up here because this device has no fingerprint or screen lock.</string>
     <string name="app_addbutton_collections_new_chip">+ New collection</string>
     <string name="app_addbutton_collections_new_private_chip">+ New in Vault</string>
+
+    <!-- Import Hub (the + FAB on My Bomps opens this bottom sheet) -->
+    <string name="app_hub_fab_description">Add a Bomp</string>
+    <string name="app_hub_title">How do you add one?</string>
+    <string name="app_hub_subtitle">A voice gets saved and stays close, ready whenever you want to hear it.</string>
+    <string name="app_hub_import">Import audio from your device</string>
+    <string name="app_hub_import_sub">Voice notes, recordings, whatever you already have saved.</string>
+    <string name="app_hub_record">Record your first Bomp</string>
+    <string name="app_hub_record_sub">Press and talk. We\'re cooking it up.</string>
+    <string name="app_hub_record_badge">Soon</string>
 </resources>

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivityIntentDispatchTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivityIntentDispatchTest.kt
@@ -129,6 +129,33 @@ internal class AddButtonActivityIntentDispatchTest : AbstractRobolectricTest() {
     }
 
     @Test
+    fun `import intent from the Hub logs add_sound with the import source`() {
+        // The in-app import Hub starts Create via AddButtonActivity.createIntent, which tags the
+        // intent SOURCE_IMPORT. The screen_view + sound_add funnel must attribute it to import, not
+        // the share-sheet default — otherwise FAB-driven imports are invisible against shares.
+        val activity = launch(AddButtonActivity.createIntent(context, SAMPLE_URI))
+
+        val addScreen =
+            fake.screens.lastOrNull { it.name == CanonicalScreenName.ADD_SOUND }
+                ?: error("createIntent did not log ADD_SOUND. Recorded: ${fake.screens.map { it.name }}")
+        assertThat(addScreen.extras["source"]).isEqualTo(AddButtonActivity.SOURCE_IMPORT)
+        assertThat(activity.intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java))
+            .isEqualTo(SAMPLE_URI)
+    }
+
+    @Test
+    fun `createIntent forwards a read grant for the picked URI`() {
+        // Security-load-bearing: the grant rides on the intent DATA (not an extra), so the same-app
+        // AddButtonActivity gets its own read permission for the SAF content URI. Dropping either the
+        // data assignment or the flag would still pass the source/EXTRA_STREAM tests but fail to read
+        // the audio on a real device.
+        val intent = AddButtonActivity.createIntent(context, SAMPLE_URI)
+
+        assertThat(intent.data).isEqualTo(SAMPLE_URI)
+        assertThat(intent.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION).isNotEqualTo(0)
+    }
+
+    @Test
     fun `malformed onNewIntent finishes the Activity even when a valid mode was alive`() {
         // Option A guard: the most recent intent always wins, including a malformed one. Without
         // this, a buggy share-receiver caller could leave the user stuck on a stale Edit screen

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenAnalyticsTest.kt
@@ -121,6 +121,21 @@ internal class AddButtonScreenAnalyticsTest : AbstractRobolectricTest() {
     }
 
     @Test
+    fun `saving a Bomp imported from the Hub tags sound_add with the import source`() {
+        // Create launched via AddButtonActivity.createIntent (the import Hub) must thread
+        // SOURCE_IMPORT all the way to the sound_add event, not fall back to the share default.
+        ActivityScenario.launch<AddButtonActivity>(AddButtonActivity.createIntent(context, SAMPLE_URI)).use {
+            composeTestRule.waitForIdle()
+            composeTestRule.onNode(hasSetTextAction()).performTextInput(NEW_NAME)
+            composeTestRule.onNodeWithText(context.getString(R.string.app_addbutton_save)).performClick()
+            composeTestRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) { fake.events.isNotEmpty() }
+
+            val event = fake.assertEmitted("sound_add")
+            assertThat(event.params["source"]).isEqualTo(AddButtonActivity.SOURCE_IMPORT)
+        }
+    }
+
+    @Test
     fun `renaming an existing button emits sound_edit and does not emit sound_add`() {
         ActivityScenario.launch<AddButtonActivity>(editIntent()).use {
             composeTestRule.waitForIdle()

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/ImportHubSheetTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/ImportHubSheetTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home
+
+import android.os.Build
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.robolectric.annotation.Config
+
+@Config(sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
+internal class ImportHubSheetTest : AbstractRobolectricTest() {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `hub shows title and the import row`() {
+        setHub()
+
+        composeTestRule.onNodeWithText("How do you add one?").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Import audio from your device").assertIsDisplayed()
+    }
+
+    @Test
+    fun `tapping the import row invokes onImport`() {
+        var imported = false
+        setHub(onImport = { imported = true })
+
+        composeTestRule.onNodeWithText("Import audio from your device").performClick()
+        composeTestRule.waitForIdle() // the row animates the sheet closed before invoking onImport
+
+        assertThat(imported).isTrue()
+    }
+
+    @Test
+    fun `record row is present, badged Soon, and disabled`() {
+        setHub()
+
+        composeTestRule.onNodeWithText("Record your first Bomp").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Soon").assertIsDisplayed()
+        // Inert by design: the merged row node carries the disabled semantic so TalkBack announces it.
+        composeTestRule.onNodeWithText("Record your first Bomp").assertIsNotEnabled()
+    }
+
+    @Test
+    fun `hub does not offer the see-how-it-works row yet`() {
+        // PR4 guard: the onboarding entry point ("Ver cómo funciona") only joins the Hub once
+        // onboarding exists. Until then it must not leak into this sheet.
+        setHub()
+
+        composeTestRule
+            .onNodeWithText("how it works", substring = true, ignoreCase = true)
+            .assertDoesNotExist()
+    }
+
+    private fun setHub(
+        onImport: () -> Unit = {},
+        onDismiss: () -> Unit = {},
+    ) {
+        composeTestRule.setContent {
+            AppTheme {
+                ImportHubSheet(onImport = onImport, onDismiss = onDismiss)
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
@@ -7,6 +7,7 @@ package com.github.barriosnahuel.vossosunboton.ui.home
 
 import android.os.Build
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -107,6 +108,75 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
 
         composeTestRule.onNodeWithContentDescription("More options").performClick()
         composeTestRule.onNodeWithText("Share Bomp").assertIsDisplayed()
+    }
+
+    @Test
+    fun `add-a-Bomp FAB is shown on My Bomps`() {
+        val viewModel = givenAViewModel()
+
+        composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithContentDescription("Add a Bomp").assertIsDisplayed()
+    }
+
+    @Test
+    fun `add-a-Bomp FAB is hidden on the Vault tab`() {
+        val viewModel = givenAViewModel()
+
+        composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
+        composeTestRule.waitForIdle()
+        viewModel.selectTab(AppTab.VAULT)
+        composeTestRule.waitForIdle()
+
+        // Vault's job is to listen — it stays FAB-less (design "regla por tab").
+        composeTestRule.onNodeWithContentDescription("Add a Bomp").assertDoesNotExist()
+    }
+
+    @Test
+    fun `add-a-Bomp FAB is hidden on the Explore tab`() {
+        val viewModel = givenAViewModel()
+
+        composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
+        composeTestRule.waitForIdle()
+        viewModel.injectHasBundledSounds(true)
+        composeTestRule.waitForIdle()
+        viewModel.selectTab(AppTab.EXPLORE_SOUNDS)
+        composeTestRule.waitForIdle()
+
+        // Explore is a consumption surface — no create affordance there.
+        composeTestRule.onNodeWithContentDescription("Add a Bomp").assertDoesNotExist()
+    }
+
+    @Test
+    fun `tapping the FAB opens the import Hub`() {
+        val viewModel = givenAViewModel()
+
+        composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithContentDescription("Add a Bomp").performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("How do you add one?").assertIsDisplayed()
+    }
+
+    @Test
+    fun `open import Hub survives an Activity recreate`() {
+        // § Stateful Composables: an opened sheet is durable progress — a recreate (rotation, theme,
+        // system kill) must not silently rewind the user back to the list. `isHubVisible` is
+        // rememberSaveable; StateRestorationTester emulates the save/restore round-trip.
+        val viewModel = givenAViewModel()
+        val restorationTester = StateRestorationTester(composeTestRule)
+        restorationTester.setContent { AppTheme { LandingScreen(viewModel) } }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithContentDescription("Add a Bomp").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("How do you add one?").assertIsDisplayed()
+
+        restorationTester.emulateSavedInstanceStateRestore()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("How do you add one?").assertIsDisplayed()
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
### Summary

Bringing a Bomp in used to mean sharing an audio *into* the app from somewhere else — there was no in-app way to create one (PR1 deliberately left the FAB slot empty).

1. User is on My Bomps.
2. Taps the new lime **"+"** button.
3. Picks **"Import audio from your device"** and chooses an audio.

**before:** the only path to add a Bomp was the system share sheet from another app.
**after:** the "+" opens a sheet to bring in any audio from the device; recording your own is shown as coming soon.

### Technical detail

Reintroduces the FAB (deferred by PR1) and gives it a live destination — the import Hub. Every tappable thing added has a real destination in this PR ("0 botones muertos").

- **`ImportHubSheet.kt`** (new): `ModalBottomSheet`, two rows — import (live) and a disabled "record" row badged "Soon"; mirrors `InlineCollectionCreateSheet`. The "see how it works" row is intentionally **absent** (joins in PR4 with onboarding).
- **`LandingScreen.kt`**: FAB on My Bomps only (design *regla por tab* — Explore/Vault stay FAB-less); `OpenDocument(arrayOf("audio/*"))` picker launcher (full SAF browser, audio-filtered); `rememberSaveable` hub-open state; list bottom-padding bump so the last card clears the FAB.
- **`AddButtonActivity.createIntent`**: explicit intent with `data` + `FLAG_GRANT_READ_URI_PERMISSION` to forward the SAF read grant; new `EXTRA_SOURCE`. The picked URI flows through the **same** inbound validator as the share sheet (scheme/MIME/size) — no new validator.
- **Analytics**: `source` threaded Activity → Screen → `sound_add` (`import` vs the preserved `share` default).
- **Strings** `app_hub_*` (EN master + es-AR); `app_ic_mic` drawable.
- **Out of scope** (later PRs): empty-state CTA (PR3), onboarding row (PR4), granular import-error copy.

```mermaid
sequenceDiagram
  actor U as User
  U->>LandingScreen: tap + FAB
  LandingScreen->>ImportHubSheet: open (rememberSaveable)
  U->>ImportHubSheet: tap Import
  ImportHubSheet->>System: GetContent("audio/*")
  System-->>LandingScreen: content URI (or null → no-op)
  LandingScreen->>AddButtonActivity: createIntent(uri) + read grant
  AddButtonActivity->>AddButtonFeature: validate scheme/MIME/size
```

### Code review tips

- **URI grant is security-load-bearing**: the read grant rides on intent `data` (an extra alone would not forward it) + `FLAG_GRANT_READ_URI_PERMISSION`; pinned by a unit test — dropping `data = uri` would pass every other test but break real-device reads.
- Picker is `OpenDocument(arrayOf("audio/*"))` — full SAF file browser filtered to audio (non-audio not selectable), better cross-OEM at surfacing on-device audio than `GetContent`'s "Recent" view. We copy at save time so we never take persistable permission; SAF needs no runtime permission. App-private media (e.g. WhatsApp voice notes) is unreachable by any SAF picker on Android 11+ — that content arrives via the existing share-sheet (`ACTION_SEND`) path.
- **9 instrumented failures are pre-existing / degraded-AVD, not from this PR** — `ComposeTimeoutException` / "Failed to inject touch input" in `PlayerConcurrencyFlowTest`, `VaultShareHiddenTest`, `ActiveFilterHeaderFlowTest`, `ManageCollectionsFlowTest`, `HomeTabFlowTest` (subsystems this diff doesn't touch). Verified identical on base: `git checkout develop (2d011a8) && ./scripts/run-instrumented-tests.sh` → same 9.
- **Manual verification suggested** (device-only, not headless-testable): FAB ↔ last-card no overlap; `sound_add {source=import}` in Firebase DebugView (aggregated Reports lag 24–48 h).

### Already tested

- Unit + Robolectric (CI also runs these): new `ImportHubSheetTest` (4); `LandingScreenTest` FAB-per-tab + open-Hub + `StateRestorationTester` recreate (+5); `source=import` attribution in `AddButtonActivityIntentDispatchTest` (+2) and `AddButtonScreenAnalyticsTest` (+1) — all green.
- instrumented (not in CI): `./scripts/run-instrumented-tests.sh` cold boot — **4/4 new `HubImportFlowTest` green**; the 9 unrelated reds verified pre-existing on base (see Code review tips).
