### PR TITLE
test(compose): migrate Robolectric Compose rules to junit4.v2

### DIFF
--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/AbstractUiTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/AbstractUiTest.kt
@@ -6,7 +6,7 @@
 package com.github.barriosnahuel.vossosunboton
 
 import android.content.Context
-import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
 import androidx.test.espresso.accessibility.AccessibilityChecks
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.matcher.ViewMatchers.withClassName

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenAnalyticsTest.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.hasSetTextAction
-import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenDuplicateNameHintTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenDuplicateNameHintTest.kt
@@ -12,7 +12,7 @@ import android.os.Build
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasSetTextAction
-import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenHapticTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenHapticTest.kt
@@ -14,7 +14,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasSetTextAction
-import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenPlaybackTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenPlaybackTest.kt
@@ -10,7 +10,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import androidx.compose.ui.test.hasSetTextAction
-import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenStrictModeTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenStrictModeTest.kt
@@ -8,7 +8,7 @@ package com.github.barriosnahuel.vossosunboton.feature.addbutton
 import android.content.Context
 import android.content.Intent
 import android.os.Build
-import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/NameFieldSupportingTextTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/NameFieldSupportingTextTest.kt
@@ -10,7 +10,7 @@ import android.os.Build
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.core.app.ApplicationProvider

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/collections/MySoundsFilterChipsRowTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/collections/MySoundsFilterChipsRowTest.kt
@@ -6,7 +6,7 @@
 package com.github.barriosnahuel.vossosunboton.feature.collections
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/onboarding/OnboardingTourTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/onboarding/OnboardingTourTest.kt
@@ -15,7 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.click
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreenTest.kt
@@ -8,7 +8,7 @@ package com.github.barriosnahuel.vossosunboton.feature.vault
 import android.content.Context
 import android.os.Build
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultScreenTest.kt
@@ -7,7 +7,7 @@ package com.github.barriosnahuel.vossosunboton.feature.vault
 
 import android.content.Context
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenAnalyticsTest.kt
@@ -7,7 +7,7 @@ package com.github.barriosnahuel.vossosunboton.ui.about
 
 import android.content.Context
 import android.os.Build
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreenTest.kt
@@ -10,7 +10,7 @@ import android.os.Build
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/ImportHubSheetTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/ImportHubSheetTest.kt
@@ -8,7 +8,7 @@ package com.github.barriosnahuel.vossosunboton.ui.home
 import android.os.Build
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivityTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivityTest.kt
@@ -9,7 +9,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenAnalyticsTest.kt
@@ -7,7 +7,7 @@ package com.github.barriosnahuel.vossosunboton.ui.home
 
 import android.content.Context
 import android.os.Build
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenOnboardingTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenOnboardingTest.kt
@@ -10,7 +10,7 @@ import android.os.Build
 import android.provider.Settings
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.StateRestorationTester
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
@@ -8,7 +8,7 @@ package com.github.barriosnahuel.vossosunboton.ui.home
 import android.os.Build
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.StateRestorationTester
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/MySoundsEmptyStateTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/MySoundsEmptyStateTest.kt
@@ -9,7 +9,7 @@ import android.os.Build
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItemTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItemTest.kt
@@ -16,7 +16,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/WelcomeStickerScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/WelcomeStickerScreenTest.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change.

- Migrates **all** Compose tests — the 20 `app/src/test/` Robolectric tests **and** the instrumented `AbstractUiTest` base class — off the `@Deprecated` (WARNING) `createComposeRule` family to the official `…junit4.v2.*` rules, per Google's [migrate-to-v2 guide](https://developer.android.com/develop/ui/compose/testing/migrate-v2). Leaves no old-package factory anywhere. Prerequisite for a *planned* (not-yet-in-build) `allWarningsAsErrors` gate.

### Technical detail

Import-only change (21 lines, one per file). v2 rules use `StandardTestDispatcher` (queued coroutines) instead of `UnconfinedTestDispatcher`.

- **No per-test sync needed** — tests gated on `waitForIdle()` / the `awaitNode*` helpers are unaffected (the documented v2-safe path); none of the 21 assert immediately after async work.
- **`StateRestorationTester` stays on the old package** — not `@Deprecated`, no v2 equivalent, and its `ComposeContentTestRule` constructor is satisfied by the v2 rule's return type. Correct by design.
- **`ComposeTestExtensions.kt` `ComposeTestRule` import stays** — it's the shared (non-deprecated) type, not a factory.

### Code review tips

- **Stacked on #1229 (merge that first).** Base is `test/deflake-vault-session-mid-search`. #1225's first CI run hit a *pre-existing* flake in `SoundsViewModelSearchTest` (unrelated to this migration — my branch never touches that file); #1229 fixes it at the root, so this PR's CI runs green against it. After #1229 merges, GitHub retargets this base to `develop`.

- **Instrumented v2 interop is uncharted.** `AbstractUiTest` combines the v2 rule with Espresso `Intents` + `AccessibilityChecks`, for which Google publishes **zero** guidance — so it was validated empirically by a full cold-boot suite run, not assumed safe.
- **One flake, classified — not a regression.** A first full run hit a lone `ComposeTimeoutException` on `saveWithBlankNameShowsRequiredError`. Re-run 3/3 green in isolation (cold-boot each) + a clean full suite run → emulator flake per ADR 0001, not a v2 ordering bug (the blank-name validation path is synchronous).
- **No CI impact / v2 is "alpha".** No `allWarningsAsErrors` gate in the build today; v2's JUnit4 rule layer needs no `@OptIn` but Google documents the surface as alpha/subject-to-change.

### Already tested

- Unit (Robolectric Compose, the 20 files): 3/3 green local re-runs.
- Instrumented (the full UI suite — **CI does not run it**, ADR 0001): 118/118 green on a cold-boot run via `run-instrumented-tests.sh`, validating the v2 base class.
