### PR TITLE
docs(labels): add c:aso concern for App Store Optimization PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,7 +332,7 @@ Apply exactly **one type label** (`a:*` or `an:*`) + **zero or more concern labe
 
 - **Type — user-facing** (appear in CHANGELOG `### Added/Changed/Fixed/Removed`): `a:feature`, `a:fix`, `an:enhancement`.
 - **Type — internal** (under `### For nerds 🤓` or omitted): `a:refactor`, `a:test`, `a:build`, `a:docs`.
-- **Concern — cross-cutting** (stackable): `c:accessibility`, `c:performance`, `c:security`, `c:i18n`, `c:observability`, `c:dependencies`.
+- **Concern — cross-cutting** (stackable): `c:accessibility`, `c:performance`, `c:security`, `c:i18n`, `c:aso`, `c:observability`, `c:dependencies`.
 - **Issues/lifecycle:** `a:bug`, `a:feature-request`, `stale`.
 
 Full "when to use" per label + worked combinations: CONTRIBUTING.md § *Labels & milestone examples*.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -833,7 +833,8 @@ The *rule* (one type label + optional concern labels; how to derive the mileston
 | `c:accessibility` | WCAG: contrast, content descriptions, touch targets, screen reader |
 | `c:performance` | User-perceivable performance (cold start, scroll, app size, frame budget) |
 | `c:security` | Security boundaries: input validation, exported components, backup hygiene |
-| `c:i18n` | Localization: translations, store listings per locale, locale-aware copy |
+| `c:i18n` | Localization: translations, locale-aware copy, adding/maintaining a locale (a new locale's store listing is `c:i18n` + `c:aso`) |
+| `c:aso` | App Store Optimization: store-listing copy, feature graphic, screenshots, keywords, custom listings — the store *presence* itself, in any locale |
 | `c:observability` | Analytics instrumentation, Crashlytics, logging, BigQuery |
 | `c:dependencies` | Library / plugin / Gradle-wrapper version bumps (auto-applied by Dependabot with `a:build`) |
 
@@ -855,6 +856,8 @@ The *rule* (one type label + optional concern labels; how to derive the mileston
 - New Firebase Analytics event: `a:build` + `c:observability`
 - Flaky test stabilization: `a:test`
 - README rewrite: `a:docs`
+- Seasonal custom store listing (existing locale): `a:docs` + `c:aso`
+- New locale's full store listing: `a:docs` + `c:i18n` + `c:aso`
 
 ## Third-party notices 📜
 


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change. Adds a `c:aso` concern label so store-presence PRs (listing copy, feature graphic, screenshots, custom listings) stop getting mislabeled as `a:docs`-only and become filterable as App Store Optimization work. Unblocks clean triage of the seasonal/marketing store PRs (e.g. #1223).

### Technical detail

- **New concern `c:aso`** (App Store Optimization) — store *presence* in any locale: listing copy, feature graphic, screenshots, keywords, custom listings. Label already created in GitHub.
- **`c:i18n` disambiguated** — it kept "store listings per locale"; reworded to localization proper. A new locale's full listing is now `c:i18n` + `c:aso`; a marketing asset in an existing locale is just `c:aso`.
- **Where:** bare name in `CLAUDE.md` § *Labels and milestone*; when-to-use row + two worked combinations in `CONTRIBUTING.md` § *Labels & milestone examples*.
- **Type for store PRs:** `a:docs` (non-code repo content) carries the type; `c:aso` carries the signal.

### Code review tips

- Pure docs; the `c:aso` GitHub label and PR #1223's relabel (`a:docs` + `c:aso`) were applied out-of-band.
- `CLAUDE.md` is at ~39.4K / 40K hard limit — this adds ~9 chars; a `/claude-md-audit` is overdue but out of scope here.
