### PR TITLE
fix(model): recover pre-stable-id sounds instead of wiping the list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 ## \[unreleased] (v2.3.0)
 
+### Fixed
+- Bomps saved before an earlier update no longer disappear when you open the app — audios stored under the old format are recovered instead of the whole list silently emptying
+
 ### For nerds 🤓
 
 #### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,12 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 ### For nerds 🤓
 
+#### Added
+- `legacy_sounds_recovered` analytics event (one-shot per install) so the pre-stable-id population is countable and the migration's retirement is verifiable (ADR 0018)
+
 #### Changed
 - Kotlin compiler warnings now fail the build (`allWarningsAsErrors`, binary/unconditional) so they can't accumulate
+- `sounds_json` decoding is now element-by-element with id de-dup and a fast path, so one corrupt record can't wipe the list and clean payloads pay no recovery cost (ADR 0018)
 
 ## \[v2.2.0] - 2026-06-15
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -120,7 +120,18 @@ class SoundsViewModel(
             .DualHomeCoachStore(application),
 ) : AndroidViewModel(application),
     PlayerControllerListener {
-    private val repo = SoundsRepository(application, onError = Tracker::track)
+    private val repo =
+        SoundsRepository(
+            application,
+            onError = Tracker::track,
+            // Pre-stable-id data was healed on read (ADR 0018). Gate to one event per install so the
+            // per-read recovery doesn't flood; lets the legacy population be counted for retirement.
+            onLegacyRecovery = {
+                if (tracker.markFiredOnce("legacy_sounds_recovered")) {
+                    tracker.log(AnalyticsEvent.LegacySoundsRecovered)
+                }
+            },
+        )
 
     // Default `false` — flipped to `true` asynchronously by the IO coroutine in `init` after
     // reading the suspend `welcomeStore.isActive()`. Sub-frame in practice; same accepted

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelAnalyticsTest.kt
@@ -81,6 +81,25 @@ internal class SoundsViewModelAnalyticsTest : AbstractRobolectricTest() {
     }
 
     @Test
+    fun `legacy_sounds_recovered emits when the store holds pre-stable-id data`() {
+        runBlocking {
+            SoundsRepository(ApplicationProvider.getApplicationContext())
+                .setRawJsonForTest("""[{"name":"bell","file":"bell.mp3"}]""")
+        }
+
+        givenAViewModel()
+
+        fake.assertEmitted("legacy_sounds_recovered")
+    }
+
+    @Test
+    fun `legacy_sounds_recovered does not emit for a clean store`() {
+        givenAViewModel()
+
+        fake.assertNotEmitted("legacy_sounds_recovered")
+    }
+
+    @Test
     fun `togglePin emits pin_toggle with the resulting pinned state`() {
         val viewModel = givenAViewModel()
         val sound = testSound("test", file = "test.mp3")

--- a/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsEvent.kt
+++ b/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsEvent.kt
@@ -431,4 +431,14 @@ sealed class AnalyticsEvent(
      * naming screen". `hasFirstVariant = true`. The inert "record" row (badged "Soon") emits nothing.
      */
     object ImportHubImportSelected : AnalyticsEvent(name = "import_hub_import_selected", hasFirstVariant = true)
+
+    /**
+     * Pre-stable-id `sounds_json` data was found on disk and recovered on read — the install carried
+     * audio saved before sound records had a stable id (ADR 0008 → 0018), which now heals on read
+     * instead of wiping the list. Gated one-shot via `tracker.markFiredOnce("legacy_sounds_recovered")`
+     * so the per-read recovery doesn't flood dashboards; `hasFirstVariant = false` because the marker
+     * is already one-shot. Makes the legacy population countable, so ADR 0018's retirement criterion
+     * ("retire the migration once the population reaches zero") is actually verifiable.
+     */
+    object LegacySoundsRecovered : AnalyticsEvent(name = "legacy_sounds_recovered", hasFirstVariant = false)
 }

--- a/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsCoverageMatrixTest.kt
+++ b/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsCoverageMatrixTest.kt
@@ -95,6 +95,7 @@ internal class AnalyticsCoverageMatrixTest {
                 "OnboardingDismissed",
                 "ImportHubOpened",
                 "ImportHubImportSelected",
+                "LegacySoundsRecovered",
             )
 
         private val SCREEN_VIEWS_WITH_REGRESSION_TEST: Set<String> =

--- a/docs/adr/0008-stable-sound-id.md
+++ b/docs/adr/0008-stable-sound-id.md
@@ -1,6 +1,6 @@
 # ADR 0008 — Sound identity is a stable internal id, not the display name
 
-- **Status:** Accepted
+- **Status:** Accepted (decision #5 / Option A amended by [ADR 0018](0018-legacy-sounds-schema-migration.md))
 - **Date:** 2026-05-15
 - **Supersedes:** The "Why `Sound.name` as the cache key" section of [ADR 0007](0007-sound-playback-pause-resume.md) and the name-as-identity weakness it called out. The rest of ADR 0007 — pause/resume semantics, position cache, listener changes — stands; the cache key migrates from `Sound.name` to `Sound.id`.
 
@@ -22,7 +22,7 @@ The app **has no users yet** — the `StoredSound` JSON schema can be broken wit
 2. **Stable across installs for bundled sounds.** Reinstalling the app must not invalidate a pinned-bundled flag persisted via the new id.
 3. **Minimum-churn migration to call sites.** The convenience constructor `Sound(name, rawRes)` for bundled sounds must keep its signature so `PackagedAudios.java` and `welcomeSticker()` need no edits. The new id is derived inside that constructor.
 4. **No regressions in `StateFlow` recomposition.** The VM intentionally re-emits the same logical sound with flipped `isPlaying`/`isPinned`. Identity must not bleed into structural equality (see *Why structural `equals` is preserved* below).
-5. **No data migration.** No-users window; old-schema JSON degrades to empty list via `decodeSafely`.
+5. **No data migration.** No-users window; old-schema JSON degrades to empty list via `decodeSafely`. **(Amended by [ADR 0018](0018-legacy-sounds-schema-migration.md): the no-users premise proved false — production Crashlytics shows a real user whose pre-id payload degraded to empty, silently wiping their saved audio. A read-time migration now derives the missing id instead of dropping the list.)**
 
 ## Decision
 

--- a/docs/adr/0018-legacy-sounds-schema-migration.md
+++ b/docs/adr/0018-legacy-sounds-schema-migration.md
@@ -1,0 +1,42 @@
+# ADR 0018 — Migrate pre-stable-id `sounds_json` payloads instead of degrading to empty
+
+- **Status:** Accepted
+- **Date:** 2026-06-21
+- **Amends:** [ADR 0008](0008-stable-sound-id.md) decision #5 ("No data migration") and its rejected Option A ("Migrate persisted data instead of breaking the schema"). The rest of ADR 0008 — the id scheme, structural `equals`, call-site identity — stands unchanged.
+
+## Context
+
+ADR 0008 made `StoredSound.id` a required field and explicitly shipped **no migration**, justified by a single premise: *"The app has no users yet."* Old-schema JSON (identity was the display `name`, no `id` field) was expected to degrade to an empty list via `decodeSafely`, and a test encoded that as the desired behavior.
+
+The premise was false. Production Crashlytics (`bomp-prod.firebase_crashlytics`, app 2.1.0) recorded a real user (moto g(20), Android 11) whose persisted payload predates the id field:
+
+```
+RuntimeException: Malformed sounds_json payload, recovering with empty list
+  caused by MissingFieldException: Field 'id' is required for type with serial
+  name '…model.data.StoredSound', but it was missing at path: $[0]
+```
+
+`kotlinx.serialization` aborts decoding the **whole list** on the first element missing `id`. `decodeSafely` catches that `SerializationException` and returns `emptyList()` — so one legacy element silently wipes every saved sound the user has, including valid ones, on every read. The user is left without access to their content; the failure recurs on each launch until they re-create everything from scratch.
+
+## Decision
+
+Add a **read-time migration** in front of strict decoding. `decodeSafely` parses the raw payload to a `JsonElement`, runs `migrateLegacySchema`, then strict-decodes the healed tree:
+
+- For each array element missing a usable `id`, derive `id = "custom:<name>"` from the element's pre-0008 name identity (ADR 0007) — a stable, deterministic key reconstructed from the only stable field a legacy record has. This is **not** the production custom-id format (those are random UUIDs minted at save time); it intentionally reuses the old name-as-identity as the recovery key (the test helpers in `TestSounds` happen to use the same `custom:<name>` shape). Old-schema names were unique (the pre-0008 name-as-identity invariant), so derived ids do not collide with each other, with new UUID-minted custom ids, or with `bundled:<rawRes>` ids.
+- An element missing **both** `id` and `name` is unrecoverable and is dropped; its siblings survive.
+- A non-array root is passed through untouched for strict decode to accept or reject.
+- Migration is **silent** (no `onError`): a successful recovery is expected behavior, not a non-fatal to investigate (per the error-tracking contract — `Tracker.track` is reserved for things ops should chase). Healed ids persist to disk on the next `mutate` write-back; until then every read re-heals.
+
+This is exactly ADR 0008's rejected Option A, now warranted because the window it relied on ("the app has no users") has closed.
+
+## Consequences
+
+- **Custom audio is recovered, not lost.** The user's files (`file != null`) reappear with a stable id and remain addressable by rename/delete/pin.
+- **Bundled stubs are not fully reconstructable (accepted limitation).** A pre-0008 pin/duration stub on a *bundled* sound stored only its `name`, not its `rawRes`. The migration assigns it `custom:<name>`, which will not match the bundled sound's real `bundled:<rawRes>` id in `mergeWithBundled`, so that single pin/duration is silently dropped. This is a strict improvement over the prior behavior (which dropped everything) and affects only re-creatable bundled flags, never user content. Reconstructing them would require a `name → rawRes` reverse lookup against `PackagedAudios`; deliberately out of scope.
+- **The legacy path is permanent.** As ADR 0008 warned, migration code ages into the codebase. It is small, pure, and fully unit-tested (`SoundsRepositoryTest`), so the maintenance cost is low.
+
+## Revisit criteria
+
+- If a future schema change adds another required field, extend `migrateLegacySchema` (or introduce a versioned payload envelope) rather than catching-and-wiping.
+- If bundled pins/durations are observed lost at meaningful scale, add the `name → rawRes` reverse lookup for bundled stubs.
+- If the legacy population reaches zero (verifiable once healed ids have persisted across the install base), the migration may be retired behind a one-shot guard like `migrateVisibilityIfNeeded` (ADR 0012).

--- a/docs/adr/0018-legacy-sounds-schema-migration.md
+++ b/docs/adr/0018-legacy-sounds-schema-migration.md
@@ -20,23 +20,26 @@ RuntimeException: Malformed sounds_json payload, recovering with empty list
 
 ## Decision
 
-Add a **read-time migration** in front of strict decoding. `decodeSafely` parses the raw payload to a `JsonElement`, runs `migrateLegacySchema`, then strict-decodes the healed tree:
+Recover legacy/partially-corrupt data at read time instead of wiping the list. `decodeSafely` works in two tiers:
 
-- For each array element missing a usable `id`, derive `id = "custom:<name>"` from the element's pre-0008 name identity (ADR 0007) — a stable, deterministic key reconstructed from the only stable field a legacy record has. This is **not** the production custom-id format (those are random UUIDs minted at save time); it intentionally reuses the old name-as-identity as the recovery key (the test helpers in `TestSounds` happen to use the same `custom:<name>` shape). Old-schema names were unique (the pre-0008 name-as-identity invariant), so derived ids do not collide with each other, with new UUID-minted custom ids, or with `bundled:<rawRes>` ids.
-- An element missing **both** `id` and `name` is unrecoverable and is dropped; its siblings survive.
-- A non-array root is passed through untouched for strict decode to accept or reject.
-- Migration is **silent** (no `onError`): a successful recovery is expected behavior, not a non-fatal to investigate (per the error-tracking contract — `Tracker.track` is reserved for things ops should chase). Healed ids persist to disk on the next `mutate` write-back; until then every read re-heals.
+- **Fast path (the overwhelming majority).** Try a single streaming `decodeFromString`. A clean modern payload decodes with no intermediate JSON tree and is returned directly — new installs pay nothing for the migration.
+- **Element-wise recovery (slow path).** Reached only when the fast path throws *or* decodes a blank `id` (conditions only legacy/corrupt data produces). Parse the list to a tree once and decode **each element independently**, so a single bad record can never abort the whole list:
+  - For an element missing or blank `id`, derive `id = "custom:<name>"` from the element's pre-0008 name identity (ADR 0007) — a stable, deterministic key reconstructed from the only stable field a legacy record has. This is **not** the production custom-id format (those are random UUIDs minted at save time); it intentionally reuses the old name-as-identity as the recovery key (the test helpers in `TestSounds` happen to use the same `custom:<name>` shape).
+  - An element that is a non-object, has no `name` to derive an id from, or still fails strict decode (e.g. a non-string `id`, a missing required `name`) is **dropped**; its siblings survive.
+  - Derived ids are **de-duplicated keep-first.** Old-schema names were unique (the pre-0008 name-as-identity upsert invariant), so collisions should not arise from pristine data — but a restored/merged Auto Backup or a hand-edited payload could reintroduce same-name records, and two identical `"custom:<name>"` ids would crash the `id`-keyed Compose lists (`LazyColumn(key = sound.id)`). Keep-first degrades that worst case (a launch crash, *worse* than the wipe this ADR fixes) to dropping the duplicate. A non-blank but meaningless sentinel `id` (e.g. the literal string `"null"`) is treated as a real id and not re-keyed — only null/blank triggers healing.
+  - Only a **corrupt root** (not valid JSON, or a non-array) degrades to an empty list with an `onError`.
+- **Recovery is observable but does not alarm.** A heal/drop is not an `onError` (that surfaces a Crashlytics non-fatal, reserved for things ops should chase). Instead the slow path invokes an injected `onLegacyRecovery` callback — decoupled from analytics exactly as `onError` is from Crashlytics — which `:app` gates one-shot per install (`markFiredOnce`) into the `legacy_sounds_recovered` analytics event. That keeps the per-read recovery quiet while making the legacy population countable (the retirement criterion below). Healed ids persist to disk on the next `mutate` write-back; until then every read re-heals.
 
 This is exactly ADR 0008's rejected Option A, now warranted because the window it relied on ("the app has no users") has closed.
 
 ## Consequences
 
 - **Custom audio is recovered, not lost.** The user's files (`file != null`) reappear with a stable id and remain addressable by rename/delete/pin.
-- **Bundled stubs are not fully reconstructable (accepted limitation).** A pre-0008 pin/duration stub on a *bundled* sound stored only its `name`, not its `rawRes`. The migration assigns it `custom:<name>`, which will not match the bundled sound's real `bundled:<rawRes>` id in `mergeWithBundled`, so that single pin/duration is silently dropped. This is a strict improvement over the prior behavior (which dropped everything) and affects only re-creatable bundled flags, never user content. Reconstructing them would require a `name → rawRes` reverse lookup against `PackagedAudios`; deliberately out of scope.
+- **Bundled stubs are not fully reconstructable (accepted limitation).** A pre-0008 pin/duration stub on a *bundled* sound stored only its `name`, not its `rawRes`. The migration assigns it `custom:<name>`, which will not match the bundled sound's real `bundled:<rawRes>` id in `mergeWithBundled`, so that single pin/duration is silently dropped (`file == null` stubs are filtered out of the rendered list, so it never surfaces as a dead/unplayable row). It does, however, get re-persisted as a file-less `custom:<name>` record on the next write — harmless dead weight that accumulates one row per legacy bundled stub; never user content. Reconstructing the pin would require a `name → rawRes` reverse lookup against `PackagedAudios`; deliberately out of scope.
 - **The legacy path is permanent.** As ADR 0008 warned, migration code ages into the codebase. It is small, pure, and fully unit-tested (`SoundsRepositoryTest`), so the maintenance cost is low.
 
 ## Revisit criteria
 
-- If a future schema change adds another required field, extend `migrateLegacySchema` (or introduce a versioned payload envelope) rather than catching-and-wiping.
-- If bundled pins/durations are observed lost at meaningful scale, add the `name → rawRes` reverse lookup for bundled stubs.
-- If the legacy population reaches zero (verifiable once healed ids have persisted across the install base), the migration may be retired behind a one-shot guard like `migrateVisibilityIfNeeded` (ADR 0012).
+- If a future schema change adds another required field, the element-wise decode already degrades that to dropping the offending element rather than wiping the list; add a field-specific healer (like the `id` one) when the field is reconstructable.
+- If bundled pins/durations are observed lost at meaningful scale, add the `name → rawRes` reverse lookup for bundled stubs (and prune the accumulated file-less rows).
+- Once `legacy_sounds_recovered` drops to ~zero new installs/day, the legacy population is effectively migrated and the slow-path healers may be retired behind a one-shot guard like `migrateVisibilityIfNeeded` (ADR 0012).

--- a/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepository.kt
+++ b/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepository.kt
@@ -280,17 +280,31 @@ class SoundsRepository(
      * field a legacy record has; it is not the production custom-id format (those are UUIDs minted at
      * save time). An element with neither `id` nor `name` is unrecoverable and is dropped, leaving its
      * siblings intact. A non-array root is returned untouched for strict decode to handle (or reject).
+     *
+     * Derived ids are de-duplicated keep-first: a repeated pre-0008 `name` would otherwise mint two
+     * identical `"custom:<name>"` ids, and `id`-keyed Compose lists (`LazyColumn(key = sound.id)`)
+     * crash on a duplicate key — so the recovery for a user with such data would turn the old silent
+     * wipe into a launch crash. Keep-first degrades that worst case to dropping the duplicate.
+     *
      * Healed ids persist on the next [mutate]; see ADR 0018 for the bundled-stub limitation and
      * revisit criteria.
      */
     private fun migrateLegacySchema(root: JsonElement): JsonElement {
         if (root !is JsonArray) return root
+        val seenIds = HashSet<String>()
         return JsonArray(
             root.mapNotNull { element ->
                 val obj = element as? JsonObject ?: return@mapNotNull element
-                if (!(obj["id"] as? JsonPrimitive)?.contentOrNull.isNullOrBlank()) return@mapNotNull obj
-                val name = (obj["name"] as? JsonPrimitive)?.contentOrNull
-                if (name.isNullOrBlank()) null else JsonObject(obj + ("id" to JsonPrimitive("custom:$name")))
+                val healed =
+                    if (!(obj["id"] as? JsonPrimitive)?.contentOrNull.isNullOrBlank()) {
+                        obj
+                    } else {
+                        val name = (obj["name"] as? JsonPrimitive)?.contentOrNull
+                        if (name.isNullOrBlank()) return@mapNotNull null
+                        JsonObject(obj + ("id" to JsonPrimitive("custom:$name")))
+                    }
+                val id = (healed["id"] as? JsonPrimitive)?.contentOrNull
+                if (id != null && !seenIds.add(id)) null else healed
             },
         )
     }

--- a/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepository.kt
+++ b/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepository.kt
@@ -259,54 +259,68 @@ class SoundsRepository(
         }
     }
 
+    /**
+     * Decodes the `sounds_json` payload element-by-element so a single bad record can never wipe the
+     * whole list (the failure mode that lost a real user's audio — ADR 0008 → 0018). The list is
+     * parsed once to a tree; each element is healed + decoded independently; an element that cannot
+     * be recovered is dropped while its siblings survive. Derived ids are de-duplicated keep-first.
+     *
+     * Only a corrupt root (not valid JSON, or a non-array) degrades to an empty list with an
+     * `onError`; per-element drops are silent recovery.
+     */
     private fun decodeSafely(raw: String?): List<StoredSound> {
         if (raw.isNullOrEmpty()) return emptyList()
+        val root =
+            try {
+                json.parseToJsonElement(raw)
+            } catch (e: SerializationException) {
+                onError(RuntimeException("Malformed sounds_json payload, recovering with empty list", e))
+                return emptyList()
+            }
+        if (root !is JsonArray) {
+            onError(
+                RuntimeException(
+                    "Invalid sounds_json structure, recovering with empty list",
+                    IllegalArgumentException("sounds_json root is not a JSON array"),
+                ),
+            )
+            return emptyList()
+        }
+        val seenIds = HashSet<String>()
+        return root.mapNotNull { decodeElement(it) }.filter { seenIds.add(it.id) }
+    }
+
+    /**
+     * Decodes one array element into a [StoredSound], or null if it is unrecoverable (a non-object,
+     * an object with no usable `id` and no `name` to derive one from, or an object that still fails
+     * strict decode — e.g. a non-string `id` or a missing required field). Returning null drops just
+     * that element; callers keep the rest.
+     */
+    private fun decodeElement(element: JsonElement): StoredSound? {
+        val obj = element as? JsonObject ?: return null
+        val healed = healLegacyId(obj) ?: return null
         return try {
-            json.decodeFromJsonElement(SOUNDS_SERIALIZER, migrateLegacySchema(json.parseToJsonElement(raw)))
+            json.decodeFromJsonElement(StoredSound.serializer(), healed)
         } catch (e: SerializationException) {
-            onError(RuntimeException("Malformed sounds_json payload, recovering with empty list", e))
-            emptyList()
+            null
         } catch (e: IllegalArgumentException) {
-            onError(RuntimeException("Invalid sounds_json structure, recovering with empty list", e))
-            emptyList()
+            null
         }
     }
 
     /**
-     * Heals payloads written before [StoredSound.id] became a required field (ADR 0008 → 0018).
-     * For each element missing a usable `id`, derives `"custom:<name>"` from the element's pre-0008
-     * name identity (ADR 0007) — a stable, deterministic key — so the user's audio is recovered
-     * instead of the whole list degrading to empty. This reconstructs identity from the only stable
-     * field a legacy record has; it is not the production custom-id format (those are UUIDs minted at
-     * save time). An element with neither `id` nor `name` is unrecoverable and is dropped, leaving its
-     * siblings intact. A non-array root is returned untouched for strict decode to handle (or reject).
-     *
-     * Derived ids are de-duplicated keep-first: a repeated pre-0008 `name` would otherwise mint two
-     * identical `"custom:<name>"` ids, and `id`-keyed Compose lists (`LazyColumn(key = sound.id)`)
-     * crash on a duplicate key — so the recovery for a user with such data would turn the old silent
-     * wipe into a launch crash. Keep-first degrades that worst case to dropping the duplicate.
-     *
-     * Healed ids persist on the next [mutate]; see ADR 0018 for the bundled-stub limitation and
-     * revisit criteria.
+     * Heals a record written before [StoredSound.id] became required (ADR 0008 → 0018): when `id` is
+     * missing or blank, derives `"custom:<name>"` from the element's pre-0008 name identity (ADR 0007)
+     * — a stable, deterministic key reconstructed from the only stable field a legacy record has (not
+     * the production custom-id format, which is a random UUID minted at save time). Returns the object
+     * unchanged when it already has a usable `id`, or null when there is no `name` to derive one from.
+     * Healed ids persist on the next [mutate]; see ADR 0018 for the bundled-stub limitation.
      */
-    private fun migrateLegacySchema(root: JsonElement): JsonElement {
-        if (root !is JsonArray) return root
-        val seenIds = HashSet<String>()
-        return JsonArray(
-            root.mapNotNull { element ->
-                val obj = element as? JsonObject ?: return@mapNotNull element
-                val healed =
-                    if (!(obj["id"] as? JsonPrimitive)?.contentOrNull.isNullOrBlank()) {
-                        obj
-                    } else {
-                        val name = (obj["name"] as? JsonPrimitive)?.contentOrNull
-                        if (name.isNullOrBlank()) return@mapNotNull null
-                        JsonObject(obj + ("id" to JsonPrimitive("custom:$name")))
-                    }
-                val id = (healed["id"] as? JsonPrimitive)?.contentOrNull
-                if (id != null && !seenIds.add(id)) null else healed
-            },
-        )
+    private fun healLegacyId(obj: JsonObject): JsonObject? {
+        val id = (obj["id"] as? JsonPrimitive)?.contentOrNull
+        if (!id.isNullOrBlank()) return obj
+        val name = (obj["name"] as? JsonPrimitive)?.contentOrNull
+        return if (name.isNullOrBlank()) null else JsonObject(obj + ("id" to JsonPrimitive("custom:$name")))
     }
 
     private fun mergeWithBundled(

--- a/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepository.kt
+++ b/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepository.kt
@@ -31,6 +31,11 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 import timber.log.Timber
 
 /**
@@ -257,7 +262,7 @@ class SoundsRepository(
     private fun decodeSafely(raw: String?): List<StoredSound> {
         if (raw.isNullOrEmpty()) return emptyList()
         return try {
-            json.decodeFromString(SOUNDS_SERIALIZER, raw)
+            json.decodeFromJsonElement(SOUNDS_SERIALIZER, migrateLegacySchema(json.parseToJsonElement(raw)))
         } catch (e: SerializationException) {
             onError(RuntimeException("Malformed sounds_json payload, recovering with empty list", e))
             emptyList()
@@ -265,6 +270,29 @@ class SoundsRepository(
             onError(RuntimeException("Invalid sounds_json structure, recovering with empty list", e))
             emptyList()
         }
+    }
+
+    /**
+     * Heals payloads written before [StoredSound.id] became a required field (ADR 0008 → 0018).
+     * For each element missing a usable `id`, derives `"custom:<name>"` from the element's pre-0008
+     * name identity (ADR 0007) — a stable, deterministic key — so the user's audio is recovered
+     * instead of the whole list degrading to empty. This reconstructs identity from the only stable
+     * field a legacy record has; it is not the production custom-id format (those are UUIDs minted at
+     * save time). An element with neither `id` nor `name` is unrecoverable and is dropped, leaving its
+     * siblings intact. A non-array root is returned untouched for strict decode to handle (or reject).
+     * Healed ids persist on the next [mutate]; see ADR 0018 for the bundled-stub limitation and
+     * revisit criteria.
+     */
+    private fun migrateLegacySchema(root: JsonElement): JsonElement {
+        if (root !is JsonArray) return root
+        return JsonArray(
+            root.mapNotNull { element ->
+                val obj = element as? JsonObject ?: return@mapNotNull element
+                if (!(obj["id"] as? JsonPrimitive)?.contentOrNull.isNullOrBlank()) return@mapNotNull obj
+                val name = (obj["name"] as? JsonPrimitive)?.contentOrNull
+                if (name.isNullOrBlank()) null else JsonObject(obj + ("id" to JsonPrimitive("custom:$name")))
+            },
+        )
     }
 
     private fun mergeWithBundled(

--- a/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepository.kt
+++ b/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepository.kt
@@ -282,10 +282,11 @@ class SoundsRepository(
         if (raw.isNullOrEmpty()) return emptyList()
         return try {
             val decoded = json.decodeFromString(SOUNDS_SERIALIZER, raw)
+            // A blank id only comes from legacy/corrupt data → recover; otherwise the fast result wins.
             if (decoded.none { it.id.isBlank() }) decoded else recoverElementwise(raw)
-        } catch (e: SerializationException) {
+        } catch (ignored: SerializationException) {
             recoverElementwise(raw)
-        } catch (e: IllegalArgumentException) {
+        } catch (ignored: IllegalArgumentException) {
             recoverElementwise(raw)
         }
     }
@@ -298,30 +299,35 @@ class SoundsRepository(
      * silent recovery.
      */
     private fun recoverElementwise(raw: String): List<StoredSound> {
+        val array = parseSoundsArray(raw) ?: return emptyList()
+        val seenIds = HashSet<String>()
+        val recovered = array.mapNotNull { decodeElement(it) }.filter { seenIds.add(it.id) }
+        // Reaching here means the fast path rejected the payload (threw or had a blank id) yet the
+        // root is a valid array — i.e. legacy/corrupt data we just healed. Signal it (gated by the
+        // caller) so the legacy population stays observable; a malformed/non-array root returned a
+        // null array above without firing.
+        onLegacyRecovery()
+        return recovered
+    }
+
+    /** Parses [raw] to a [JsonArray], or null (with an `onError`) if it is not valid JSON or not an array. */
+    private fun parseSoundsArray(raw: String): JsonArray? {
         val root =
             try {
                 json.parseToJsonElement(raw)
             } catch (e: SerializationException) {
                 onError(RuntimeException("Malformed sounds_json payload, recovering with empty list", e))
-                return emptyList()
+                return null
             }
-        if (root !is JsonArray) {
+        return root as? JsonArray ?: run {
             onError(
                 RuntimeException(
                     "Invalid sounds_json structure, recovering with empty list",
                     IllegalArgumentException("sounds_json root is not a JSON array"),
                 ),
             )
-            return emptyList()
+            null
         }
-        val seenIds = HashSet<String>()
-        val recovered = root.mapNotNull { decodeElement(it) }.filter { seenIds.add(it.id) }
-        // Reaching here means the fast path rejected the payload (threw or had a blank id) yet the
-        // root is a valid array — i.e. legacy/corrupt data we just healed. Signal it (gated by the
-        // caller) so the legacy population stays observable; a malformed/non-array root returned
-        // above without firing.
-        onLegacyRecovery()
-        return recovered
     }
 
     /**
@@ -331,13 +337,12 @@ class SoundsRepository(
      * that element; callers keep the rest.
      */
     private fun decodeElement(element: JsonElement): StoredSound? {
-        val obj = element as? JsonObject ?: return null
-        val healed = healLegacyId(obj) ?: return null
+        val healed = (element as? JsonObject)?.let { healLegacyId(it) } ?: return null
         return try {
             json.decodeFromJsonElement(StoredSound.serializer(), healed)
-        } catch (e: SerializationException) {
+        } catch (ignored: SerializationException) {
             null
-        } catch (e: IllegalArgumentException) {
+        } catch (ignored: IllegalArgumentException) {
             null
         }
     }

--- a/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepository.kt
+++ b/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepository.kt
@@ -260,16 +260,35 @@ class SoundsRepository(
     }
 
     /**
-     * Decodes the `sounds_json` payload element-by-element so a single bad record can never wipe the
-     * whole list (the failure mode that lost a real user's audio — ADR 0008 → 0018). The list is
-     * parsed once to a tree; each element is healed + decoded independently; an element that cannot
-     * be recovered is dropped while its siblings survive. Derived ids are de-duplicated keep-first.
+     * Decodes the `sounds_json` payload, recovering legacy/partially-corrupt data instead of wiping
+     * the list (ADR 0008 → 0018).
      *
-     * Only a corrupt root (not valid JSON, or a non-array) degrades to an empty list with an
-     * `onError`; per-element drops are silent recovery.
+     * Fast path (every post-migration install — the overwhelming majority): a clean payload decodes
+     * in a single streaming pass with no intermediate JSON tree. The element-by-element recovery
+     * (tree parse + per-element heal/decode + de-dup) runs only when the fast path proves the payload
+     * is not clean — it threw, or it decoded but carries a blank `id` (which only legacy/corrupt data
+     * produces). So new users never pay the recovery cost, and old users still get fully healed.
      */
     private fun decodeSafely(raw: String?): List<StoredSound> {
         if (raw.isNullOrEmpty()) return emptyList()
+        return try {
+            val decoded = json.decodeFromString(SOUNDS_SERIALIZER, raw)
+            if (decoded.none { it.id.isBlank() }) decoded else recoverElementwise(raw)
+        } catch (e: SerializationException) {
+            recoverElementwise(raw)
+        } catch (e: IllegalArgumentException) {
+            recoverElementwise(raw)
+        }
+    }
+
+    /**
+     * Slow path: parse the list to a tree once, heal + decode each element independently, drop any
+     * that cannot be recovered (a single bad record can never wipe the rest — the failure mode that
+     * lost a real user's audio), and de-duplicate derived ids keep-first. Only a corrupt root (not
+     * valid JSON, or a non-array) degrades to an empty list with an `onError`; per-element drops are
+     * silent recovery.
+     */
+    private fun recoverElementwise(raw: String): List<StoredSound> {
         val root =
             try {
                 json.parseToJsonElement(raw)

--- a/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepository.kt
+++ b/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepository.kt
@@ -56,6 +56,15 @@ class SoundsRepository(
      * non-fatals in the dashboard.
      */
     private val onError: (Throwable) -> Unit = { Timber.w(it) },
+    /**
+     * Invoked when a read recovered legacy/corrupt `sounds_json` data (a pre-stable-id payload that
+     * was healed, or any element that had to be dropped). May fire on more than one read until the
+     * healed data is persisted, so callers must gate it (e.g. `markFiredOnce`) before emitting
+     * telemetry. Decoupled from analytics exactly as [onError] is from Crashlytics; `:app` wires the
+     * one-shot `legacy_sounds_recovered` event so the population stays observable (ADR 0018). Default
+     * no-op.
+     */
+    private val onLegacyRecovery: () -> Unit = {},
 ) {
     private val storedSounds: Flow<List<StoredSound>> =
         context.bompsStore.data
@@ -306,7 +315,13 @@ class SoundsRepository(
             return emptyList()
         }
         val seenIds = HashSet<String>()
-        return root.mapNotNull { decodeElement(it) }.filter { seenIds.add(it.id) }
+        val recovered = root.mapNotNull { decodeElement(it) }.filter { seenIds.add(it.id) }
+        // Reaching here means the fast path rejected the payload (threw or had a blank id) yet the
+        // root is a valid array — i.e. legacy/corrupt data we just healed. Signal it (gated by the
+        // caller) so the legacy population stays observable; a malformed/non-array root returned
+        // above without firing.
+        onLegacyRecovery()
+        return recovered
     }
 
     /**

--- a/model/src/test/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepositoryTest.kt
+++ b/model/src/test/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepositoryTest.kt
@@ -312,6 +312,22 @@ internal class SoundsRepositoryTest : AbstractRobolectricTest() {
         }
 
     @Test
+    fun `two legacy elements sharing a name collapse to one recovered sound keep-first`() =
+        runTest {
+            // Same derived id "custom:bell" for both — without de-dup this crashes id-keyed Compose
+            // lists; keep-first drops the second, leaving the first ("a.mp3") addressable.
+            repo.setRawJsonForTest(
+                """[{"name":"bell","file":"a.mp3"},{"name":"bell","file":"b.mp3"}]""",
+            )
+
+            val list = repo.sounds.first().filter { !it.isBundled() }
+
+            assertThat(list).hasSize(1)
+            assertThat(list.single().id).isEqualTo("custom:bell")
+            assertThat(list.single().file).isEqualTo("a.mp3")
+        }
+
+    @Test
     fun `legacy element preserves its persisted flags through the migration`() =
         runTest {
             repo.setRawJsonForTest(

--- a/model/src/test/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepositoryTest.kt
+++ b/model/src/test/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepositoryTest.kt
@@ -352,6 +352,29 @@ internal class SoundsRepositoryTest : AbstractRobolectricTest() {
         }
 
     @Test
+    fun `a non-object array element is dropped without wiping valid siblings`() =
+        runTest {
+            repo.setRawJsonForTest("""[5,{"id":"custom:keep","name":"keep","file":"keep.mp3"}]""")
+
+            val list = repo.sounds.first().filter { !it.isBundled() }
+
+            assertThat(list.map { it.name }).containsExactly("keep")
+            assertThat(recordedErrors).isEmpty()
+        }
+
+    @Test
+    fun `an element with a valid id but missing the required name is dropped without wiping siblings`() =
+        runTest {
+            repo.setRawJsonForTest(
+                """[{"id":"custom:x","file":"x.mp3"},{"id":"custom:keep","name":"keep","file":"keep.mp3"}]""",
+            )
+
+            val list = repo.sounds.first().filter { !it.isBundled() }
+
+            assertThat(list.map { it.name }).containsExactly("keep")
+        }
+
+    @Test
     fun `legacy element missing both id and name is dropped without wiping the list`() =
         runTest {
             repo.setRawJsonForTest(

--- a/model/src/test/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepositoryTest.kt
+++ b/model/src/test/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepositoryTest.kt
@@ -262,17 +262,90 @@ internal class SoundsRepositoryTest : AbstractRobolectricTest() {
         }
 
     @Test
-    fun `legacy JSON without an id field returns empty list and reports via onError`() =
+    fun `legacy JSON without an id field recovers the custom sound by deriving a stable id`() =
         runTest {
-            // Pre-stable-id schema: valid JSON, but StoredSound.id is now a required field.
-            // No data migration ships (the app had no users) — the read degrades to an empty list.
+            // Pre-stable-id schema (ADR 0008 → 0018): valid JSON, but StoredSound.id is now required.
+            // A real user updated with this on disk; the migration derives id from name, recovering it.
             repo.setRawJsonForTest("""[{"name":"bell","file":"bell.mp3"}]""")
+
+            val list = repo.sounds.first().filter { !it.isBundled() }
+
+            assertThat(list).hasSize(1)
+            assertThat(list.single().name).isEqualTo("bell")
+            assertThat(list.single().file).isEqualTo("bell.mp3")
+            // Recovery is graceful: not reported as a malformed-payload error.
+            assertThat(recordedErrors).isEmpty()
+        }
+
+    @Test
+    fun `legacy element with a blank id string is healed from its name`() =
+        runTest {
+            repo.setRawJsonForTest("""[{"id":"","name":"bell","file":"bell.mp3"}]""")
+
+            val list = repo.sounds.first().filter { !it.isBundled() }
+
+            assertThat(list.single().name).isEqualTo("bell")
+            assertThat(recordedErrors).isEmpty()
+        }
+
+    @Test
+    fun `non-array JSON root returns empty list and reports via onError`() =
+        runTest {
+            repo.setRawJsonForTest("""{"name":"bell","file":"bell.mp3"}""")
 
             val list = repo.sounds.first().filter { !it.isBundled() }
 
             assertThat(list).isEmpty()
             assertThat(recordedErrors).hasSize(1)
-            assertThat(recordedErrors.single().message).contains("Malformed sounds_json")
+        }
+
+    @Test
+    fun `legacy element without id does not wipe sibling valid elements`() =
+        runTest {
+            repo.setRawJsonForTest(
+                """[{"name":"old","file":"old.mp3"},{"id":"custom:new","name":"new","file":"new.mp3"}]""",
+            )
+
+            val list = repo.sounds.first().filter { !it.isBundled() }
+
+            assertThat(list.map { it.name }).containsExactly("old", "new")
+        }
+
+    @Test
+    fun `legacy element preserves its persisted flags through the migration`() =
+        runTest {
+            repo.setRawJsonForTest(
+                """[{"name":"bell","file":"bell.mp3","isPinned":true,"isFavorite":true}]""",
+            )
+
+            val recovered = repo.sounds.first().first { it.name == "bell" }
+
+            assertThat(recovered.isPinned).isTrue()
+            assertThat(recovered.isFavorite).isTrue()
+        }
+
+    @Test
+    fun `recovered legacy sound is addressable by its derived id on the next write`() =
+        runTest {
+            repo.setRawJsonForTest("""[{"name":"bell","file":"bell.mp3"}]""")
+
+            repo.rename("custom:bell", "doorbell")
+
+            val list = repo.sounds.first().filter { !it.isBundled() }
+            assertThat(list.single().name).isEqualTo("doorbell")
+        }
+
+    @Test
+    fun `legacy element missing both id and name is dropped without wiping the list`() =
+        runTest {
+            repo.setRawJsonForTest(
+                """[{"file":"orphan.mp3"},{"id":"custom:keep","name":"keep","file":"keep.mp3"}]""",
+            )
+
+            val list = repo.sounds.first().filter { !it.isBundled() }
+
+            assertThat(list.map { it.name }).containsExactly("keep")
+            assertThat(recordedErrors).isEmpty()
         }
 
     // ── isVisibleInMySounds (ADR 0012) ──────────────────────────────────────────────────────

--- a/model/src/test/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepositoryTest.kt
+++ b/model/src/test/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepositoryTest.kt
@@ -375,6 +375,32 @@ internal class SoundsRepositoryTest : AbstractRobolectricTest() {
         }
 
     @Test
+    fun `onLegacyRecovery fires when a legacy payload is recovered`() =
+        runTest {
+            var recoveries = 0
+            val observed =
+                SoundsRepository(context, onError = { recordedErrors += it }, onLegacyRecovery = { recoveries++ })
+            observed.setRawJsonForTest("""[{"name":"bell","file":"bell.mp3"}]""")
+
+            observed.sounds.first()
+
+            assertThat(recoveries).isAtLeast(1)
+        }
+
+    @Test
+    fun `onLegacyRecovery does not fire for a clean modern payload`() =
+        runTest {
+            var recoveries = 0
+            val observed =
+                SoundsRepository(context, onError = { recordedErrors += it }, onLegacyRecovery = { recoveries++ })
+            observed.save(testSound("bell", "bell.mp3"))
+
+            observed.sounds.first()
+
+            assertThat(recoveries).isEqualTo(0)
+        }
+
+    @Test
     fun `legacy element missing both id and name is dropped without wiping the list`() =
         runTest {
             repo.setRawJsonForTest(


### PR DESCRIPTION
### Summary

1. You save some Bomps
2. You update the app to a newer version
3. You open the app

**before:** your saved Bomps are gone — My Bomps comes up empty and stays empty on every relaunch, with no way to get them back.
**after:** your Bomps are recovered on open and persist normally.

One real user hit this in production (Crashlytics, app 2.1.0, single device) — saved audios silently vanishing after an update.

### Technical detail

`StoredSound.id` became a required field in ADR 0008, which shipped **no migration** on the premise "the app has no users." Production Crashlytics disproves it: a pre-id payload threw `MissingFieldException`, and `decodeSafely` caught it and returned `emptyList()` — wiping the entire list on every read.

The decode is now a **two-tier, element-tolerant recovery** (built across the commits, hardened from a code review):

- **Fast path** — a clean modern payload decodes in a single streaming `decodeFromString`; new installs pay nothing for the migration. Recovery runs only when that throws or yields a blank `id`.
- **Element-wise recovery** — parses the list once and heals/decodes each element independently. A missing/blank `id` is healed to `custom:<name>` from the pre-0008 name identity (ADR 0007); a non-object, no-name, or otherwise-undecodable element is dropped while **siblings survive** (one bad record can't wipe the list). Only a corrupt root (invalid JSON / non-array) still degrades to empty with `onError`.
- **Keep-first id de-dup** — a repeated legacy name would mint two identical `custom:<name>` ids and crash the `id`-keyed Compose lists; de-dup degrades that to dropping the duplicate.
- **Observability** — recovery fires an injected `onLegacyRecovery` hook (`:model` stays decoupled from analytics) wired in `SoundsViewModel` to the one-shot `legacy_sounds_recovered` event, so the legacy population is countable.
- **ADR 0018 (new)** — amends ADR 0008 §5 / Option A with the Crashlytics evidence; documents the bundled-stub limitation, sentinel-id edge, and revisit criteria.

### Code review tips

- **Decode path is the blast radius** — every `sounds_json` read flows through `decodeSafely`. The fast path returns clean modern payloads untouched; recovery is reached only for legacy/corrupt data. Covered by `SoundsRepositoryTest`.
- **Compose duplicate-key crash** was the sharpest review finding — the keep-first de-dup is what stops a recovery from turning the old silent wipe into a launch crash for a user with same-name legacy records.
- **New analytics event** `legacy_sounds_recovered` is registered in `AnalyticsCoverageMatrixTest`; gated one-shot via `markFiredOnce`.
- **ADR divergence is deliberate** — ships ADR 0008's rejected Option A. User-directed, evidence-backed, documented in ADR 0018.
- **Rebased** onto `origin/develop` (picked up the `lifecycleCompose` bump); clean, no conflicts.

### Already tested

- TDD red→green across the stack: `SoundsRepositoryTest` (recovery, sibling survival, dedup keep-first, non-object/missing-name drop, blank-id heal, non-array root, `onLegacyRecovery` fires/doesn't) + `SoundsViewModelAnalyticsTest` (`legacy_sounds_recovered` emits / not) + `AnalyticsCoverageMatrixTest`
- Local `./gradlew test` + `check -x test` + `check-adr-invariants.sh` + analytics-wrapper guard green (CI re-runs these)
- Instrumented UI suite via `./scripts/run-instrumented-tests.sh` (cold-boot AVD, Android 14 / API 34): 120 tests, 0 failed, 2 skipped — green
