### PR TITLE
docs(test): tell deterministic test reds apart from emulator flakes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -253,6 +253,13 @@ RUNS=3 ./scripts/run-instrumented-tests.sh
 
 HTML report: `app/build/reports/androidTests/connected/debug/index.html`. Raw XML: `app/build/outputs/androidTest-results/connected/debug/`.
 
+#### Is the red the emulator, or a real bug?
+
+Before re-running, classify by **determinism and timing** — not every red is the degraded emulator:
+
+- **Emulator flake** — `ComposeTimeoutException`, `ComposeNotIdleException`, `Process crashed`. Non-deterministic, varies run to run, usually on a slow pass. A clean cold boot (or freeing host load) makes it pass. Re-run via the wrapper.
+- **Deterministic bug** — `Failed to inject touch input. Reason: Expected exactly '1' node but found '2'`, or an `assertCountEquals` mismatch. Fails **instantly and identically every run**, cold boot included. The `inject touch` wording is misleading: Compose resolves the single target node *before* sending input, so this throws in the test process and the emulator is never invoked. It means matcher ambiguity — two real nodes in the tree (read the dump: two distinct rows) — i.e. a **test-isolation / seeding bug**, not the AVD. **Re-running never helps.** Fix the data the test renders. Rationale: [ADR 0001 § *Not every red is the emulator*](docs/adr/0001-local-ui-test-suite.md).
+
 #### Run a single test class
 
 Any extra arguments are passed straight through to Gradle:

--- a/docs/adr/0001-local-ui-test-suite.md
+++ b/docs/adr/0001-local-ui-test-suite.md
@@ -120,6 +120,29 @@ timing-sensitive tests. If a cold-booted run is still slow or flaky, check the h
 before suspecting a test: close other heavy work and re-run, rather than chasing a
 non-existent test bug.
 
+### Not every red is the emulator — deterministic vs. degradation reds
+
+The *Cold boot per run* note above explains the reds that **are** the emulator. There is a
+second class that looks similar but is the opposite — a real code/data bug — and must not be
+re-run away. Triage by determinism and timing before blaming the AVD:
+
+- **Degradation reds** (emulator): `ComposeTimeoutException`, `ComposeNotIdleException`,
+  `Process crashed`. Non-deterministic, vary run to run, often on a slow run; a clean cold
+  boot makes them pass. Re-running is the right move.
+- **Deterministic reds** (code/data): `Failed to inject touch input. Reason: Expected
+  exactly '1' node but found '2'` and `assertCountEquals` count mismatches. These fail
+  **instantly and identically every run**, on a fresh cold boot too. The `inject touch`
+  wording is misleading: Compose resolves the single target node *before* sending any input,
+  so the assertion throws in the test process and the emulator's input pipeline is never
+  invoked. The cause is matcher ambiguity — two real nodes in the semantics tree (read the
+  node dump: two distinct list rows) — which means a **test-isolation / seeding bug**, not
+  the AVD. Re-running never helps; fix the data the test renders.
+
+A worked instance: a one-time persistence migration in `SoundsViewModel.init` re-armed by
+the test fixture resurrected a second MY_SOUNDS row, turning every "exactly one play/share
+button" assertion into a `found '2' nodes` red that read, wrongly, as "the emulator can't
+inject gestures."
+
 ### History note: dynamic feature workaround (removed)
 
 The `:feature_addbutton` module used to be a dynamic feature with


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change.

Documents how to tell a deterministic test-isolation bug apart from an emulator flake, so the next contributor doesn't misread `Failed to inject touch input: found 2 nodes` as the AVD failing to inject gestures — the exact misdiagnosis that motivated #1226.

### Technical detail

- **ADR 0001** — new subsection *Not every red is the emulator*: degradation reds (`ComposeTimeoutException`, `Process crashed`) vary run to run and a cold boot fixes them; deterministic reds (`found '2' nodes`, `assertCountEquals` mismatch) fail identically every run, mean matcher ambiguity from a real extra row, and re-running never helps.
- **CONTRIBUTING** — a parallel *Is the red the emulator, or a real bug?* triage block in the Local UI test suite section, with the key insight that Compose resolves the target node before sending input, so a `found 2 nodes` failure never reaches the emulator.

### Code review tips

- Docs only (ADR + CONTRIBUTING). No CHANGELOG entry — a triage note is neither user-visible nor architecturally significant per the repo's changelog rule.
- The worked instance referenced is #1226.

### Already tested

Docs only — no code paths touched; CircleCI covers the markdown-adjacent checks.