### PR TITLE
fix(test): stop the welcome sticker resurrecting across instrumented tests

### DIFF
--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/TestData.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/TestData.kt
@@ -62,6 +62,12 @@ internal object TestData {
             // Hide welcome by default in instrumented tests; opt-in via [enableWelcomeSticker].
             val welcome = WelcomeStickerStore(context)
             welcome.clearForTest()
+            // Pre-run the one-time persistence migration so its guard is set before consume().
+            // clearForTest() wipes that guard, so without this the Activity's SoundsViewModel.init
+            // re-runs migrateToPersistentIfNeeded() and resets consumed=false — resurrecting the
+            // welcome as a second MY_SOUNDS row and breaking the "exactly one share/play button"
+            // assumption every other instrumented test relies on.
+            welcome.migrateToPersistentIfNeeded()
             welcome.consume()
         }
         // Process-scoped singleton — survives across tests in the same instrumentation process,

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/HubImportFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/HubImportFlowTest.kt
@@ -21,8 +21,10 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.barriosnahuel.vossosunboton.AbstractUiTest
 import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.TestData
 import com.github.barriosnahuel.vossosunboton.awaitNodeWithContentDescription
 import com.github.barriosnahuel.vossosunboton.awaitNodeWithText
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -33,6 +35,16 @@ import org.junit.runner.RunWith
  */
 @RunWith(AndroidJUnit4::class)
 internal class HubImportFlowTest : AbstractUiTest() {
+    @Before
+    override fun setUp() {
+        super.setUp()
+        // The + FAB only renders when MY_SOUNDS is non-empty — the welcome-empty state swaps it for
+        // an inline Import CTA instead (LandingScreen.kt:452). Seed one audio so the FAB these tests
+        // drive actually exists; clearAll() now correctly hides the welcome, so without a seed the
+        // list would be empty and every fabLabel() lookup would time out.
+        TestData.seedCustomSounds(context, count = 1)
+    }
+
     @Test
     fun fabOpensImportHub() {
         ActivityScenario.launch(LandingActivity::class.java).use {

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/WelcomeIsolationGuardTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/WelcomeIsolationGuardTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.barriosnahuel.vossosunboton.AbstractUiTest
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.TestData
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithText
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Regression guard for instrumented-test isolation: [TestData.clearAll] must leave MY_SOUNDS free
+ * of the welcome sticker so the rest of the suite's "exactly one play/share button per seeded
+ * sound" assertions hold.
+ *
+ * The bug this guards: the persistent-welcome migration runs on every SoundsViewModel.init and
+ * resets consumed=false. clearAll wipes the migration guard, so the migration re-armed on every
+ * test and resurrected the welcome as a second MY_SOUNDS row — surfacing across unrelated tests as
+ * "Failed to inject touch input: found 2 nodes" or ComposeTimeout on a count-bearing header.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class WelcomeIsolationGuardTest : AbstractUiTest() {
+    @Test
+    fun clearAllHidesTheWelcomeSoASeededSoundHasExactlyOnePlayButton() {
+        TestData.seedCustomSounds(context, count = 1)
+
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            // Wait for the seeded sound to render before asserting the negatives below.
+            composeRule.awaitNodeWithText("custom_1")
+
+            val welcomeTitle = context.getString(R.string.app_welcome_sticker_title)
+            composeRule.onAllNodesWithText(welcomeTitle).assertCountEquals(0)
+            // One seeded sound ⇒ exactly one Play control; a resurrected welcome would make it two.
+            composeRule.onAllNodesWithContentDescription(playLabel()).assertCountEquals(1)
+        }
+    }
+
+    private fun playLabel() = context.getString(R.string.app_play)
+}


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change.

Restores the local instrumented UI suite to green: on a dev machine it was failing deterministically (the welcome sticker re-appearing as a phantom second row), which masked real regressions and blocked the pre-push functional gate. Production behavior is untouched.

### Technical detail

The welcome-sticker persistence migration runs on every `SoundsViewModel.init` and resets `consumed=false` (intentional, unit-tested: it resurrects the welcome for users who consumed it under the old self-destruct model). `TestData.clearAll()` hid the welcome with `consume()`, but `clearForTest()` also wipes the migration's one-time guard — so the migration re-armed every test and un-consumed it, adding a 2nd MY_SOUNDS row.

- **`TestData.clearAll()`** — pre-runs `migrateToPersistentIfNeeded()` (public API) before `consume()`, so the guard is set and the Activity's init migration no-ops; the `consume()` sticks.
- **`HubImportFlowTest`** — adds a `setUp()` seeding one sound. The `+` FAB only renders when My Sounds is non-empty (`LandingScreen.kt:452` swaps it for an inline Import CTA when empty); these 5 tests drove the FAB and never seeded, silently relying on the resurrected welcome to keep the list non-empty.
- **`WelcomeIsolationGuardTest`** (new) — asserts `clearAll()` leaves zero welcome rows and exactly one play control for one seeded sound.
- **Unchanged:** no production code; the migration stays as-is.

### Code review tips

- The fix is fixture-only; the `enableWelcomeSticker` opt-in path still re-wipes the guard after `clearAll`, so welcome-on tests are unaffected (state-walked).
- Guard test can't pass for the wrong reason: the welcome renders through the same `SoundItem`/`app_play`, so a resurrection yields 2 play nodes; `awaitNodeWithText("custom_1")` is a hard barrier before the count.
- Rebased onto latest `develop` (`c8e8d5d`) — clean, no conflicts.
- An unrelated StrictMode `InstanceCountViolation` flake (`SearchOverlayTest`) appeared in 1 of 3 cold-boot runs and was absent in the authoritative run — known GC-timing flake, not this change.

### Already tested

- instrumented: local cold-boot wrapper vs `develop` c8e8d5d — 118/118 green, 2 skipped (includes the new guard + all 5 HubImportFlowTest).