### PR TITLE
test(search): align locked-Vault search siblings with the proven looper flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - The instrumented UI test wrapper now cold-boots the emulator with host-GPU rendering and widened CPU/RAM (`-gpu host -cores 6 -memory 4096`, env-overridable), so the suite runs faster and less flaky than on the software-rendered AVD defaults
 - Migrated unit tests off deprecated JDK/Kotlin APIs — `Locale.of(...)` replaces the deprecated `Locale(...)` constructor, and a redundant non-null assertion was removed
 - Acknowledged the test-only warnings that have no supported replacement — opt-in annotations for the experimental coroutine-test dispatcher and `@Suppress` for the reflection unchecked-casts and the deprecated-in-4.16.1 Robolectric resolve-info setter, consistent with the existing test-suite convention
+- Aligned the two remaining locked-Vault search tests (private-only filtered out, cross-tagged kept) with the proven main-looper flush their mid-search-flip sibling already uses, so a loaded CI machine can no longer red them when the injected collection membership lags behind the synchronous assert
 
 ## \[v2.1.0] - 2026-05-25
 

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelSearchTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelSearchTest.kt
@@ -134,6 +134,11 @@ internal class SoundsViewModelSearchTest : AbstractRobolectricTest() {
         )
 
         viewModel.onSearchQueryChange("Mama")
+        // Same paused-looper hazard as the mid-search-flip sibling's pre-condition assert: the
+        // recompute settles on the VM's Dispatchers.Main collector, so the injected private-collection
+        // membership can lag under CI load. Flush before reading searchResults.value (CLAUDE.md § await
+        // every async input).
+        shadowOf(Looper.getMainLooper()).idle()
 
         assertThat(viewModel.searchResults.value.map { it.id }).contains(publicAudio.id)
         assertThat(viewModel.searchResults.value.map { it.id }).doesNotContain(privateAudio.id)
@@ -158,6 +163,11 @@ internal class SoundsViewModelSearchTest : AbstractRobolectricTest() {
         )
 
         viewModel.onSearchQueryChange("carlos")
+        // Same paused-looper hazard as the mid-search-flip sibling's pre-condition assert: the
+        // recompute settles on the VM's Dispatchers.Main collector, so the injected cross-tagged
+        // membership can lag under CI load. Flush before reading searchResults.value (CLAUDE.md § await
+        // every async input).
+        shadowOf(Looper.getMainLooper()).idle()
 
         assertThat(viewModel.searchResults.value.map { it.id }).contains(crossTagged.id)
     }


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change.

Protects the two locked-Vault search regression tests — *private-only audio stays hidden while the Vault is locked*, *cross-tagged audio stays visible* — from intermittently reddening CI on a loaded machine. The guard they provide stays trustworthy instead of failing for a timing reason unrelated to the product.

### Technical detail

Apply the same `shadowOf(Looper.getMainLooper()).idle()` flush the mid-search-flip sibling already uses to the two remaining locked-Vault search tests.

- **`SoundsViewModelSearchTest`** — both siblings read `searchResults.value` synchronously right after `onSearchQueryChange(...)`. The collections/Vault-filter recompute settles on the VM's `Dispatchers.Main` collector, which Robolectric pauses, so the injected collection membership can lag under load. One `idle()` before the read drains it. No assertion changed.
- **Criterion alignment** — this is the #1229 deflake applied to the flip sibling's pre-condition, now extended to the two it deliberately left untouched. The three locked-Vault tests now share one synchronization pattern.
- **Out of scope** — the simpler name-filter tests don't depend on the async collection chain and stay flush-free.
- **CHANGELOG** — one line under v2.2.0 → *For nerds → Changed*.

### Code review tips

- The flush only moves *when* the StateFlow is read to its settled state (production's main looper isn't paused), so it can't mask a real Vault leak; the paired `contains(...)` assert keeps an empty/unsettled list from vacuously passing `doesNotContain`. The three modified/sibling search tests pass on CI.
- **CI red is a pre-existing, unrelated flake — not from this PR.** The failures are in `SoundsViewModelVisibilityTest` (a file this PR does not touch): `applyAssignment can hide an audio that lives only in a public collection` (Truth assert) and `turning visibility off hides the audio from the MY_SOUNDS Todo view` (`TimeoutCancellationException`) — the same load-dependent async family this change addresses elsewhere. Non-deterministic across two runs of this exact commit (2 then 1 failure); the class passes 6/6 locally on base — verified with `git checkout 34a6507 && ./gradlew :app:testDebugUnitTest --tests "…SoundsViewModelVisibilityTest" --rerun-tasks`. A separate deflake (its own PR) is the right fix, not scope-creep here.
- Also observed pre-existing: `AddButtonScreenPlaybackTest > Edit flow stops preview playback…` intermittently fails locally with `Default FirebaseApp is not initialized` (cross-test static pollution; passed on CI here).

### Already tested

- `SoundsViewModelSearchTest` (both modified siblings + the flip sibling) run locally: 10/10 green, repeated; and green on CI. ktlint / detekt / spotless green locally.
- No `src/androidTest` change → instrumented suite out of scope. The full unit suite is CI-covered.
