### PR TITLE
test: resolve and silence deprecation/quality warnings in unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 #### Changed
 - Scroll benchmark now seeds a controlled corpus and runs across three list sizes (20 / 50 / 200) so the sound-list frame timing exposes whether scroll jank scales with item count
 - The instrumented UI test wrapper now cold-boots the emulator with host-GPU rendering and widened CPU/RAM (`-gpu host -cores 6 -memory 4096`, env-overridable), so the suite runs faster and less flaky than on the software-rendered AVD defaults
+- Migrated unit tests off deprecated JDK/Kotlin APIs — `Locale.of(...)` replaces the deprecated `Locale(...)` constructor, and a redundant non-null assertion was removed
+- Acknowledged the test-only warnings that have no supported replacement — opt-in annotations for the experimental coroutine-test dispatcher and `@Suppress` for the reflection unchecked-casts and the deprecated-in-4.16.1 Robolectric resolve-info setter, consistent with the existing test-suite convention
 
 ## \[v2.1.0] - 2026-05-25
 

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerTest.kt
@@ -21,6 +21,7 @@ import io.mockk.verify
 import io.mockk.verifyOrder
 import io.mockk.verifySequence
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.After
@@ -531,6 +532,7 @@ internal class PlayerControllerTest : AbstractRobolectricTest() {
      * before the test method moves to its `verify {}` block. UnconfinedTestDispatcher resumes the
      * continuation on the calling thread, so withContext(ioDispatcher) does not actually schedule.
      */
+    @OptIn(ExperimentalCoroutinesApi::class)
     private fun controllerForTest(mp: MediaPlayer): PlayerControllerImpl {
         val dispatcher = UnconfinedTestDispatcher()
         return PlayerControllerImpl(

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreenTest.kt
@@ -162,7 +162,7 @@ internal class ImmersiveListenScreenTest : AbstractRobolectricTest() {
         // Released near the right edge → a fraction well into the second half of the clip.
         assertThat(seeked).isNotNull()
         assertThat(seeked!!).isAtLeast(0.5f)
-        assertThat(seeked!!).isAtMost(1f)
+        assertThat(seeked).isAtMost(1f)
     }
 
     @Test

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/security/ScreenLockSettingsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/security/ScreenLockSettingsTest.kt
@@ -9,6 +9,7 @@ import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.pm.ActivityInfo
+import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
@@ -37,7 +38,7 @@ internal class ScreenLockSettingsTest : AbstractRobolectricTest() {
 
     @Test
     fun `isAvailable is true when an activity resolves the intent`() {
-        shadowOf(context.packageManager).addResolveInfoForIntent(ScreenLockSettings.intent(), settingsResolveInfo())
+        context.packageManager.registerSettingsResolver()
 
         assertThat(ScreenLockSettings.isAvailable(context)).isTrue()
     }
@@ -50,7 +51,7 @@ internal class ScreenLockSettingsTest : AbstractRobolectricTest() {
     @Test
     fun `open launches the set-new-password screen`() {
         val activity = Robolectric.buildActivity(Activity::class.java).create().get()
-        shadowOf(activity.packageManager).addResolveInfoForIntent(ScreenLockSettings.intent(), settingsResolveInfo())
+        activity.packageManager.registerSettingsResolver()
 
         val launched = ScreenLockSettings.open(activity)
 
@@ -70,6 +71,12 @@ internal class ScreenLockSettingsTest : AbstractRobolectricTest() {
         assertThat(launched).isFalse()
         verify(exactly = 1) { Tracker.track(any()) }
     }
+
+    // Robolectric 4.16.1 deprecated every ShadowPackageManager resolve-info setter with no lightweight
+    // replacement; the installPackage-based alternative would rewrite this boundary test's setup.
+    @Suppress("DEPRECATION")
+    private fun PackageManager.registerSettingsResolver() =
+        shadowOf(this).addResolveInfoForIntent(ScreenLockSettings.intent(), settingsResolveInfo())
 
     private fun settingsResolveInfo() =
         ResolveInfo().apply {

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenTest.kt
@@ -268,7 +268,7 @@ internal class AboutScreenTest : AbstractRobolectricTest() {
 
     @Test
     fun `cafecito button is displayed when locale country is AR`() {
-        Locale.setDefault(Locale("es", "AR"))
+        Locale.setDefault(Locale.of("es", "AR"))
         launch()
         composeTestRule
             .onNodeWithText(context.getString(R.string.app_about_gratitude_cafecito_button))
@@ -298,7 +298,7 @@ internal class AboutScreenTest : AbstractRobolectricTest() {
 
     @Test
     fun `tap on cafecito emits about_gratitude_cafecito_open after intent succeeds`() {
-        Locale.setDefault(Locale("es", "AR"))
+        Locale.setDefault(Locale.of("es", "AR"))
         launch()
         composeTestRule
             .onNodeWithText(context.getString(R.string.app_about_gratitude_cafecito_button))

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/DurationFormatterTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/DurationFormatterTest.kt
@@ -34,9 +34,9 @@ internal class DurationFormatterTest {
     @Test
     fun `fullDate is uppercase and carries day and year regardless of locale`() {
         val epoch = epochOf(2024, Calendar.DECEMBER, 24)
-        val formatted = fullDate(epoch, Locale("es", "AR"))
+        val formatted = fullDate(epoch, Locale.of("es", "AR"))
         // Month abbreviation text varies by JVM locale data, so assert structure, not exact MMM.
-        assertThat(formatted).isEqualTo(formatted.uppercase(Locale("es", "AR")))
+        assertThat(formatted).isEqualTo(formatted.uppercase(Locale.of("es", "AR")))
         assertThat(formatted).contains("24")
         assertThat(formatted).contains("2024")
     }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenOnboardingTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenOnboardingTest.kt
@@ -175,6 +175,7 @@ internal class LandingScreenOnboardingTest : AbstractRobolectricTest() {
         return vm
     }
 
+    @Suppress("UNCHECKED_CAST")
     private fun SoundsViewModel.injectSounds(value: List<Sound>) {
         SoundsViewModel::class.java
             .getDeclaredField("_sounds")

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
@@ -239,6 +239,7 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
         return vm
     }
 
+    @Suppress("UNCHECKED_CAST")
     private fun SoundsViewModel.injectHasBundledSounds(value: Boolean) {
         SoundsViewModel::class.java
             .getDeclaredField("_hasBundledSounds")
@@ -250,6 +251,7 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
     // Drives the global library (allSoundsCache) to a known value. The debug build's loadSounds
     // primes allSoundsCache with the bundled catalog, so injecting AFTER waitForIdle (once that
     // cascade settles, same reasoning as injectHasBundledSounds) is the only way to empty it.
+    @Suppress("UNCHECKED_CAST")
     private fun SoundsViewModel.injectLibrary(value: List<Sound>) {
         SoundsViewModel::class.java
             .getDeclaredField("allSoundsCache")
@@ -261,6 +263,7 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
     // Drives the rendered list (`_sounds`) directly. A fresh install seeds it with the welcome
     // sticker, so emptying it is the only way to reach the welcome-empty state once init's load
     // has settled (inject AFTER waitForIdle, same cascade reasoning as injectLibrary).
+    @Suppress("UNCHECKED_CAST")
     private fun SoundsViewModel.injectSounds(value: List<Sound>) {
         SoundsViewModel::class.java
             .getDeclaredField("_sounds")

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
@@ -528,6 +528,7 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
     }
 
     @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun `a concurrent repo write while a delete is pending does not resurrect the sound`() {
         // Companion to the fix above. fix #1's flush persists the previous deletion, and that write
         // fires the reactive `repo.sounds` collector, which re-runs loadSounds. loadSounds must keep

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/util/LocalizedUrlTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/util/LocalizedUrlTest.kt
@@ -20,49 +20,49 @@ internal class LocalizedUrlTest {
 
     @Test
     fun `Argentine Spanish maps to es-AR`() {
-        assertThat(toSupportedHl(Locale("es", "AR"))).isEqualTo("es-AR")
+        assertThat(toSupportedHl(Locale.of("es", "AR"))).isEqualTo("es-AR")
     }
 
     @Test
     fun `Spain Spanish maps to es-ES`() {
-        assertThat(toSupportedHl(Locale("es", "ES"))).isEqualTo("es-ES")
+        assertThat(toSupportedHl(Locale.of("es", "ES"))).isEqualTo("es-ES")
     }
 
     @Test
     fun `Latin American Spanish countries fall back to es-419`() {
         listOf("MX", "CL", "UY", "CO", "PE", "BO", "419").forEach { country ->
-            assertThat(toSupportedHl(Locale("es", country))).isEqualTo("es-419")
+            assertThat(toSupportedHl(Locale.of("es", country))).isEqualTo("es-419")
         }
     }
 
     @Test
     fun `Spanish without country falls back to es-419`() {
-        assertThat(toSupportedHl(Locale("es"))).isEqualTo("es-419")
+        assertThat(toSupportedHl(Locale.of("es"))).isEqualTo("es-419")
     }
 
     @Test
     fun `English of any country maps to en`() {
         listOf("US", "GB", "AU", "IN", "CA").forEach { country ->
-            assertThat(toSupportedHl(Locale("en", country))).isEqualTo("en")
+            assertThat(toSupportedHl(Locale.of("en", country))).isEqualTo("en")
         }
-        assertThat(toSupportedHl(Locale("en"))).isEqualTo("en")
+        assertThat(toSupportedHl(Locale.of("en"))).isEqualTo("en")
     }
 
     @Test
     fun `Portuguese of any country maps to pt-BR`() {
         listOf("BR", "PT", "AO", "MZ").forEach { country ->
-            assertThat(toSupportedHl(Locale("pt", country))).isEqualTo("pt-BR")
+            assertThat(toSupportedHl(Locale.of("pt", country))).isEqualTo("pt-BR")
         }
     }
 
     @Test
     fun `unsupported languages fall back to en`() {
         listOf(
-            Locale("ja", "JP"),
-            Locale("fr", "FR"),
-            Locale("de", "DE"),
-            Locale("zh", "CN"),
-            Locale("it", "IT"),
+            Locale.of("ja", "JP"),
+            Locale.of("fr", "FR"),
+            Locale.of("de", "DE"),
+            Locale.of("zh", "CN"),
+            Locale.of("it", "IT"),
             Locale.ROOT,
         ).forEach { locale ->
             assertThat(toSupportedHl(locale)).isEqualTo("en")
@@ -83,10 +83,10 @@ internal class LocalizedUrlTest {
 
     @Test
     fun `withDeviceHl uses the JVM default locale`() {
-        Locale.setDefault(Locale("pt", "BR"))
+        Locale.setDefault(Locale.of("pt", "BR"))
         assertThat("https://example.com/p".withDeviceHl()).isEqualTo("https://example.com/p?hl=pt-BR")
 
-        Locale.setDefault(Locale("ja", "JP"))
+        Locale.setDefault(Locale.of("ja", "JP"))
         assertThat("https://example.com/p".withDeviceHl()).isEqualTo("https://example.com/p?hl=en")
     }
 }


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change. The unit-test build log was carrying ~50 deprecation/quality warnings; this PR clears the non-Compose ones so a genuinely new warning stands out instead of hiding in known noise. Two distinct intents: some warnings are **resolved** (code migrated to the supported API) and some are **silenced** (usage kept where there is no supported replacement). Every test keeps the same semantics and assertion strength.

### Technical detail

All changes are in `app/src/test/` — no production code touched.

**Resolved (migrated to the supported API — the cause is gone):**

- **`Locale(...)` → `Locale.of(...)`** in `LocalizedUrlTest`, `DurationFormatterTest`, `AboutScreenTest`. The two-arg constructor is deprecated since JDK 19; the factory is semantically identical (build is JDK 21).
- **Redundant `!!` removed** in `ImmersiveListenScreenTest` — the receiver is already smart-cast non-null, so the assertion is unchanged.

**Silenced (no supported replacement — acknowledged, consistent with existing convention):**

- **`@OptIn(ExperimentalCoroutinesApi::class)`** at function scope for the `UnconfinedTestDispatcher` usages in `PlayerControllerTest` / `SoundsViewModelTest`. The entire `kotlinx-coroutines-test` dispatcher API is experimental — opt-in is the sanctioned mechanism, already used in **12 sites across 10 test files** on `develop`.
- **`@Suppress("UNCHECKED_CAST")`** on the four reflection field-setter helpers in `LandingScreenTest` / `LandingScreenOnboardingTest` that weren't already suppressed. Generics are erased, so the cast of a private `MutableStateFlow` field can't be statically verified; sibling test files already carry this annotation (**7 sites on `develop`**) — this just makes the idiom consistent.
- **`@Suppress("DEPRECATION")`** for Robolectric — in 4.16.1 **all four** `ShadowPackageManager` resolve-info setters are deprecated with no lightweight replacement. Centralized the call into a `PackageManager.registerSettingsResolver()` helper instead of rewriting the test setup.

**Deliberately out of scope:** the Compose `createComposeRule` / `createEmptyComposeRule` / `createAndroidComposeRule` → `androidx.compose.ui.test.junit4.v2.*` migration. That swaps `UnconfinedTestDispatcher` for `StandardTestDispatcher` (queued vs. immediate execution) and needs per-test synchronization review — a separate, higher-risk PR.

### Code review tips

- `ScreenLockSettingsTest` is a **security-boundary** test (Vault screen-lock resolvability gate). The helper passes the identical receiver / intent / `ResolveInfo` as the two original call sites; the negative test still exercises the unregistered path — boundary unchanged. Rewriting to the non-deprecated `installPackage` + `IntentFilter` path was avoided on purpose: too much risk on a security test for a cosmetic warning.
- The `@Suppress("UNCHECKED_CAST")` sites all reflect into private `SoundsViewModel` fields to drive test state. That reflection pattern is a pre-existing test smell (separate from this PR); a follow-up may propose a `@VisibleForTesting` state seam to replace it — tracked outside this PR.
- One pre-existing **production** warning is left untouched (not a test warning, out of scope): `LandingScreen.kt:967 Condition is always 'true'`.

### Already tested

CI covers the full gate here (unit tests + ktlint/detekt/spotless/Android Lint). No instrumented run was needed — no `androidTest/` source is touched, so the unit-test + lint jobs are the complete obligatory suite.
