### PR TITLE
docs: Firebase CLI/MCP deobfuscated-crash path + GitHub release procedure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 ### For nerds 🤓
 
+#### Added
+- Documented the GitHub release procedure (tag from develop, notes from the store change file, R8 mapping archived as the sole asset) and the Firebase CLI/MCP path for reading deobfuscated Crashlytics stacks
+
 #### Changed
 - Kotlin compiler warnings now fail the build (`allWarningsAsErrors`, binary/unconditional) so they can't accumulate
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ Hard rules:
 
 SQL post-mortem on crash history: CONTRIBUTING.md § *BigQuery export*. Releases-only — `bomp-prod` exports Crashlytics/Analytics/Performance to BigQuery (`us`, daily). `bomp-debug` does not export.
 
-**Reading a specific crash's stack:** BQ frames are R8-obfuscated (`r8-map-id-…`, `ki2.q`); read the deobfuscated trace in **Crashlytics** (Console or the Firebase MCP, § *Local setup*). Use BQ for aggregation/counts/JOINs only — detail in CONTRIBUTING.md § *BigQuery export*.
+**Reading a specific crash's stack:** BQ frames are R8-obfuscated (`r8-map-id-…`, `ki2.q`); read the stack in **Crashlytics** (Console / Firebase MCP), which deobfuscates only when the build's R8 mapping was uploaded — often missing today (§ *Release builds*). BQ for aggregation/counts/JOINs only — detail in CONTRIBUTING.md § *BigQuery export*.
 
 ## StrictMode debug audit
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,8 @@ Hard rules:
 
 SQL post-mortem on crash history: CONTRIBUTING.md § *BigQuery export*. Releases-only — `bomp-prod` exports Crashlytics/Analytics/Performance to BigQuery (`us`, daily). `bomp-debug` does not export.
 
+**Reading a specific crash's stack:** BQ frames are R8-obfuscated (`r8-map-id-…`, `ki2.q`); read the deobfuscated trace in **Crashlytics** (Console or the Firebase MCP, § *Local setup*). Use BQ for aggregation/counts/JOINs only — detail in CONTRIBUTING.md § *BigQuery export*.
+
 ## StrictMode debug audit
 
 Source of truth: `app/src/debug/.../StrictModeConfigurator.kt` (debug-only, never reaches release). Unknown violations crash debug + instrumented runs by design — `Tracker.track(StrictModeException(violation))` with a static wrapper `"StrictMode: <ViolationClassName>"`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ But, before going deeper I suggest you to take a look to the [opensource.guide](
 
     It must return **`BUILD SUCCESS`**.
 4. *(Optional)* To let Claude Code diagnose CI failures, set up the CircleCI MCP server — see [§ Continuous Integration](#continuous-integration-). An agent can wire it up; you provide the token and restart Claude Code.
+5. *(Optional)* To let Claude Code read **deobfuscated** Crashlytics stacks, install the Firebase CLI (`npm install -g firebase-tools`) and wire the Firebase MCP — per-user, not committed (`claude mcp add -s local firebase -- firebase experimental:mcp --dir .`), then `firebase login` + restart Claude Code. An agent can wire it up; you provide the login. When to use it (deobfuscated traces) vs BQ (aggregation): [§ BigQuery export](#bigquery-export-).
 
 ## Directory structure 🎄
 - [app/](/app) Android application module which depends on all other submodules to be the great app you're building. The Add Button flow lives at `app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/`.
@@ -567,7 +568,27 @@ A **seed** — expand it as the release process is formalized (store rollout ste
 - [ ] **Bump `versionCode` + `versionName`** in `app/build.gradle` to match the milestone.
 - [ ] **Release lint gate** — `./gradlew app:lintVitalRelease` green.
 - [ ] **Build the AAB** — `./gradlew app:bundle`.
+- [ ] **Write the store change notes** — `store-listing/{en-US,es-AR}/changelog-<versionCode>.txt`; the GitHub release notes are sourced from the en-US file (§ *Creating the GitHub release*).
 - [ ] **Manual analytics smoke** — verify events in DebugView before merging (§ *Analytics events*); aggregated Reports lag 24–48 h.
+
+### Creating the GitHub release
+
+After the checklist above is green and the version bump is merged to `develop`:
+
+1. **Build the release bundle** — `./gradlew app:bundleRelease`. Besides the AAB, this runs `uploadCrashlyticsMappingFileRelease`, uploading the R8 mapping to Firebase — the source the Crashlytics Console/MCP use to de-obfuscate stacks (§ *BigQuery export* → *Stack frames come R8-obfuscated*). **Caveats:** CI never uploads it (the CircleCI `bundle` job excludes the task with `-x uploadCrashlyticsMappingFileRelease`), so this **local** build is the only mapping upload; and the upload needs the **real** release `google-services.json` present (skip-worktree) — on the scrubbed dummy it 400s.
+2. **Create the release + tag from `develop`**, notes from the store change file, attaching **only** the R8 mapping as the single asset:
+
+   ```bash
+   gh release create vX.Y.Z --target develop --title "vX.Y.Z" \
+     --notes-file store-listing/en-US/changelog-<versionCode>.txt \
+     app/build/outputs/mapping/release/mapping.txt
+   ```
+
+   `<versionCode>` is the value in `app/build.gradle`. Add a footer line linking to the full `CHANGELOG.md` on `develop` if the notes file omits it.
+3. **Attach nothing else.** The mapping is a backup for offline `retrace`; **never** attach the keystore, `secure.properties`, the real `google-services.json`, or the `.aab` (the `.aab` carries no mapping anyway).
+4. **Verify the asset landed** — `gh release view vX.Y.Z --json assets -q '.assets[].name'` must list `mapping.txt`. Print an explicit line for the maintainer to confirm, e.g. `✅ mapping.txt attached to vX.Y.Z` (or ⚠️ + re-run `gh release upload vX.Y.Z app/build/outputs/mapping/release/mapping.txt` if missing).
+
+Why archive the mapping: Firebase already holds it for Console/MCP de-obfuscation, but a GitHub-release copy keyed to the tag is a durable offline backup for `retrace`, independent of Firebase retention.
 
 ## Bundled audio files 🔊
 
@@ -817,6 +838,22 @@ Returns `0` early on if no crashes — that's a feature, not a bug.
 - Performance regressions across releases — easier to diff trace medians via `WITH` clauses than to flip between Console screens.
 
 The Console is still right for: real-time DebugView, alert configuration, single-issue triage. BQ is for *retrospectives* across N events / users / days.
+
+### Stack frames come R8-obfuscated — read the trace in Crashlytics, not BQ
+
+The export stores frames **raw**: `blame_frame.file` = `r8-map-id-…` (the mapping id, not a source path), symbols = R8-renamed (`ki2.q`, `et2.n`). Only the exception **message** is human-readable. The Crashlytics **Console** (and the Firebase MCP — § *Local setup*) de-obfuscate server-side via the mapping the release build uploads; the BQ export does not. This is a Firebase limitation (export = raw, Console/MCP = deobfuscated), **not** a misconfiguration.
+
+So to read a *single crash's stack*, use the **Console or the Firebase MCP** — never BQ. BQ stays for aggregation / trends / JOINs (above). The diagnostic that triggered this note (a `sounds_json` crash) was only root-causable because the exception *message* carried the real FQN + field; a generic message would have left the BQ export near-useless.
+
+**Wiring the Firebase MCP (one-time, per-user — not committed):**
+
+```bash
+npm install -g firebase-tools
+claude mcp add -s local firebase -- firebase experimental:mcp --dir .
+firebase login          # interactive (browser) — run via the ! prefix in Claude Code
+```
+
+Restart Claude Code so it loads the server's tools. The MCP auto-detects the Android Crashlytics SDK and exposes read tools that return **deobfuscated** issues/traces (select the `bomp-prod` project). `firebase login` is per-user auth, like the CircleCI token (§ *Continuous Integration*).
 
 ## Labels & milestone examples 🏷️
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -587,8 +587,9 @@ After the checklist above is green and the version bump is merged to `develop`:
    `<versionCode>` is the value in `app/build.gradle`. Add a footer line linking to the full `CHANGELOG.md` on `develop` if the notes file omits it.
 3. **Attach nothing else.** The mapping is a backup for offline `retrace`; **never** attach the keystore, `secure.properties`, the real `google-services.json`, or the `.aab` (the `.aab` carries no mapping anyway).
 4. **Verify the asset landed** — `gh release view vX.Y.Z --json assets -q '.assets[].name'` must list `mapping.txt`. Print an explicit line for the maintainer to confirm, e.g. `✅ mapping.txt attached to vX.Y.Z` (or ⚠️ + re-run `gh release upload vX.Y.Z app/build/outputs/mapping/release/mapping.txt` if missing).
+5. **Verify Firebase actually got the mapping** — the build log must show `uploadCrashlyticsMappingFileRelease` *ran* (not skipped). Within minutes, a fresh crash on this version should de-obfuscate in the Console / via the Firebase MCP (real frames, **not** `r8-map-id-…`). This step exists because past releases shipped **without** the mapping (§ *BigQuery export* → *Stack frames come R8-obfuscated*) — so Crashlytics couldn't deobfuscate them either.
 
-Why archive the mapping: Firebase already holds it for Console/MCP de-obfuscation, but a GitHub-release copy keyed to the tag is a durable offline backup for `retrace`, independent of Firebase retention.
+Why archive the mapping: even when Firebase holds it for Console/MCP de-obfuscation, a GitHub-release copy keyed to the tag is a durable offline `retrace` backup independent of Firebase retention — and the safety net for exactly the case above, where the Firebase upload didn't happen.
 
 ## Bundled audio files 🔊
 
@@ -841,9 +842,11 @@ The Console is still right for: real-time DebugView, alert configuration, single
 
 ### Stack frames come R8-obfuscated — read the trace in Crashlytics, not BQ
 
-The export stores frames **raw**: `blame_frame.file` = `r8-map-id-…` (the mapping id, not a source path), symbols = R8-renamed (`ki2.q`, `et2.n`). Only the exception **message** is human-readable. The Crashlytics **Console** (and the Firebase MCP — § *Local setup*) de-obfuscate server-side via the mapping the release build uploads; the BQ export does not. This is a Firebase limitation (export = raw, Console/MCP = deobfuscated), **not** a misconfiguration.
+Frames carry `blame_frame.file` = `r8-map-id-…` (a mapping UUID, not a source path) and R8-renamed symbols (`ki2.q`, `et2.n`). Crashlytics — Console **and** the Firebase MCP (§ *Local setup*) — de-obfuscate server-side, **but only if the R8 mapping for that build was uploaded to Firebase.**
 
-So to read a *single crash's stack*, use the **Console or the Firebase MCP** — never BQ. BQ stays for aggregation / trends / JOINs (above). The diagnostic that triggered this note (a `sounds_json` crash) was only root-causable because the exception *message* carried the real FQN + field; a generic message would have left the BQ export near-useless.
+**Today it usually isn't.** CI excludes the mapping upload (§ *Release builds*) and release builds haven't been reliably uploading it, so shipped crashes read `r8-map-id-…` frames **even in Crashlytics / the MCP** — verified live on the 2.1.0 `sounds_json` issue: `at x83.a(r8-map-id-…:42)`. Only the exception **message** is human-readable (a static `Tracker.track` wrapper message — which is the *only* reason that crash was diagnosable). So the fix is **not** "use the MCP instead of BQ" — it's making every release **upload + verify** its mapping (§ *Release builds* → *Creating the GitHub release*). Once the mapping is in Firebase, the Console/MCP show real frames; the BQ export never deobfuscates regardless.
+
+Tooling division (once mappings are present): **reading a single crash's stack** → Console or Firebase MCP (the agent-accessible path); **aggregation / trends / JOINs** → BQ.
 
 **Wiring the Firebase MCP (one-time, per-user — not committed):**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -575,7 +575,7 @@ A **seed** — expand it as the release process is formalized (store rollout ste
 
 After the checklist above is green and the version bump is merged to `develop`:
 
-1. **Build the release bundle** — `./gradlew app:bundleRelease`. Besides the AAB, this runs `uploadCrashlyticsMappingFileRelease`, uploading the R8 mapping to Firebase — the source the Crashlytics Console/MCP use to de-obfuscate stacks (§ *BigQuery export* → *Stack frames come R8-obfuscated*). **Caveats:** CI never uploads it (the CircleCI `bundle` job excludes the task with `-x uploadCrashlyticsMappingFileRelease`), so this **local** build is the only mapping upload; and the upload needs the **real** release `google-services.json` present (skip-worktree) — on the scrubbed dummy it 400s.
+1. **Build the release bundle** — `./gradlew app:bundleRelease` (or `app:bundle`). The Crashlytics Gradle plugin auto-wires `uploadCrashlyticsMappingFileRelease` into this task (verify: `./gradlew :app:bundleRelease --dry-run | grep Crashlytics`), so with the **real** `google-services.json` active it uploads the R8 mapping to Firebase as part of the build — no separate command. **Do NOT pass `-x uploadCrashlyticsMappingFileRelease`** when cutting a real release: that flag is **CI-only** (CI builds against the scrubbed dummy config, where the upload 400s). Passing it — or building without the real `google-services.json` — is the most likely cause of past releases shipping obfuscated: `injectCrashlyticsMappingFileIdRelease` still embeds the `r8-map-id` into the app, but the matching `mapping.txt` never lands in Firebase, so Crashlytics/MCP can't de-obfuscate (§ *BigQuery export* → *Stack frames come R8-obfuscated*).
 2. **Create the release + tag from `develop`**, notes from the store change file, attaching **only** the R8 mapping as the single asset:
 
    ```bash
@@ -856,7 +856,16 @@ claude mcp add -s local firebase -- firebase experimental:mcp --dir .
 firebase login          # interactive (browser) — run via the ! prefix in Claude Code
 ```
 
-Restart Claude Code so it loads the server's tools. The MCP auto-detects the Android Crashlytics SDK and exposes read tools that return **deobfuscated** issues/traces (select the `bomp-prod` project). `firebase login` is per-user auth, like the CircleCI token (§ *Continuous Integration*).
+Restart Claude Code so it loads the server's tools. The MCP auto-detects the Android Crashlytics SDK and exposes read tools (`crashlytics_get_report`, `crashlytics_batch_get_events`, `crashlytics_get_issue`, `crashlytics_list_events`, …) that return frames **deobfuscated when the mapping is present** (else still `r8-map-id-…`). `firebase login` is per-user auth, like the CircleCI token (§ *Continuous Integration*).
+
+Those tools need the **Firebase App Id** (not a secret — it ships inside the APK; the secret is the API key in `google-services.json`):
+
+| Project | App Id | Package |
+|---|---|---|
+| `bomp-prod` (release) | `1:383291838647:android:8f96908ee8b49821da3d32` | `com.github.barriosnahuel.vossosunboton` |
+| `bomp-debug` (debug) | `1:947596384148:android:1ecfa2fa66603e42e52181` | `com.github.barriosnahuel.vossosunboton.debug` |
+
+`bomp-debug` does not export to BQ and rarely has real crashes; for crash triage use the `bomp-prod` App Id.
 
 ## Labels & milestone examples 🏷️
 


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change. Formalizes two ops workflows so future release/diagnosis sessions don't re-derive them by guesswork:

- **Reading crashes:** a crash was triaged against BigQuery, whose frames come back R8-obfuscated (`r8-map-id-…`, `ki2.q`). This documents that BQ is for *aggregation* and **Crashlytics (Console / Firebase MCP)** is the path for *deobfuscated* stacks — but only when the build's mapping reached Firebase. **Live finding (verified via the MCP against `bomp-prod`):** shipped releases aren't uploading the mapping, so today even Crashlytics shows `r8-map-id-…` frames. The MCP is the agent-accessible piece; the missing upload is the real gap.
- **Cutting releases:** GitHub releases were cut by inferring from past ones, which never archived the R8 `mapping.txt`. Adds a procedure that tags from `develop`, sources notes from the store change file, attaches the mapping as the **sole asset**, and **verifies the Firebase upload + deobfuscation** as a mandatory step.

### Technical detail

Docs-only across three files; no code touched.

- **`CLAUDE.md`** (§ Error tracking): one-line pointer — BQ frames are R8-obfuscated; read stacks in Crashlytics (deobfuscates only when the build's mapping was uploaded — often missing today), BQ for aggregation only.
- **`CONTRIBUTING.md`** (§ Local setup): optional step 5 mirroring the CircleCI-MCP pattern — install `firebase-tools` + wire the Firebase MCP via `claude mcp add -s local`.
- **`CONTRIBUTING.md`** (§ BigQuery export): the obfuscation gap (export = raw; Console/MCP deobfuscate **iff** the mapping is in Firebase), the MCP wire-up, and a versioned table of the prod/debug **Firebase App Ids** the Crashlytics MCP tools require (not secrets — they ship in the APK).
- **`CONTRIBUTING.md`** (§ Release builds): *Creating the GitHub release* — `app:bundleRelease` (upload is auto-wired; **don't** pass the CI-only `-x uploadCrashlyticsMappingFileRelease`), notes from `store-listing/en-US/changelog-<versionCode>.txt`, `mapping.txt` as the only asset, post-create asset + Firebase-upload verification. Plus a checklist item to write the store change file.
- **`CHANGELOG.md`**: one For-nerds/Added line.

### Code review tips

- **Env actions deliberately NOT in this PR:** `firebase-tools` installed globally + Firebase MCP wired into the maintainer's **local** config (`~/.claude.json`, not committed). The server is Connected; it needs the maintainer's interactive `firebase login` + restart to load tools with auth.
- **Root-cause of the missing upload (investigated live):** the upload task is auto-wired into `bundleRelease` (`--dry-run` confirms), and the mapping does reach **Play** (bundled in the AAB) — but the separate **Firebase** upload didn't run/verify on past agent-cut releases. The dry-run proves the task is *wired*, not that it *executes*; the new mandatory verify step closes that. A deeper execution-level failure isn't fully ruled out (would need a real release build to confirm) — flagged, not asserted.
- **40K gate:** CLAUDE.md = 39,742 B < 40,000; `scripts/check-adr-invariants.sh` green.
- **Merged `origin/develop`** (resolved a CHANGELOG `#### Added` conflict by keeping both the `legacy_sounds_recovered` line and this PR's docs line). Net diff vs develop = the 3 docs files only.

### Already tested

- Docs-only: UI/instrumented suite exempt per CLAUDE.md (no Composable/VM/intent/persistence touched); the guard checks CI runs are not replicated here.
- **Firebase MCP verified live** against `bomp-prod` (real `crashlytics_get_report` / `crashlytics_batch_get_events` reads) — this is how the "shipped crashes still obfuscated" gap was confirmed, not assumed.
