### PR TITLE
chore(release): cut v2.2.0 (versionCode 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][], and this project adheres to [Semantic Versioning][].
 
-## \[unreleased] (v2.2.0)
+## \[v2.2.0] - 2026-06-15
 
 ### Added
 - A "+" button on My Bomps opens a sheet to bring in a new Bomp — pick any audio from your device and it becomes yours; recording your own is coming soon

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Bomp is your personal collection of the voices that matter. Save them, keep them
 [<img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" height="80"/>](https://play.google.com/store/apps/details?id=com.github.barriosnahuel.vossosunboton)
 
 ## Project status 📖
-[![version](https://img.shields.io/badge/version-2.1.0-brightgreen.svg)](https://github.com/barriosnahuel/bomp/releases)
-[![Semver](https://img.shields.io/badge/SemVer-v2.1.0-green.svg)](http://semver.org/spec/v2.0.0.html)
+[![version](https://img.shields.io/badge/version-2.2.0-brightgreen.svg)](https://github.com/barriosnahuel/bomp/releases)
+[![Semver](https://img.shields.io/badge/SemVer-v2.2.0-green.svg)](http://semver.org/spec/v2.0.0.html)
 [![stable](https://img.shields.io/badge/stability-experimental-green.svg)](https://nodejs.org/api/documentation.html#documentation_stability_index)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE)
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,8 +19,8 @@ android {
         applicationId "com.github.barriosnahuel.vossosunboton"
         minSdkVersion 23
         targetSdkVersion 37
-        versionCode 6
-        versionName '2.1.0'
+        versionCode 7
+        versionName '2.2.0'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         // Keep capture/utility drivers out of the default suite (connectedDebugAndroidTest /
         // run-instrumented-tests.sh). The store-screenshot driver still runs via

--- a/store-listing/en-US/changelog-7.txt
+++ b/store-listing/en-US/changelog-7.txt
@@ -1,0 +1,8 @@
+What's new in this version.
+
+▸ Add audios more easily: tap "+" and pick any one on your phone to make it yours.
+▸ The magnifier now lives up top, on every tab — search your audios whenever you want, even before your collection grows.
+▸ What you share now plays inline in more chat apps, and carries an invite so the other side can have Bomp too.
+▸ A short tour shows how to save, nickname and bomp: reopen it anytime.
+
+Thanks for bomping.

--- a/store-listing/es-AR/changelog-7.txt
+++ b/store-listing/es-AR/changelog-7.txt
@@ -1,0 +1,8 @@
+Novedades de esta versión.
+
+▸ Sumá audios más fácil: tocá "+" y elegí cualquiera de tu teléfono para hacerlo tuyo.
+▸ La lupa ahora vive arriba, en cada pestaña — buscá tus audios cuando quieras, aunque tu colección recién empiece.
+▸ Lo que compartís suena al toque en más apps, y va con una invitación para que del otro lado también tengan Bomp.
+▸ Un tour cortito muestra cómo guardar, apodar y bompear: reabrilo cuando quieras.
+
+Gracias por bompear.


### PR DESCRIPTION
### Summary

Internal — release housekeeping to cut **v2.2.0 (versionCode 7)**. No app behavior change. Unblocks building the production AAB; the store "What's new" for v2.2.0 ships with it.

### Technical detail

- **`app/build.gradle`** — `versionCode 6 → 7`, `versionName 2.1.0 → 2.2.0` (develop already carries the v2.2.0 features, so the name moves with it).
- **`CHANGELOG.md`** — finalize `## [unreleased] (v2.2.0)` → `## [v2.2.0] - 2026-06-15`.
- **`README.md`** — version badges → 2.2.0.
- **`store-listing/{es-AR,en-US}/changelog-7.txt`** (new) — the v2.2.0 store "What's new", warm register like `changelog-6`, distilling the user-facing `[unreleased]` items (import via "+", search in the top bar, inline-play shares + invite, the reopenable tour). 450 / 438 chars (≤500).

### Code review tips

- **The `changelog-7` copy is a draft for your review** — es-AR voseo + en-US, DNA-checked (no tournament refs, no banned anti-tags). Easy to iterate.
- "What's new" is a **release** field uploaded with the AAB — **not** part of the AR custom listing (#1223).
- **Must merge before the final bundle** (Step 4); pairs with the baseline-profile PR. Order between the two is free.
- No code touched → CI just compiles the bump; no behavior change.

### Already tested

- Char counts es-AR 450 / en-US 438 (≤500); version + CHANGELOG heading verified.
- Release validation (`lintVitalRelease` / `bundleRelease`) runs in Step 4 on merged `develop`, not per-PR.
