### PR TITLE
docs(contributing): document per-user CircleCI MCP setup for CI failure diagnosis

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ But, before going deeper I suggest you to take a look to the [opensource.guide](
     > ./gradlew check
 
     It must return **`BUILD SUCCESS`**.
+4. *(Optional)* To let Claude Code diagnose CI failures, set up the CircleCI MCP server — see [§ Continuous Integration](#continuous-integration-). An agent can wire it up; you provide the token and restart Claude Code.
 
 ## Directory structure 🎄
 - [app/](/app) Android application module which depends on all other submodules to be the great app you're building. The Add Button flow lives at `app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/`.
@@ -67,6 +68,11 @@ We use Circle CI, so if you're gonna change the [config.yml](.circleci/config.ym
 - https://circleci.com/docs/2.0/local-cli
 
 > circleci config validate
+
+### Diagnosing CI failures from Claude Code
+Claude Code can read remote pipeline/job logs via the official [CircleCI MCP server](https://github.com/CircleCI-Public/mcp-server-circleci) (`@circleci/mcp-server-circleci`). Setup is **per-user, not committed**: a personal CircleCI API token in your env (carries full account access — treat as a secret) + `claude mcp add -s local …`. Follow the package README for the current commands, or just ask an agent to wire it up.
+
+**Gotcha:** the token resolves at Claude Code launch. If you get `401`, fully quit and relaunch Claude Code from a shell that has the token exported — a `/mcp` reconnect reuses the old env and won't pick it up.
 
 ### Instrumented UI tests are local-only
 The instrumented suite under `app/src/androidTest/` is **intentionally not run on CircleCI**. It needs a booted emulator and is meant to replace manual end-to-end QA on the contributor's machine. Setup, run commands, and synchronization helpers live in [Testing → Local UI test suite](#testing-); rationale lives in [ADR 0001](docs/adr/0001-local-ui-test-suite.md).


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change (contributor docs). Until now, *how to let Claude Code read CircleCI pipeline logs and diagnose failures* lived only in one-off chat sessions; this records it so a contributor — or an agent doing initial repo setup — can wire it up without rediscovering the rough edges.

### Technical detail

- **`CONTRIBUTING.md` § Continuous Integration** — new `### Diagnosing CI failures from Claude Code`: names the official server (`@circleci/mcp-server-circleci`), states the setup shape (**per-user, local scope, personal API token**), links the package README as the live source of the actual commands, and captures the one expensive gotcha — the token resolves at Claude Code **launch**, so a `401` means "fully restart, not `/mcp` reconnect".
- **`CONTRIBUTING.md` § Local setup** — optional step 4 pointing to that section, so the onboarding path (README → CONTRIBUTING → Local setup) surfaces it; flags the two human-only steps (token + restart).
- **Deliberately minimal** — no UI walkthrough or exact command sequence: those go stale (CircleCI UI/commands change, Node may already be installed) and an agent re-derives them on demand. Left out of scope: `CLAUDE.md` (a procedure, not a write-time invariant; 40K budget) and a committed `.mcp.json` (would prompt every contributor + 401-spam token-less worktrees/CI).

### Code review tips

- The `[§ Continuous Integration](#continuous-integration-)` anchor matches the ToC entry (line 11) — worth confirming it resolves in GitHub's rendered view.
- **No milestone applied:** `CHANGELOG.md` has no `## [unreleased]` section (v2.2.0 was just cut), so none was derivable — assign manually if wanted. No CHANGELOG entry added (contributor-docs, not user-facing).

### Already tested

- Docs-only; no test suite covers `CONTRIBUTING.md`. Verified locally what CI doesn't: the new note renders in house style and the section anchor resolves. Pre-push guards (ktlint/detekt/spotless + ADR/security/analytics/assertion greps) passed on push.
