### PR TITLE
feat(home): Import CTA on the empty My Bomps state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Audios you share now arrive ready to play inline in more chat apps, instead of as a file the other person has to download first
 - Sharing an audio now adds a short, warm invite and a link, so whoever receives it can have Bomp too
 - The app opens faster in the first launches after installing or updating — the entry screen's startup code is now precompiled, so it reaches interactive sooner, most noticeably on lower-tier devices
+- When your audio list is empty, the screen now offers an Import button that opens the add-a-Bomp sheet right there, so adding your first voice is one tap away
 
 ### For nerds 🤓
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -386,9 +386,18 @@ private fun ScaffoldedLanding(
             )
         },
         // FAB only on My Bomps (design "regla por tab"): Explore is a consumption surface and Vault's
-        // job is to listen — both stay FAB-less. The single + opens the import Hub.
+        // job is to listen — both stay FAB-less. The single + opens the import Hub. Suppressed in the
+        // welcome-empty state, where MySoundsEmptyState carries the one "Import" CTA instead — a single
+        // imperative, not two routes to the same Hub.
         floatingActionButton = {
-            if (selectedTab == AppTab.MY_SOUNDS) {
+            // Mirror MySoundsBody's `showWelcomeEmptyState` exactly so the FAB and the inline CTA are
+            // never both shown: welcome-empty = My Bomps, no audios, and no *resolvable* active filter
+            // (an unresolved/stale filter id collapses to the welcome-empty state, not the filter one).
+            val showsWelcomeEmpty =
+                selectedTab == AppTab.MY_SOUNDS &&
+                    sounds.isEmpty() &&
+                    !(activeFilter != null && publicCollections.any { it.id == activeFilter })
+            if (selectedTab == AppTab.MY_SOUNDS && !showsWelcomeEmpty) {
                 FloatingActionButton(
                     onClick = onCreateClick,
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
@@ -443,6 +452,7 @@ private fun ScaffoldedLanding(
                     collectionsByAudio = collectionsByAudio,
                     allCollections = collections,
                     onActiveFilterEditClick = onActiveFilterEditClick,
+                    onImportClick = onCreateClick,
                     viewModel = viewModel,
                     context = context,
                 )
@@ -857,6 +867,7 @@ private fun MySoundsBody(
     collectionsByAudio: Map<String, List<String>>,
     allCollections: List<com.github.barriosnahuel.vossosunboton.model.Collection>,
     onActiveFilterEditClick: (String) -> Unit,
+    onImportClick: () -> Unit,
     viewModel: SoundsViewModel,
     context: Context,
 ) {
@@ -899,7 +910,10 @@ private fun MySoundsBody(
             showFilterEmptyState && activeCollection != null ->
                 MySoundsFilterEmptyState(collectionName = activeCollection.name)
             showWelcomeEmptyState ->
-                MySoundsEmptyState()
+                // weight(1f) so the centered group fills the space *below* the chips row, not the
+                // full viewport — without it the empty state's fillMaxSize requests the whole height
+                // (Column gives non-weighted children the full max), pushing the CTA below the fold.
+                MySoundsEmptyState(onImportClick = onImportClick, modifier = Modifier.weight(1f))
             else ->
                 SoundsList(
                     sounds = sounds,

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -390,12 +390,12 @@ private fun ScaffoldedLanding(
         // welcome-empty state, where MySoundsEmptyState carries the one "Import" CTA instead — a single
         // imperative, not two routes to the same Hub.
         floatingActionButton = {
-            // Mirror MySoundsBody's `showWelcomeEmptyState` exactly so the FAB and the inline CTA are
-            // never both shown: welcome-empty = My Bomps, no audios, and no *resolvable* active filter
-            // (an unresolved/stale filter id collapses to the welcome-empty state, not the filter one).
+            // Mirror MySoundsBody's `showWelcomeEmptyState` so the FAB and the inline CTA are never
+            // both shown: the list is welcome-empty when there are no audios and no *resolvable*
+            // active filter (an unresolved/stale filter id collapses to the welcome-empty state, not
+            // the filter one). The MY_SOUNDS guard below scopes it to that tab.
             val showsWelcomeEmpty =
-                selectedTab == AppTab.MY_SOUNDS &&
-                    sounds.isEmpty() &&
+                sounds.isEmpty() &&
                     !(activeFilter != null && publicCollections.any { it.id == activeFilter })
             if (selectedTab == AppTab.MY_SOUNDS && !showsWelcomeEmpty) {
                 FloatingActionButton(

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/MySoundsEmptyState.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/MySoundsEmptyState.kt
@@ -14,6 +14,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -31,17 +35,25 @@ import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
 /**
  * Heart-first empty state for MY_SOUNDS. Renders only when the user has no custom sounds AND the
  * welcome sticker has been consumed (so the list is genuinely empty). Continues the voice from
- * the welcome audio: keep close the voices that matter, hear them whenever you want. Absent on
- * purpose: any imperative CTA — the FAB does the asking, the copy paints the room.
+ * the welcome audio: keep close the voices that matter, hear them whenever you want. Owns the one
+ * import imperative for this state — [onImportClick] opens the same add-a-Bomp Hub as the FAB,
+ * which the host suppresses here so there is exactly one call to action.
  */
 @Composable
-internal fun MySoundsEmptyState(modifier: Modifier = Modifier) {
+internal fun MySoundsEmptyState(
+    onImportClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     val rippleColor = MaterialTheme.colorScheme.primary
 
     Column(
         modifier =
             modifier
                 .fillMaxSize()
+                // Scrollable so the CTA stays reachable when the centered group is taller than the
+                // space left below the chips row (short screens / large font scale) — without it the
+                // button clips below the fold.
+                .verticalScroll(rememberScrollState())
                 .padding(horizontal = Spacing.XXL),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
@@ -89,6 +101,19 @@ internal fun MySoundsEmptyState(modifier: Modifier = Modifier) {
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.fillMaxWidth(),
         )
+        Spacer(Modifier.height(Spacing.XL))
+        // Filled-primary tier (ADR 0010): the single main action of an otherwise empty screen.
+        // Opens the import Hub — the same destination the FAB carries when the list is non-empty.
+        Button(
+            onClick = onImportClick,
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                ),
+        ) {
+            Text(text = stringResource(R.string.app_my_sounds_empty_cta))
+        }
     }
 }
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/MySoundsEmptyState.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/MySoundsEmptyState.kt
@@ -7,11 +7,13 @@ package com.github.barriosnahuel.vossosunboton.ui.home
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -46,73 +48,78 @@ internal fun MySoundsEmptyState(
 ) {
     val rippleColor = MaterialTheme.colorScheme.primary
 
-    Column(
-        modifier =
-            modifier
-                .fillMaxSize()
-                // Scrollable so the CTA stays reachable when the centered group is taller than the
-                // space left below the chips row (short screens / large font scale) — without it the
-                // button clips below the fold.
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = Spacing.XXL),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-    ) {
-        // Concentric ripples — a voice resonating into a quiet room. Alphas descend from inner
-        // to outer so the eye anchors on the pulse and reads outward as a fade.
-        Canvas(modifier = Modifier.size(RIPPLE_SIZE)) {
-            val center = Offset(size.width / 2f, size.height / 2f)
-            val strokePx = RIPPLE_STROKE.toPx()
-            drawCircle(
-                color = rippleColor.copy(alpha = INNER_RIPPLE_ALPHA),
-                radius = INNER_RIPPLE_RADIUS.toPx(),
-                center = center,
-                style = Stroke(strokePx),
-            )
-            drawCircle(
-                color = rippleColor.copy(alpha = MID_RIPPLE_ALPHA),
-                radius = MID_RIPPLE_RADIUS.toPx(),
-                center = center,
-                style = Stroke(strokePx),
-            )
-            drawCircle(
-                color = rippleColor.copy(alpha = OUTER_RIPPLE_ALPHA),
-                radius = OUTER_RIPPLE_RADIUS.toPx(),
-                center = center,
-                style = Stroke(strokePx),
-            )
-        }
-        Spacer(Modifier.height(Spacing.XL))
-        Text(
-            text = stringResource(R.string.app_my_sounds_empty_headline),
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.SemiBold,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        Spacer(Modifier.height(Spacing.MD))
-        Text(
-            text = stringResource(R.string.app_my_sounds_empty_body),
-            style = MaterialTheme.typography.bodyMedium,
-            textAlign = TextAlign.Center,
-            // `onSurfaceVariant` is the M3 role for secondary body text and is validated by
-            // `AppThemeContrastTest` to meet WCAG AA. An alpha-modified `onSurface` would push
-            // light-mode contrast below 4.5:1 for normal-size text — outside the audit's reach.
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        Spacer(Modifier.height(Spacing.XL))
-        // Filled-primary tier (ADR 0010): the single main action of an otherwise empty screen.
-        // Opens the import Hub — the same destination the FAB carries when the list is non-empty.
-        Button(
-            onClick = onImportClick,
-            colors =
-                ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                ),
+    // heightIn(min = maxHeight) keeps the group vertically centered while it fits the viewport (the
+    // common case — "the copy paints the room"), and lets the Column grow past it so verticalScroll
+    // makes the CTA reachable when it doesn't fit (short screen / large font scale). Plain
+    // fillMaxSize + verticalScroll would defeat Arrangement.Center (scroll measures content with
+    // unbounded height, leaving no free space to distribute) and top-align the group.
+    BoxWithConstraints(modifier = modifier.fillMaxSize()) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .heightIn(min = maxHeight)
+                    .padding(horizontal = Spacing.XXL),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
         ) {
-            Text(text = stringResource(R.string.app_my_sounds_empty_cta))
+            // Concentric ripples — a voice resonating into a quiet room. Alphas descend from inner
+            // to outer so the eye anchors on the pulse and reads outward as a fade.
+            Canvas(modifier = Modifier.size(RIPPLE_SIZE)) {
+                val center = Offset(size.width / 2f, size.height / 2f)
+                val strokePx = RIPPLE_STROKE.toPx()
+                drawCircle(
+                    color = rippleColor.copy(alpha = INNER_RIPPLE_ALPHA),
+                    radius = INNER_RIPPLE_RADIUS.toPx(),
+                    center = center,
+                    style = Stroke(strokePx),
+                )
+                drawCircle(
+                    color = rippleColor.copy(alpha = MID_RIPPLE_ALPHA),
+                    radius = MID_RIPPLE_RADIUS.toPx(),
+                    center = center,
+                    style = Stroke(strokePx),
+                )
+                drawCircle(
+                    color = rippleColor.copy(alpha = OUTER_RIPPLE_ALPHA),
+                    radius = OUTER_RIPPLE_RADIUS.toPx(),
+                    center = center,
+                    style = Stroke(strokePx),
+                )
+            }
+            Spacer(Modifier.height(Spacing.XL))
+            Text(
+                text = stringResource(R.string.app_my_sounds_empty_headline),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(Modifier.height(Spacing.MD))
+            Text(
+                text = stringResource(R.string.app_my_sounds_empty_body),
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center,
+                // `onSurfaceVariant` is the M3 role for secondary body text and is validated by
+                // `AppThemeContrastTest` to meet WCAG AA. An alpha-modified `onSurface` would push
+                // light-mode contrast below 4.5:1 for normal-size text — outside the audit's reach.
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(Modifier.height(Spacing.XL))
+            // Filled-primary tier (ADR 0010): the single main action of an otherwise empty screen.
+            // Opens the import Hub — the same destination the FAB carries when the list is non-empty.
+            Button(
+                onClick = onImportClick,
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    ),
+            ) {
+                Text(text = stringResource(R.string.app_my_sounds_empty_cta))
+            }
         }
     }
 }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -90,6 +90,7 @@
     <!-- Mis audios — empty state (welcome consumido, sin Bomps propios todavía) -->
     <string name="app_my_sounds_empty_headline">Acá viven las voces que te importan.</string>
     <string name="app_my_sounds_empty_body">Una risa, un \"feliz cumple\", el \"estoy llegando\" del que querés. Compartí cualquier audio desde WhatsApp, Telegram o donde sea — se queda guardado y lo escuchás cuando quieras.</string>
+    <string name="app_my_sounds_empty_cta">Importar</string>
 
     <!-- Sticker Cero (variante de bienvenida, fresh install) -->
     <string name="app_welcome_sticker_title">Tu primer audio-abrazo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,6 +96,7 @@
     <!-- My Sounds empty state (welcome consumed, no custom sounds yet) -->
     <string name="app_my_sounds_empty_headline">This is where the voices live.</string>
     <string name="app_my_sounds_empty_body">A laugh, a "happy birthday", an "on my way" from someone who matters. Share any voice note from WhatsApp, Telegram, or wherever — it\'ll wait right here, ready when you are.</string>
+    <string name="app_my_sounds_empty_cta">Import</string>
 
     <!-- Welcome sticker (Sticker Cero, fresh-install variant) -->
     <string name="app_welcome_sticker_title">Your first voice-hug</string>

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
@@ -179,6 +180,50 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
         composeTestRule.onNodeWithText("How do you add one?").assertIsDisplayed()
     }
 
+    @Test
+    fun `empty My Bomps hides the FAB and shows the Import CTA instead`() {
+        val viewModel = givenAViewModel()
+
+        composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
+        composeTestRule.waitForIdle()
+        viewModel.injectSounds(emptyList())
+        composeTestRule.waitForIdle()
+
+        // Welcome-empty state owns the single imperative: the inline "Import" CTA, not the FAB
+        // (design "estado vacío": fab=null + CTA Importar).
+        composeTestRule.onNodeWithContentDescription("Add a Bomp").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Import").performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun `non-empty My Bomps shows the FAB and no inline Import CTA`() {
+        // Reverse of the empty-state swap: with audios present (a fresh install seeds the welcome
+        // sticker, so the list is non-empty), the FAB is the create affordance and the empty-state
+        // CTA must not appear.
+        val viewModel = givenAViewModel()
+
+        composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithContentDescription("Add a Bomp").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Import").assertDoesNotExist()
+    }
+
+    @Test
+    fun `tapping the empty-state Import CTA opens the import Hub`() {
+        val viewModel = givenAViewModel()
+
+        composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
+        composeTestRule.waitForIdle()
+        viewModel.injectSounds(emptyList())
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Import").performScrollTo().performClick()
+        composeTestRule.waitForIdle()
+
+        // Same destination the FAB carries (design: "mismo sheet desde el CTA del estado vacío").
+        composeTestRule.onNodeWithText("How do you add one?").assertIsDisplayed()
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun givenAViewModel(): SoundsViewModel {
         val vm =
@@ -210,6 +255,17 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
             .getDeclaredField("allSoundsCache")
             .also { it.isAccessible = true }
             // Safe: allSoundsCache is always MutableStateFlow<List<Sound>> — type parameter erased at runtime
+            .let { (it.get(this) as MutableStateFlow<List<Sound>>).value = value }
+    }
+
+    // Drives the rendered list (`_sounds`) directly. A fresh install seeds it with the welcome
+    // sticker, so emptying it is the only way to reach the welcome-empty state once init's load
+    // has settled (inject AFTER waitForIdle, same cascade reasoning as injectLibrary).
+    private fun SoundsViewModel.injectSounds(value: List<Sound>) {
+        SoundsViewModel::class.java
+            .getDeclaredField("_sounds")
+            .also { it.isAccessible = true }
+            // Safe: _sounds is always MutableStateFlow<List<Sound>> — type parameter erased at runtime
             .let { (it.get(this) as MutableStateFlow<List<Sound>>).value = value }
     }
 }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/MySoundsEmptyStateTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/MySoundsEmptyStateTest.kt
@@ -7,12 +7,15 @@ package com.github.barriosnahuel.vossosunboton.ui.home
 
 import android.os.Build
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.R
+import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.robolectric.annotation.Config
@@ -29,10 +32,27 @@ internal class MySoundsEmptyStateTest : AbstractRobolectricTest() {
         val body = context.getString(R.string.app_my_sounds_empty_body)
 
         composeTestRule.setContent {
-            MaterialTheme { MySoundsEmptyState() }
+            MaterialTheme { MySoundsEmptyState(onImportClick = {}) }
         }
 
         composeTestRule.onNodeWithText(headline).assertIsDisplayed()
         composeTestRule.onNodeWithText(body).assertIsDisplayed()
+    }
+
+    @Test
+    fun `MySoundsEmptyState Import CTA invokes the callback when tapped`() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val cta = context.getString(R.string.app_my_sounds_empty_cta)
+        var imports = 0
+
+        composeTestRule.setContent {
+            MaterialTheme { MySoundsEmptyState(onImportClick = { imports++ }) }
+        }
+
+        composeTestRule.onNodeWithText(cta).assertIsDisplayed()
+        composeTestRule.onNodeWithText(cta).assertHasClickAction()
+        composeTestRule.onNodeWithText(cta).performClick()
+
+        assertThat(imports).isEqualTo(1)
     }
 }


### PR DESCRIPTION
### Summary
1. User opens Bomp with My Bomps empty — no audios yet (e.g. the welcome audio was deleted)

**before:** the empty screen showed only the ripple illustration and copy; the floating "+" was the only way to add an audio.
**after:** an "Import" button sits in the empty screen and opens the same add-a-Bomp sheet; the "+" steps aside there, so there's one clear next step.

### Technical detail
Adds the empty-state import CTA and routes FAB-vs-CTA by state so only one ever shows.
- **`MySoundsEmptyState`** — new filled-primary "Import" CTA (ADR 0010, `primaryContainer`/`onPrimaryContainer`) → opens the existing import Hub. Wrapped in `BoxWithConstraints` + `heightIn(min = maxHeight)` + `verticalScroll` so the group stays vertically centered when it fits and scrolls (CTA reachable) only on short screens / large font scale.
- **`LandingScreen`** — threads the Hub-opening callback to the empty state; FAB suppressed exactly when the welcome-empty state renders (predicate mirrors `MySoundsBody.showWelcomeEmptyState`, incl. an unresolved/stale active filter) so the FAB and CTA are never both shown.
- **Strings** — `app_my_sounds_empty_cta` (en "Import" / es-AR "Importar").
- **Out of scope** — the first-run nudge and the secondary "Ver cómo funciona" (PR4). See Code review tips.

### Code review tips
- **FAB ↔ CTA mutual exclusion** is the delicate spot: the FAB-suppression predicate in `LandingScreen` must stay in lockstep with `MySoundsBody.showWelcomeEmptyState`. A self-review caught a stale-filter divergence (active filter id → deleted collection) where both could show; fixed by mirroring the exact predicate.
- **Interpretation (conservative scope):** PR3's "Nuevo" line is "welcome + CTA Importar → Hub". I implemented that and hid the FAB in the empty state (design mock `fab={null}`). I **deferred the first-run nudge** ("Sumá la primera voz tuya"): it is not in the PR3 "Nuevo" line and it competes with the existing welcome swipe-hint nudge on the same first-run screen — a product-priority call for you.
- **Baseline Profile** not regenerated: the CTA lives in the empty-state composable (not the warm-start first frame) and adds no new startup classes.
- Manual check (device-only): on a very short screen / max font scale, confirm the CTA scrolls into reach.
- **Code-review pass** (high-effort) ran on this branch; fixed a centering regression it caught (scroll + `Arrangement.Center` top-aligned the group) and a duplicated tab check. **Deliberately deferred (non-blocking):** (1) the welcome-empty predicate is derived in two spots (FAB site + `MySoundsBody`) kept in sync by comment + guarded by the two new FAB/CTA tests — a single-source lift is a follow-up; (2) the committed Baseline Profile has a now-dead `MySoundsEmptyState` entry (signature gained `onImportClick`) — non-hot path, regenerate when convenient (slower first render at worst, never broken).

### Already tested
- **Instrumented (not in CI — ADR 0001):** ran twice via the cold-boot wrapper; the AVD degraded on this host (~14 min/run) and flaked **9/116 each run — a *different* 9 each time**, all infra signatures (`ComposeTimeoutException` / "Failed to inject touch input"), none in the changed code. `HubImportFlowTest` (the import-Hub instrumented flow, closest to this change) **passed both runs**. **Not a clean green — please re-run on a healthy AVD before merge-relying on it.** Unit + detekt/ktlint/spotless/Android-Lint are green and covered by CircleCI.
