### PR TITLE
build(baseline): fail fast when profiling google-services is the CI dummy

### DIFF
--- a/scripts/check-profileable-google-services.sh
+++ b/scripts/check-profileable-google-services.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Fail fast when the profiling build types still carry the scrubbed CI google-services dummy.
+#
+# The `benchmark` and `nonMinifiedRelease` build types install under applicationId `.debug` and reuse the
+# real DEBUG Firebase config. The committed copies are scrubbed dummies (so CI compiles), seeded with the
+# real key only via scripts/setup-worktree.sh (skip-worktree). If the profiling build runs against the
+# dummy, Firebase init throws `IllegalArgumentException: Please set a valid API key` ~0.3s after launch, the
+# process dies before Macrobenchmark can flush the profile, and the run fails with the cryptic
+# `never flushed profiles in any process` — costing real diagnosis time.
+#
+# This guard catches that BEFORE the build. Used by scripts/generate-baseline-profile.sh; behaviour-tested
+# by scripts/test-check-profileable-google-services.sh. Exits 0 (silent) when the configs are real.
+#
+# See CLAUDE.md § Worktree setup and CONTRIBUTING.md § Firebase config file.
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+DEBUG="app/src/debug/google-services.json"
+TARGETS=(
+  "app/src/nonMinifiedRelease/google-services.json"
+  "app/src/benchmark/google-services.json"
+)
+
+# True when the working file is byte-identical to the committed copy — i.e. still the scrubbed CI dummy,
+# never seeded with the real key. Process substitution (not a pipe) so `set -o pipefail` can't trip on the
+# SIGPIPE git-show takes when cmp stops early.
+is_dummy() { cmp -s "$1" <(git show "HEAD:$1" 2>/dev/null); }
+
+dummies=()
+for t in "${TARGETS[@]}"; do
+  if is_dummy "$t"; then dummies+=("$t"); fi
+done
+
+if [ "${#dummies[@]}" -eq 0 ]; then exit 0; fi
+
+{
+  echo "✘ The profiling build's google-services is the scrubbed CI dummy:"
+  for d in "${dummies[@]}"; do echo "    $d"; done
+  echo
+  echo "  These build types install under applicationId '.debug' and would crash on Firebase init"
+  echo "  (IllegalArgumentException: Please set a valid API key) ~0.3s after launch, so the process dies"
+  echo "  before Macrobenchmark flushes the profile — surfacing as the cryptic 'never flushed profiles'."
+  echo
+  if is_dummy "$DEBUG"; then
+    echo "  The real debug config is missing too ($DEBUG is the dummy). Set up the primary worktree's"
+    echo "  google-services first (CONTRIBUTING.md § Firebase config file), then re-run."
+  else
+    echo "  Fix — seed each from the real debug config (skip-worktree FIRST so the real key never stages):"
+    for d in "${dummies[@]}"; do
+      echo "    git update-index --skip-worktree -- $d && cp $DEBUG $d"
+    done
+    echo "  Or, in a linked worktree, just run: ./scripts/setup-worktree.sh"
+  fi
+} >&2
+exit 1

--- a/scripts/generate-baseline-profile.sh
+++ b/scripts/generate-baseline-profile.sh
@@ -24,6 +24,11 @@ TEST_APK=macrobenchmark/build/outputs/apk/benchmark/macrobenchmark-benchmark.apk
 DEST=app/src/main/baseline-prof.txt
 REMOTE="/storage/emulated/0/Android/media/$TEST_PKG/BaselineProfileGenerator_generate-baseline-prof.txt"
 
+# Fail fast (before the build) if the profiling build types still carry the scrubbed CI google-services
+# dummy — otherwise nonMinifiedRelease crashes on Firebase init and the run dies with the cryptic
+# "never flushed profiles". The guard explains how to seed the real config.
+./scripts/check-profileable-google-services.sh
+
 # Resolve a single target device unless ANDROID_SERIAL is already set. Read `adb devices` ONCE so a
 # device (dis)connecting between the count and the pick can't leave us with an empty serial.
 if [ -z "${ANDROID_SERIAL:-}" ]; then


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change. When `nonMinifiedRelease`/`benchmark` google-services is still the scrubbed CI dummy, `generate-baseline-profile.sh` now **fails fast with a clear, actionable message** instead of the cryptic `never flushed profiles`. The dummy key crashes the profiling build on Firebase init (`Please set a valid API key`) ~0.3s after launch, so the process dies before Macrobenchmark can flush — a failure mode that cost real diagnosis time.

### Technical detail

- **`scripts/check-profileable-google-services.sh`** (new) — pure git+`cmp` guard: flags each profiling config byte-identical to the committed dummy and prints how to seed the real key (skip-worktree + `cp` from debug, or `setup-worktree.sh` in a linked worktree). Distinct message when the debug config itself is the dummy.
- **`scripts/generate-baseline-profile.sh`** — invokes the guard before building.
- **No CI job, no behaviour test, on purpose.** The guard only protects a manual, device-bound dev script and just improves an error message — low stakes. The repo CI-tests only high-stakes operational scripts (e.g. the data-loss-capable `cleanup-merged-worktrees.sh`), not every script; gating the release `bundle` on this would be illogical.

### Code review tips

- **Interpretation:** fail-fast (abort + message), not auto-seeding — keeps secret-file mutation centralized in `setup-worktree.sh`; this script writes no google-services.
- Detection is `cmp` vs `git show HEAD:` — catches "still the committed dummy" (the actual failure mode); a hand-edited invalid key is out of scope. Fails *open* if a config isn't in HEAD.

### Already tested

- `bash -n` on both touched scripts: clean. Guard exercised by hand across its three paths (seeded / dummy-with-real-debug / debug-also-dummy). CI does not run this script.
