### PR TITLE
build: clear non-test-rule Kotlin warnings ahead of allWarningsAsErrors gate

### DIFF
--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -964,7 +964,7 @@ private fun MySoundsBody(
             )
         }
         when {
-            showFilterEmptyState && activeCollection != null ->
+            showFilterEmptyState ->
                 MySoundsFilterEmptyState(collectionName = activeCollection.name)
             showWelcomeEmptyState ->
                 // weight(1f) so the centered group fills the space *below* the chips row, not the

--- a/commons_android/build.gradle
+++ b/commons_android/build.gradle
@@ -53,4 +53,7 @@ dependencies {
     testImplementation libs.mockk
     testImplementation libs.robolectric
     testImplementation libs.androidx.test.core
+    // AnalyticsCoverageMatrixTest enumerates AnalyticsEvent::class.sealedSubclasses; kotlin-reflect
+    // is the runtime backing for that reflection call (otherwise resolved only transitively).
+    testImplementation libs.kotlin.reflect
 }

--- a/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/FirebaseAnalyticsTrackerTest.kt
+++ b/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/FirebaseAnalyticsTrackerTest.kt
@@ -9,7 +9,9 @@ import android.os.Build
 import android.os.Bundle
 import com.google.common.truth.Truth.assertThat
 import com.google.firebase.analytics.FirebaseAnalytics
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
@@ -37,7 +39,7 @@ internal class FirebaseAnalyticsTrackerTest {
     @Test
     fun `log emits the base event with its params`() {
         val captured = slot<Bundle>()
-        every { firebase.logEvent(any(), capture(captured)) } answers { Unit }
+        every { firebase.logEvent(any(), capture(captured)) } just Runs
 
         tracker.log(AnalyticsEvent.SoundPlay(surface = "my_sounds"))
 
@@ -92,7 +94,7 @@ internal class FirebaseAnalyticsTrackerTest {
     @Test
     fun `log propagates SoundAdd params verbatim into the bundle`() {
         val captured = slot<Bundle>()
-        every { firebase.logEvent("sound_add", capture(captured)) } answers { Unit }
+        every { firebase.logEvent("sound_add", capture(captured)) } just Runs
 
         tracker.log(
             AnalyticsEvent.SoundAdd(
@@ -116,7 +118,7 @@ internal class FirebaseAnalyticsTrackerTest {
     @Test
     fun `logScreen emits SCREEN_VIEW with the canonical screen name`() {
         val captured = slot<Bundle>()
-        every { firebase.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, capture(captured)) } answers { Unit }
+        every { firebase.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, capture(captured)) } just Runs
 
         tracker.logScreen("my_sounds")
 
@@ -126,7 +128,7 @@ internal class FirebaseAnalyticsTrackerTest {
     @Test
     fun `logScreen merges extras into the screen view bundle`() {
         val captured = slot<Bundle>()
-        every { firebase.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, capture(captured)) } answers { Unit }
+        every { firebase.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, capture(captured)) } just Runs
 
         val extras = Bundle().apply { putString("source", "share") }
         tracker.logScreen("add_sound", extras)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -110,6 +110,7 @@ androidx-test-rules               = { module = "androidx.test:rules",       vers
 robolectric                       = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 truth                             = { module = "com.google.truth:truth",    version.ref = "truth" }
 mockk                             = { module = "io.mockk:mockk",            version.ref = "mockk" }
+kotlin-reflect                    = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 espresso-core                     = { module = "androidx.test.espresso:espresso-core",          version.ref = "espresso" }
 espresso-intents                  = { module = "androidx.test.espresso:espresso-intents",       version.ref = "espresso" }
 espresso-accessibility            = { module = "androidx.test.espresso:espresso-accessibility", version.ref = "espresso" }


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change.

Unblocks turning on the `allWarningsAsErrors` build gate (PR follows): clears the remaining Kotlin compiler warnings on `develop` so the gate can be enabled without reddening untouched code. With the Compose test-rule v2 migration already merged, these were the only warnings left.

### Technical detail

- **`LandingScreen.kt`** — dropped the redundant `&& activeCollection != null` from the `MySoundsFilterEmptyState` branch. `showFilterEmptyState` already AND-includes that null-check, so K2 flagged the extra term as always-true. Branch selection and the `activeCollection.name` smart-cast are unchanged.
- **`FirebaseAnalyticsTrackerTest`** — `answers { Unit }` → `just Runs` at 4 capture sites (the trailing `Unit` was the unused-expression warning). Capture/verify semantics identical.
- **`commons_android` / `libs.versions.toml`** — explicit `testImplementation kotlin-reflect` (test-only, version-matched to the compiler) backing `AnalyticsEvent::class.sealedSubclasses`, previously resolved only transitively.

### Code review tips

- **Stacked on #1235** (deflake) for flake-free CI — base is the deflake branch; **merge #1235 first**, GitHub retargets this to `develop` afterward. Rebased onto it cleanly (no file overlap): `d64f4fb → 33b58b3`.
- The `LandingScreen` smart-cast now relies on K2's variable-condition tracking (a `val` boolean carrying the null-check). Sound under the repo's Kotlin 2.4.0 K2 pin; would not compile under K1 / `languageVersion=1.9`.
- No production behavior change — the removed operand is compiler-proven always-true; a full warning re-sweep (debug + release + unit + androidTest) shows zero Kotlin warnings remaining.

### Already tested

- No suite beyond CI is required: the production change is a compiler-verified no-op exercised by the Robolectric `LandingScreen` unit tests (run by CI); the instrumented suite is not implicated.
