### PR TITLE
chore(release): open the v2.3.0 development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][], and this project adheres to [Semantic Versioning][].
 
-## \[unreleased]
+## \[unreleased] (v2.3.0)
 
 ### For nerds 🤓
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,8 +19,8 @@ android {
         applicationId "com.github.barriosnahuel.vossosunboton"
         minSdkVersion 23
         targetSdkVersion 37
-        versionCode 7
-        versionName '2.2.0'
+        versionCode 8
+        versionName '2.3.0'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         // Keep capture/utility drivers out of the default suite (connectedDebugAndroidTest /
         // run-instrumented-tests.sh). The store-screenshot driver still runs via


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change. Opens the **v2.3.0** development cycle on develop: develop builds now carry the next version, and the changelog's Unreleased section is tagged for v2.3.0.

### Technical detail

- **`app/build.gradle`** — versionCode `7 → 8`, versionName `2.2.0 → 2.3.0`.
- **`CHANGELOG.md`** — tagged the existing `## [unreleased]` heading with `(v2.3.0)`.

### Code review tips

- **Interpretation (CHANGELOG):** the task asked for a *new empty* `[unreleased] (v2.3.0)`, but a **populated** `## [unreleased]` already existed (the `allWarningsAsErrors` entry merged after the v2.2.0 cut). I added the `(v2.3.0)` marker to that existing heading instead of creating a second one (two `[unreleased]` sections would be malformed); its content is a legit v2.3.0-cycle change. The released `## [v2.2.0]` section is untouched.
- **README version badges deliberately left at `2.2.0`** (the released version) — bumping them would advertise an unreleased version. Flagging in case you'd rather they track `build.gradle`.
- **Obligatory gates = compile + unit** (both run in CI); the instrumented suite is not obligatory — no app or test code is touched, only `build.gradle` + `CHANGELOG.md`.

### Already tested

Local `./gradlew assembleDebug test` green (build + unit); the PR's CI re-runs both. No instrumented run — version/changelog only.
