### PR TITLE
test(home): deflake the assign-close coach & moved-to-vault tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][], and this project adheres to [Semantic Versioning][].
 
+## \[unreleased]
+
+### For nerds 🤓
+
+#### Changed
+- Kotlin compiler warnings now fail the build (`allWarningsAsErrors`, binary/unconditional) so they can't accumulate
+
 ## \[v2.2.0] - 2026-06-15
 
 ### Added

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -964,7 +964,7 @@ private fun MySoundsBody(
             )
         }
         when {
-            showFilterEmptyState && activeCollection != null ->
+            showFilterEmptyState ->
                 MySoundsFilterEmptyState(collectionName = activeCollection.name)
             showWelcomeEmptyState ->
                 // weight(1f) so the centered group fills the space *below* the chips row, not the

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelVisibilityTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelVisibilityTest.kt
@@ -201,7 +201,16 @@ internal class SoundsViewModelVisibilityTest : AbstractRobolectricTest() {
         val context = ApplicationProvider.getApplicationContext<android.app.Application>()
         runBlocking { SoundsRepository(context).save(testSound("coach", file = "c.mp3")) }
         val vm = givenAViewModel()
-        runBlocking { withTimeout(TIMEOUT_MS) { vm.collections.first { it.isNotEmpty() } } }
+        runBlocking {
+            withTimeout(TIMEOUT_MS) {
+                vm.collections.first { it.isNotEmpty() }
+                // Await the reactive loadSounds priming allSoundsCache with "coach" BEFORE applyAssignment:
+                // evaluateAssignCloseEffects early-returns when the cache lacks the audio, so on a loaded CI
+                // machine the dual-home coach never fires and the await below times out (CLAUDE.md § JVM
+                // tests — await every async input).
+                vm.library.first { lib -> lib.any { it.name == "coach" } }
+            }
+        }
 
         // "Listo" with the audio staged into the Baúl while staying visible → the dual-home coach.
         vm.applyAssignment(
@@ -230,7 +239,15 @@ internal class SoundsViewModelVisibilityTest : AbstractRobolectricTest() {
         val context = ApplicationProvider.getApplicationContext<android.app.Application>()
         runBlocking { SoundsRepository(context).save(testSound("moved", file = "m.mp3")) }
         val vm = givenAViewModel()
-        runBlocking { withTimeout(TIMEOUT_MS) { vm.collections.first { it.isNotEmpty() } } }
+        runBlocking {
+            withTimeout(TIMEOUT_MS) {
+                vm.collections.first { it.isNotEmpty() }
+                // Await allSoundsCache priming with "moved" before applyAssignment — evaluateAssignCloseEffects
+                // early-returns on an unprimed cache, so the moved-to-vault event never fires on a loaded CI
+                // machine (CLAUDE.md § JVM tests — await every async input).
+                vm.library.first { lib -> lib.any { it.name == "moved" } }
+            }
+        }
 
         vm.applyAssignment(
             "custom:moved",

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,17 @@ allprojects {
     }
 }
 
+// Binary, unconditional: every Kotlin compiler warning fails the build, so warnings can't
+// accumulate. All-or-nothing — the compile log must stay at zero `w:` (see docs/adr/0017).
+// Documented escape if the upgrade treadmill ever reddens untouched-code PRs: a CI-property gate.
+subprojects {
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask).configureEach {
+        compilerOptions {
+            allWarningsAsErrors.set(true)
+        }
+    }
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/commons_android/build.gradle
+++ b/commons_android/build.gradle
@@ -53,4 +53,7 @@ dependencies {
     testImplementation libs.mockk
     testImplementation libs.robolectric
     testImplementation libs.androidx.test.core
+    // AnalyticsCoverageMatrixTest enumerates AnalyticsEvent::class.sealedSubclasses; kotlin-reflect
+    // is the runtime backing for that reflection call (otherwise resolved only transitively).
+    testImplementation libs.kotlin.reflect
 }

--- a/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/FirebaseAnalyticsTrackerTest.kt
+++ b/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/FirebaseAnalyticsTrackerTest.kt
@@ -9,7 +9,9 @@ import android.os.Build
 import android.os.Bundle
 import com.google.common.truth.Truth.assertThat
 import com.google.firebase.analytics.FirebaseAnalytics
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
@@ -37,7 +39,7 @@ internal class FirebaseAnalyticsTrackerTest {
     @Test
     fun `log emits the base event with its params`() {
         val captured = slot<Bundle>()
-        every { firebase.logEvent(any(), capture(captured)) } answers { Unit }
+        every { firebase.logEvent(any(), capture(captured)) } just Runs
 
         tracker.log(AnalyticsEvent.SoundPlay(surface = "my_sounds"))
 
@@ -92,7 +94,7 @@ internal class FirebaseAnalyticsTrackerTest {
     @Test
     fun `log propagates SoundAdd params verbatim into the bundle`() {
         val captured = slot<Bundle>()
-        every { firebase.logEvent("sound_add", capture(captured)) } answers { Unit }
+        every { firebase.logEvent("sound_add", capture(captured)) } just Runs
 
         tracker.log(
             AnalyticsEvent.SoundAdd(
@@ -116,7 +118,7 @@ internal class FirebaseAnalyticsTrackerTest {
     @Test
     fun `logScreen emits SCREEN_VIEW with the canonical screen name`() {
         val captured = slot<Bundle>()
-        every { firebase.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, capture(captured)) } answers { Unit }
+        every { firebase.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, capture(captured)) } just Runs
 
         tracker.logScreen("my_sounds")
 
@@ -126,7 +128,7 @@ internal class FirebaseAnalyticsTrackerTest {
     @Test
     fun `logScreen merges extras into the screen view bundle`() {
         val captured = slot<Bundle>()
-        every { firebase.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, capture(captured)) } answers { Unit }
+        every { firebase.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, capture(captured)) } just Runs
 
         val extras = Bundle().apply { putString("source", "share") }
         tracker.logScreen("add_sound", extras)

--- a/docs/adr/0017-all-warnings-as-errors-binary.md
+++ b/docs/adr/0017-all-warnings-as-errors-binary.md
@@ -1,0 +1,83 @@
+# ADR 0017 — Binary `allWarningsAsErrors` for Kotlin compilation
+
+- **Status:** Accepted
+- **Date:** 2026-06-16
+- **Supersedes:** —
+
+## Context
+
+Kotlin compiler warnings (`w:`) carry real signal — deprecations, always-true
+conditions, unused expressions, reflection-not-on-classpath — but they do not
+fail the build, so they accumulate silently. By the time a deprecation becomes a
+removal in a later Kotlin/AGP bump, the warning has been ignored for months.
+
+With the Compose test-rule `junit4.v2` migration merged and the residual
+production + analytics-test warnings cleared, the whole compile log
+(`compileDebugKotlin`, `compileReleaseKotlin`, `compileDebugUnitTestKotlin`,
+`compileDebugAndroidTestKotlin` across all modules) reached **zero** `w:`. That
+is the precondition for turning warnings into errors: the gate is all-or-nothing
+and would fail on every pre-existing warning otherwise.
+
+## Decision drivers
+
+1. **Warnings should not rot.** A warning nobody is forced to read is a
+   deprecation discovered too late.
+2. **Simplicity first.** The smallest mechanism that holds the line, with a known
+   escape if it ever becomes counterproductive.
+3. **Uniform across modules and variants** — main, unit test, and androidTest, in
+   every module, with one declaration.
+
+## Options considered
+
+- **CI-property gate** (`allWarningsAsErrors.set(providers.gradleProperty(...))`,
+  `-PwarningsAsErrors=true` only in CI). Lets an upgrade PR flip the gate off while
+  fixing newly-introduced warnings. Rejected as the *starting* point: it is more
+  machinery than the current need, and a local build that passes while CI fails on
+  warnings is a worse feedback loop. Kept as the documented fallback.
+- **Per-module `kotlin { compilerOptions { ... } }`.** Same effect, four edit
+  sites that drift. Rejected for the single root declaration.
+- **Binary, unconditional, in the root `subprojects` block.** Chosen.
+
+## Decision
+
+Enable `allWarningsAsErrors` **binary and unconditional** in the root
+`build.gradle`, applied to every `KotlinCompilationTask` in every subproject:
+
+```groovy
+subprojects {
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask).configureEach {
+        compilerOptions {
+            allWarningsAsErrors.set(true)
+        }
+    }
+}
+```
+
+Any new Kotlin warning now fails the build locally and in CI alike. Keeping the
+compile log at zero `w:` is a hard precondition for any change.
+
+## Consequences
+
+- A Kotlin/AGP/library bump that introduces new warnings on otherwise-untouched
+  code will redden the upgrade PR. That is intended: the warnings get fixed (or
+  suppressed with a justified `@Suppress`) in the same PR that raises the version.
+- **Documented escape — the upgrade treadmill.** If bumps start reddening
+  untouched-code PRs often enough that it is net-negative, switch to the
+  CI-property gate:
+  `allWarningsAsErrors.set(providers.gradleProperty("warningsAsErrors").map { it.toBoolean() }.orElse(false))`,
+  pass `-PwarningsAsErrors=true` only in CI, and flip it off in the upgrade PR
+  while fixing the new warnings. This is the fallback, not day one.
+- A deliberately-kept warning needs an explicit, local `@Suppress` with a reason —
+  visible in review — instead of silently joining a warning pile.
+- No new CI job: the existing `compile` / `test` / `lint` jobs already invoke the
+  Kotlin compiler, so the gate rides along. A standalone grep guard for the build
+  flag was considered and skipped — removing the flag is self-evident in review and
+  would immediately let warnings back in.
+
+## Cross-references
+
+- `CLAUDE.md` § *Project-specific overrides* (build policy).
+- Verified at landing: full build green at zero warnings; a deliberately
+  reintroduced warning failed the build with `e: warnings found and -Werror
+  specified`, then reverted.
+- Kotlin compiler options (`allWarningsAsErrors`): https://kotlinlang.org/docs/gradle-compiler-options.html

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -110,6 +110,7 @@ androidx-test-rules               = { module = "androidx.test:rules",       vers
 robolectric                       = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 truth                             = { module = "com.google.truth:truth",    version.ref = "truth" }
 mockk                             = { module = "io.mockk:mockk",            version.ref = "mockk" }
+kotlin-reflect                    = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 espresso-core                     = { module = "androidx.test.espresso:espresso-core",          version.ref = "espresso" }
 espresso-intents                  = { module = "androidx.test.espresso:espresso-intents",       version.ref = "espresso" }
 espresso-accessibility            = { module = "androidx.test.espresso:espresso-accessibility", version.ref = "espresso" }


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change; CI resilience.

Two `SoundsViewModelVisibilityTest` cases (the dual-home coach and the moved-to-vault feedback) failed intermittently on loaded CI machines — about 1 in 3 runs locally. They invoked `applyAssignment` before the reactive `loadSounds` had primed the audio catalog, so the ViewModel's close-effects step saw an empty cache, never emitted the one-shot coach / moved-to-vault event, and the test's await timed out.

### Technical detail

- **`SoundsViewModelVisibilityTest`** — before `applyAssignment`, also await `vm.library` (the `allSoundsCache` `StateFlow`) containing the staged audio, mirroring the sibling `hideme` test. `evaluateAssignCloseEffects` does `allSoundsCache.value.firstOrNull { it.id == audioId } ?: return`, so an unprimed cache silently swallows the event.
- No production change; no assertions relaxed — only the missing precondition await is added (CLAUDE.md § JVM tests — await every async input).

### Code review tips

- The await keys on the audio `name` in `vm.library`, consistent with the `testSound("coach" / "moved")` setup. Same `runBlocking { withTimeout(...) }` shape already used elsewhere in the file.

### Already tested

- Re-ran the test class 12× locally after the fix: 12/12 green (was ~1/3 red before).
