### PR TITLE
feat: in-app Bomp recorder (+ internal SoundSource groundwork)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 ### For nerds 🤓
 
 #### Added
+- Internal `SoundSource` provenance (`RECORDED` / `IMPORTED` / `BUNDLED`) on saved audios — derived on read (existing audios decode as imported, bundled audio as bundled) and persisted for recordings, with no backfill migration needed. Groundwork for the in-app recorder — no UI change yet (ADR 0019)
 - `legacy_sounds_recovered` analytics event (one-shot per install) so the pre-stable-id population is countable and the migration's retirement is verifiable (ADR 0018)
 - Documented the GitHub release procedure (tag from develop, notes from the store change file, R8 mapping archived as the sole asset) and the Firebase CLI/MCP path for reading deobfuscated Crashlytics stacks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 ## \[unreleased] (v2.3.0)
 
 ### Added
-- Record a Bomp without leaving the app — the add sheet's "Record" option opens a full-screen recorder: tap to record, listen back, and save it like any other Bomp
+- Record a Bomp without leaving the app — the add sheet's "Record" option opens a full-screen recorder: tap to record, listen back on a real waveform, and save it like any other Bomp; if you leave mid-recording, a banner offers to pick it back up
 
 ### Fixed
 - Bomps saved before an earlier update no longer disappear when you open the app — audios stored under the old format are recovered instead of the whole list silently emptying
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 #### Added
 - In-app audio recorder (`RecordingActivity` + `MediaRecorder`, AAC/M4A, tap-to-toggle, 60s/1s bounds): the first runtime-permission surface (`RECORD_AUDIO`), reusing the existing `AddButtonFeature` save pipeline and the immersive listen look (ADR 0019)
+- Recorder review shows the clip's real amplitude envelope (reuses the listen screen's `WaveformExtractor` via a new `content://` URI overload) instead of a synthetic shape
+- Recording draft recovery (`RecorderDraftStore`): an unsaved clip survives backgrounding, a launcher re-entry, and process death — a Landing banner resumes it into Review (ADR 0019 § Draft recovery)
 - Internal `SoundSource` provenance (`RECORDED` / `IMPORTED` / `BUNDLED`) on saved audios — derived on read (existing audios decode as imported, bundled audio as bundled), now stamped `RECORDED` by the recorder; no backfill migration needed (ADR 0019)
 - `legacy_sounds_recovered` analytics event (one-shot per install) so the pre-stable-id population is countable and the migration's retirement is verifiable (ADR 0018)
 - Documented the GitHub release procedure (tag from develop, notes from the store change file, R8 mapping archived as the sole asset) and the Firebase CLI/MCP path for reading deobfuscated Crashlytics stacks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - In-app audio recorder (`RecordingActivity` + `MediaRecorder`, AAC/M4A, tap-to-toggle, 60s/1s bounds): the first runtime-permission surface (`RECORD_AUDIO`), reusing the existing `AddButtonFeature` save pipeline and the immersive listen look (ADR 0019)
 - Recorder review shows the clip's real amplitude envelope (reuses the listen screen's `WaveformExtractor` via a new `content://` URI overload) instead of a synthetic shape
 - Recording draft recovery (`RecorderDraftStore`): an unsaved clip survives backgrounding, a launcher re-entry, and process death — a Landing banner resumes it into Review (ADR 0019 § Draft recovery)
+- Recorder funnel analytics: `recording_completed` (review reached), `record_permission_result` (mic grant/deny), and the draft-recovery trio `recording_draft_banner_shown` / `_resumed` / `_discarded`
 - Internal `SoundSource` provenance (`RECORDED` / `IMPORTED` / `BUNDLED`) on saved audios — derived on read (existing audios decode as imported, bundled audio as bundled), now stamped `RECORDED` by the recorder; no backfill migration needed (ADR 0019)
 - `legacy_sounds_recovered` analytics event (one-shot per install) so the pre-stable-id population is countable and the migration's retirement is verifiable (ADR 0018)
 - Documented the GitHub release procedure (tag from develop, notes from the store change file, R8 mapping archived as the sole asset) and the Firebase CLI/MCP path for reading deobfuscated Crashlytics stacks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 #### Added
 - In-app audio recorder (`RecordingActivity` + `MediaRecorder`, AAC/M4A, tap-to-toggle, 60s/1s bounds): the first runtime-permission surface (`RECORD_AUDIO`), reusing the existing `AddButtonFeature` save pipeline and the immersive listen look (ADR 0019)
-- Recorder review shows the clip's real amplitude envelope (reuses the listen screen's `WaveformExtractor` via a new `content://` URI overload) instead of a synthetic shape
+- Recorder review shows the clip's real amplitude envelope (reuses the listen screen's `WaveformExtractor` via a new `content://` URI overload) instead of a synthetic shape — rendered instantly from the live-captured samples (no post-stop decode flash); a restored draft still decodes the file
 - Recording draft recovery (`RecorderDraftStore`): an unsaved clip survives backgrounding, a launcher re-entry, and process death — a Landing banner resumes it into Review (ADR 0019 § Draft recovery)
 - Recorder funnel analytics: `recording_completed` (review reached), `record_permission_result` (mic grant/deny), and the draft-recovery trio `recording_draft_banner_shown` / `_resumed` / `_discarded`
 - Internal `SoundSource` provenance (`RECORDED` / `IMPORTED` / `BUNDLED`) on saved audios — derived on read (existing audios decode as imported, bundled audio as bundled), now stamped `RECORDED` by the recorder; no backfill migration needed (ADR 0019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,17 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 ## \[unreleased] (v2.3.0)
 
+### Added
+- Record a Bomp without leaving the app — the add sheet's "Record" option opens a full-screen recorder: tap to record, listen back, and save it like any other Bomp
+
 ### Fixed
 - Bomps saved before an earlier update no longer disappear when you open the app — audios stored under the old format are recovered instead of the whole list silently emptying
 
 ### For nerds 🤓
 
 #### Added
-- Internal `SoundSource` provenance (`RECORDED` / `IMPORTED` / `BUNDLED`) on saved audios — derived on read (existing audios decode as imported, bundled audio as bundled) and persisted for recordings, with no backfill migration needed. Groundwork for the in-app recorder — no UI change yet (ADR 0019)
+- In-app audio recorder (`RecordingActivity` + `MediaRecorder`, AAC/M4A, tap-to-toggle, 60s/1s bounds): the first runtime-permission surface (`RECORD_AUDIO`), reusing the existing `AddButtonFeature` save pipeline and the immersive listen look (ADR 0019)
+- Internal `SoundSource` provenance (`RECORDED` / `IMPORTED` / `BUNDLED`) on saved audios — derived on read (existing audios decode as imported, bundled audio as bundled), now stamped `RECORDED` by the recorder; no backfill migration needed (ADR 0019)
 - `legacy_sounds_recovered` analytics event (one-shot per install) so the pre-stable-id population is countable and the migration's retirement is verifiable (ADR 0018)
 - Documented the GitHub release procedure (tag from develop, notes from the store change file, R8 mapping archived as the sole asset) and the Firebase CLI/MCP path for reading deobfuscated Crashlytics stacks
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -204,4 +204,5 @@ dependencies {
     androidTestImplementation libs.androidx.uiautomator
     androidTestImplementation libs.truth
     androidTestImplementation libs.mockk
+    androidTestImplementation testFixtures(project(':commons_android'))
 }

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderFlowTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.recorder
+
+import android.Manifest
+import android.os.SystemClock
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ActivityScenario
+import androidx.test.rule.GrantPermissionRule
+import com.github.barriosnahuel.vossosunboton.AbstractUiTest
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithContentDescription
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithText
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+
+/**
+ * Instrumented regression coverage for the recorder's lifecycle + disk-threading bugs that only
+ * surface on a real device: the debug build's StrictMode penalty throws on disk-on-main, and these
+ * paths never run under Robolectric. A fake [RecorderEngine] stands in for the mic — the bugs are
+ * about Activity lifecycle, FileProvider, and StrictMode, not audio — while temp files, the
+ * FileProvider URI, and StrictMode run for real on the emulator.
+ *
+ * Guards (each a crash/regression caught manually on a Pixel):
+ * - Stop → Review must not crash (FileProvider URI resolution off the main thread).
+ * - A config-change recreate mid-recording must keep recording (onStop must not treat it as
+ *   backgrounding). Real rotation additionally never recreates (manifest `configChanges`).
+ * - Destroying mid-recording must not crash (temp cleanup off the main thread).
+ *
+ * Note: deliberately no global device rotation here — `UiDevice.setOrientation*` mutates shared
+ * emulator state and destabilises the rest of the suite. `recreate()` exercises the same guard.
+ */
+internal class RecorderFlowTest : AbstractUiTest() {
+    @get:Rule
+    val micPermission: GrantPermissionRule = GrantPermissionRule.grant(Manifest.permission.RECORD_AUDIO)
+
+    private lateinit var engine: FakeRecorderEngine
+
+    @Before
+    override fun setUp() {
+        super.setUp()
+        engine = FakeRecorderEngine()
+        RecorderEngineProvider.setForTest(engine)
+    }
+
+    @After
+    override fun tearDown() {
+        RecorderEngineProvider.setForTest(null)
+        super.tearDown()
+    }
+
+    @Test
+    fun recordingThenStoppingReachesReviewWithoutCrashing() {
+        ActivityScenario.launch(RecordingActivity::class.java).use {
+            startRecording()
+            // The clip must cross the 1 s minimum so Stop moves to Review (not "too short").
+            SystemClock.sleep(MIN_CLIP_WAIT_MS)
+            composeRule.awaitNodeWithContentDescription(string(R.string.app_recorder_cd_stop)).performClick()
+
+            // Reaching Review without a StrictMode DiskReadViolation crash is the regression guard.
+            composeRule.awaitNodeWithText(string(R.string.app_recorder_use)).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun recordingSurvivesAConfigChangeRecreate() {
+        ActivityScenario.launch(RecordingActivity::class.java).use { scenario ->
+            startRecording()
+
+            scenario.recreate()
+
+            // Still recording (Stop still offered): a config-change recreate must not auto-stop via onStop,
+            // and the ViewModel + capture survive it.
+            composeRule.awaitNodeWithContentDescription(string(R.string.app_recorder_cd_stop)).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun destroyingWhileRecordingDoesNotCrash() {
+        ActivityScenario.launch(RecordingActivity::class.java).use {
+            startRecording()
+            // Closing destroys the Activity → onCleared. A DiskWriteViolation (File.delete on main)
+            // there would crash the process; surviving teardown is the regression guard.
+        }
+    }
+
+    private fun startRecording() {
+        composeRule.awaitNodeWithContentDescription(string(R.string.app_recorder_cd_record)).performClick()
+        composeRule.awaitNodeWithContentDescription(string(R.string.app_recorder_cd_stop)).assertIsDisplayed()
+    }
+
+    private fun string(resId: Int): String = context.getString(resId)
+
+    private companion object {
+        const val MIN_CLIP_WAIT_MS = 1_300L
+    }
+}
+
+private class FakeRecorderEngine : RecorderEngine {
+    override var onMaxDurationReached: (() -> Unit)? = null
+    override var onInterrupted: (() -> Unit)? = null
+
+    override fun start(outputFile: File) {
+        // Produce a real file so the off-main FileProvider URI resolution has something to point at.
+        outputFile.parentFile?.mkdirs()
+        outputFile.createNewFile()
+    }
+
+    override fun stop(): Boolean = true
+
+    override fun maxAmplitude(): Float = 0.4f
+
+    override fun release() = Unit
+}

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderResumeDraftTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderResumeDraftTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.recorder
+
+import android.Manifest
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.test.core.app.ActivityScenario
+import androidx.test.rule.GrantPermissionRule
+import com.github.barriosnahuel.vossosunboton.AbstractUiTest
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithText
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Instrumented integration coverage for ADR 0019 § Draft recovery: a persisted draft (its temp clip +
+ * the [DataStoreRecorderDraftStore] metadata) reopens [RecordingActivity] straight into Review. This is
+ * the launcher-re-entry / process-death path — the bug where a captured-but-unsaved clip was silently
+ * lost when the app was re-opened from the launcher instead of Recents. Real DataStore + FileProvider +
+ * the Activity run on the emulator; only the mic (irrelevant here, no recording happens) is absent.
+ */
+internal class RecorderResumeDraftTest : AbstractUiTest() {
+    @get:Rule
+    val micPermission: GrantPermissionRule = GrantPermissionRule.grant(Manifest.permission.RECORD_AUDIO)
+
+    private val draftStore by lazy { DataStoreRecorderDraftStore(context) }
+
+    @After
+    fun clearDraft() {
+        runBlocking { draftStore.clearForTest() }
+        RecorderTempFiles.purge(context)
+    }
+
+    @Test
+    fun resumingADraftReopensTheRecorderInReview() {
+        val clip = RecorderTempFiles.newTempFile(context)
+        context.resources.openRawResource(R.raw.app_branding_audio).use { input ->
+            clip.outputStream().use { output -> input.copyTo(output) }
+        }
+        runBlocking {
+            draftStore.save(clip, durationMs = 3_000)
+            draftStore.draft.first { it != null }
+        }
+
+        ActivityScenario.launch<RecordingActivity>(RecordingActivity.createIntent(context, resumeDraft = true)).use {
+            // Review affordances present → the persisted clip was restored, not lost.
+            composeRule.awaitNodeWithText(string(R.string.app_recorder_use)).assertIsDisplayed()
+            composeRule.awaitNodeWithText(string(R.string.app_recorder_rerecord)).assertIsDisplayed()
+            // 3 s restored duration surfaces on the timer.
+            composeRule.awaitNodeWithText("0:03").assertIsDisplayed()
+        }
+    }
+
+    private fun string(resId: Int): String = context.getString(resId)
+}

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/recorder/WaveformExtractorContentUriTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/recorder/WaveformExtractorContentUriTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.recorder
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.feature.vault.WaveformExtractor
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+/**
+ * Instrumented coverage for the review waveform's real-data path: [WaveformExtractor] decoding a clip
+ * from a `content://` FileProvider URI (the temp recording is not yet a saved Sound). MediaCodec
+ * decoding only runs on a device — never under Robolectric — so this guards on the emulator that the
+ * review wave is a genuine amplitude envelope, not the synthetic shape it replaced.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class WaveformExtractorContentUriTest {
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @After
+    fun tearDown() {
+        RecorderTempFiles.purge(context)
+    }
+
+    @Test
+    fun extractsARealEnvelopeFromAContentUri() {
+        val clip = File(File(context.cacheDir, "recordings").apply { mkdirs() }, "extractor-fixture.mp3")
+        context.resources.openRawResource(R.raw.app_branding_audio).use { input ->
+            clip.outputStream().use { output -> input.copyTo(output) }
+        }
+        val uri = RecorderTempFiles.contentUriFor(context, clip)
+
+        val peaks = runBlocking { WaveformExtractor.extract(context, uri, RECORDER_WAVEFORM_BARS) }
+
+        assertThat(peaks).isNotNull()
+        assertThat(peaks!!.size).isEqualTo(RECORDER_WAVEFORM_BARS)
+        // A real envelope varies bar to bar; the old synthetic/placeholder path would be uniform.
+        assertThat(peaks.toSet().size).isGreaterThan(1)
+    }
+}

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/RecorderDraftBannerFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/RecorderDraftBannerFlowTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.barriosnahuel.vossosunboton.AbstractUiTest
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.TestData
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithText
+import com.github.barriosnahuel.vossosunboton.feature.recorder.DataStoreRecorderDraftStore
+import com.github.barriosnahuel.vossosunboton.feature.recorder.RecorderTempFiles
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumented integration coverage for the draft-recovery banner wiring on My Bomps (ADR 0019 §
+ * Draft recovery): a persisted draft surfaces the resume banner on the real Landing screen, and
+ * Discard tears it down. Complements the stateless `RecorderDraftBannerTest` (which only checks the
+ * row's callbacks) and `RecorderResumeDraftTest` (the recorder side) — this is the only test that
+ * exercises `SoundsViewModel.pendingDraft` → banner render → `discardDraft` end to end.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class RecorderDraftBannerFlowTest : AbstractUiTest() {
+    private val draftStore by lazy { DataStoreRecorderDraftStore(context) }
+
+    @After
+    fun clearDraft() {
+        runBlocking { draftStore.clearForTest() }
+        RecorderTempFiles.purge(context)
+    }
+
+    @Test
+    fun aPendingDraftShowsTheResumeBannerOnMyBomps() {
+        seedDraft()
+
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            composeRule.awaitNodeWithText(string(R.string.app_recorder_draft_banner_message)).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun discardingFromTheBannerRemovesIt() {
+        seedDraft()
+
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            composeRule.awaitNodeWithText(string(R.string.app_recorder_draft_discard)).performClick()
+
+            // The store clear propagates through pendingDraft → the banner leaves composition.
+            composeRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) {
+                composeRule.onAllNodesWithText(string(R.string.app_recorder_draft_banner_message)).fetchSemanticsNodes().isEmpty()
+            }
+        }
+    }
+
+    private fun seedDraft() {
+        // One custom sound so My Bomps renders its normal list (not a first-run onboarding surface).
+        TestData.seedCustomSounds(context, count = 1)
+        val clip = RecorderTempFiles.newTempFile(context).apply { createNewFile() }
+        runBlocking {
+            draftStore.save(clip, durationMs = 3_000)
+            draftStore.draft.first { it != null }
+        }
+    }
+
+    private fun string(resId: Int): String = context.getString(resId)
+
+    private companion object {
+        const val WAIT_TIMEOUT_MS = 5_000L
+    }
+}

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/RecorderDraftBannerFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/RecorderDraftBannerFlowTest.kt
@@ -5,51 +5,85 @@
  */
 package com.github.barriosnahuel.vossosunboton.ui.home
 
+import android.app.Activity
+import android.app.Instrumentation
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.Intents.intending
+import androidx.test.espresso.intent.matcher.ComponentNameMatchers.hasClassName
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.barriosnahuel.vossosunboton.AbstractUiTest
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.TestData
 import com.github.barriosnahuel.vossosunboton.awaitNodeWithText
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.FakeAnalyticsTracker
 import com.github.barriosnahuel.vossosunboton.feature.recorder.DataStoreRecorderDraftStore
 import com.github.barriosnahuel.vossosunboton.feature.recorder.RecorderTempFiles
+import com.github.barriosnahuel.vossosunboton.feature.recorder.RecordingActivity
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
  * Instrumented integration coverage for the draft-recovery banner wiring on My Bomps (ADR 0019 §
- * Draft recovery): a persisted draft surfaces the resume banner on the real Landing screen, and
- * Discard tears it down. Complements the stateless `RecorderDraftBannerTest` (which only checks the
- * row's callbacks) and `RecorderResumeDraftTest` (the recorder side) — this is the only test that
- * exercises `SoundsViewModel.pendingDraft` → banner render → `discardDraft` end to end.
+ * Draft recovery): a persisted draft surfaces the resume banner on the real Landing screen, Discard
+ * tears it down, and the funnel events (`recording_draft_banner_shown` / `_resumed` / `_discarded`)
+ * fire. The only test exercising `SoundsViewModel.pendingDraft` → render → `discardDraft` end to end.
  */
 @RunWith(AndroidJUnit4::class)
 internal class RecorderDraftBannerFlowTest : AbstractUiTest() {
     private val draftStore by lazy { DataStoreRecorderDraftStore(context) }
+    private val analytics = FakeAnalyticsTracker()
+
+    @Before
+    override fun setUp() {
+        super.setUp()
+        AnalyticsTrackerProvider.setForTest(analytics)
+    }
 
     @After
-    fun clearDraft() {
+    override fun tearDown() {
+        AnalyticsTrackerProvider.setForTest(null)
         runBlocking { draftStore.clearForTest() }
         RecorderTempFiles.purge(context)
+        super.tearDown()
     }
 
     @Test
-    fun aPendingDraftShowsTheResumeBannerOnMyBomps() {
+    fun aPendingDraftShowsTheResumeBannerAndLogsTheImpression() {
         seedDraft()
 
         ActivityScenario.launch(LandingActivity::class.java).use {
             composeRule.awaitNodeWithText(string(R.string.app_recorder_draft_banner_message)).assertIsDisplayed()
+            analytics.assertEmitted("recording_draft_banner_shown")
         }
     }
 
     @Test
-    fun discardingFromTheBannerRemovesIt() {
+    fun resumingFromTheBannerLogsAndOpensTheRecorder() {
+        seedDraft()
+        intending(hasComponent(hasClassName(RecordingActivity::class.java.name)))
+            .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, null))
+
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            composeRule.awaitNodeWithText(string(R.string.app_recorder_draft_continue)).performClick()
+            composeRule.waitForIdle()
+
+            analytics.assertEmitted("recording_draft_resumed")
+            intended(hasComponent(hasClassName(RecordingActivity::class.java.name)))
+        }
+    }
+
+    @Test
+    fun discardingFromTheBannerRemovesItAndLogsTheEvent() {
         seedDraft()
 
         ActivityScenario.launch(LandingActivity::class.java).use {
@@ -59,6 +93,7 @@ internal class RecorderDraftBannerFlowTest : AbstractUiTest() {
             composeRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) {
                 composeRule.onAllNodesWithText(string(R.string.app_recorder_draft_banner_message)).fetchSemanticsNodes().isEmpty()
             }
+            analytics.assertEmitted("recording_draft_discarded")
         }
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -88,6 +88,7 @@
              intent; it hands the captured clip to AddButtonActivity for naming + save. -->
         <activity
             android:name=".feature.recorder.RecordingActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize"
             android:exported="false"
             android:excludeFromRecents="true"
             android:launchMode="singleTask"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,10 @@
         </intent>
     </queries>
 
+    <!-- In-app recorder (ADR 0019): requested at runtime before the first capture; denial routes to
+         Settings or an import escape. The Vault still never taps the mic for playback visuals. -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+
     <application
         android:name=".MainApplication"
         android:allowBackup="true"
@@ -79,6 +83,16 @@
                 <data android:mimeType="audio/*" />
             </intent-filter>
         </activity>
+
+        <!-- In-app recorder (ADR 0019). Not exported: launched only by the import Hub via an explicit
+             intent; it hands the captured clip to AddButtonActivity for naming + save. -->
+        <activity
+            android:name=".feature.recorder.RecordingActivity"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:launchMode="singleTask"
+            android:parentActivityName=".ui.home.LandingActivity"
+            tools:ignore="Instantiatable" />
 
     </application>
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivity.kt
@@ -109,25 +109,29 @@ class AddButtonActivity : FragmentActivity() {
         /** Source param for `screen_view {add_sound}` and `sound_add`: the surface that opened Create. */
         const val SOURCE_SHARE = "share"
         const val SOURCE_IMPORT = "import"
+        const val SOURCE_RECORD = "record"
 
         private const val EXTRA_SOURCE = "com.github.barriosnahuel.vossosunboton.extra.SOURCE"
 
         /**
-         * Builds an explicit intent to start the Create flow from an audio [uri] the user picked
-         * in-app (the import Hub). [Intent.FLAG_GRANT_READ_URI_PERMISSION] + [Intent.setData]
-         * forward the SAF read grant to this Activity so the copy at save time can read the stream
-         * even if the launching screen is killed first. The URI still flows through the same inbound
-         * validator (`AddButtonFeature`) as the share-sheet path — see CLAUDE.md § Security boundaries.
+         * Builds an explicit intent to start the Create flow from an audio [uri] the user produced
+         * in-app — the import Hub picker ([SOURCE_IMPORT], default) or the recorder ([SOURCE_RECORD]).
+         * [Intent.FLAG_GRANT_READ_URI_PERMISSION] + [Intent.setData] forward the read grant to this
+         * Activity so the copy at save time can read the stream even if the launching screen is killed
+         * first. The URI still flows through the same inbound validator (`AddButtonFeature`) as the
+         * share-sheet path — see CLAUDE.md § Security boundaries. [source] also tags `sound_add`'s
+         * analytics source and, for [SOURCE_RECORD], the persisted `SoundSource.RECORDED` provenance.
          */
         fun createIntent(
             context: Context,
             uri: Uri,
+            source: String = SOURCE_IMPORT,
         ): Intent =
             Intent(context, AddButtonActivity::class.java).apply {
                 data = uri
                 addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 putExtra(Intent.EXTRA_STREAM, uri)
-                putExtra(EXTRA_SOURCE, SOURCE_IMPORT)
+                putExtra(EXTRA_SOURCE, source)
             }
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
@@ -16,6 +16,7 @@ import com.github.barriosnahuel.vossosunboton.commons.file.copy
 import com.github.barriosnahuel.vossosunboton.commons.file.getFile
 import com.github.barriosnahuel.vossosunboton.model.CollectionAccess
 import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.github.barriosnahuel.vossosunboton.model.SoundSource
 import com.github.barriosnahuel.vossosunboton.model.data.manager.CollectionsRepository
 import com.github.barriosnahuel.vossosunboton.model.data.manager.SoundsRepository
 import kotlinx.coroutines.Deferred
@@ -25,6 +26,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import org.jetbrains.annotations.NotNull
 import timber.log.Timber
+import java.io.File
 import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.io.IOException
@@ -37,6 +39,7 @@ interface AddButtonFeature {
         uri: String,
         publicCollectionIds: Set<String> = emptySet(),
         privateCollectionIds: Set<String> = emptySet(),
+        source: SoundSource = SoundSource.IMPORTED,
     ): Deferred<Int>
 
     fun renameButtonAsync(
@@ -57,9 +60,9 @@ private class AddButtonFeatureImpl : AddButtonFeature {
         uri: String,
         publicCollectionIds: Set<String>,
         privateCollectionIds: Set<String>,
+        source: SoundSource,
     ): Deferred<Int> {
         val sanitizedName = name.replace(Regex("[^a-zA-Z0-9._-]"), "_")
-        val fileName = "$sanitizedName-${System.currentTimeMillis()}.mp3"
         // Mint the stable id once, at the creation site — `SoundsRepository.save` is a pure upsert
         // keyed by the id it is given, so identity must originate here, not in the repository.
         // See ADR 0008.
@@ -69,11 +72,17 @@ private class AddButtonFeatureImpl : AddButtonFeature {
         return GlobalScope.async(Dispatchers.IO) {
             var feedbackMessage = R.string.app_addbutton_feedback_save_failed
             val parsed = Uri.parse(uri)
-            when (validateAudioUri(context, parsed)) {
-                ValidationResult.Ok -> Unit
-                ValidationResult.Rejected -> return@async R.string.app_feedback_generic_error_contact_support
-                ValidationResult.Unreadable -> return@async R.string.app_addbutton_feedback_uri_unreadable
-            }
+            // Derive the destination extension from the validated MIME so the saved file's name matches
+            // its actual container (a recorded clip is AAC/MP4, an imported .opus stays .opus) — share
+            // MIME resolution keys on the extension. Unknown MIME falls back to mp3.
+            val mime =
+                when (val result = validateAudioUri(context, parsed)) {
+                    is ValidationResult.Ok -> result.mime
+                    ValidationResult.Rejected -> return@async R.string.app_feedback_generic_error_contact_support
+                    ValidationResult.Unreadable -> return@async R.string.app_addbutton_feedback_uri_unreadable
+                }
+            val extension = AUDIO_EXT_BY_MIME[mime] ?: DEFAULT_AUDIO_EXT
+            val fileName = "$sanitizedName-${System.currentTimeMillis()}.$extension"
             // getFile() resolves context.getExternalFilesDir(...), which performs disk I/O —
             // keep it inside the IO dispatcher so StrictMode does not flag it on the main thread.
             val targetFile = getFile(context, fileName)
@@ -89,25 +98,8 @@ private class AddButtonFeatureImpl : AddButtonFeature {
                         } else {
                             copy(inputStream, fileOutputStream)
                             val repo = SoundsRepository(context)
-                            repo.save(Sound(id, name, fileName))
-                            val durationMs =
-                                runCatching {
-                                    val retriever = MediaMetadataRetriever()
-                                    try {
-                                        retriever.setDataSource(targetFile.absolutePath)
-                                        retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)?.toInt()
-                                    } finally {
-                                        retriever.release()
-                                    }
-                                }.onFailure {
-                                    Tracker.log("addbutton.fileName=$fileName")
-                                    Tracker.track(
-                                        RuntimeException("Failed to extract duration metadata", it),
-                                    )
-                                }.getOrNull()
-                            if (durationMs != null) {
-                                repo.saveDuration(id, name, durationMs)
-                            }
+                            repo.save(Sound(id, name, fileName).copy(source = source))
+                            extractDurationMs(targetFile, fileName)?.let { repo.saveDuration(id, name, it) }
                             // Apply collection tags now so the audio shows up in the right place
                             // immediately. Failures don't roll back the save (the audio still
                             // exists, just untagged) but ARE reported as non-fatal so we can spot
@@ -138,6 +130,24 @@ private class AddButtonFeatureImpl : AddButtonFeature {
             feedbackMessage
         }
     }
+
+    /** Best-effort duration probe of the just-copied file; a failure is non-fatal (the audio saves). */
+    private fun extractDurationMs(
+        file: File,
+        fileName: String,
+    ): Int? =
+        runCatching {
+            val retriever = MediaMetadataRetriever()
+            try {
+                retriever.setDataSource(file.absolutePath)
+                retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)?.toInt()
+            } finally {
+                retriever.release()
+            }
+        }.onFailure {
+            Tracker.log("addbutton.fileName=$fileName")
+            Tracker.track(RuntimeException("Failed to extract duration metadata", it))
+        }.getOrNull()
 
     override fun renameButtonAsync(
         context: Context,
@@ -184,7 +194,7 @@ private class AddButtonFeatureImpl : AddButtonFeature {
                 else -> null
             }
         return if (rejection == null) {
-            ValidationResult.Ok
+            ValidationResult.Ok(mime)
         } else {
             Timber.w("Rejected inbound URI: %s", rejection)
             ValidationResult.Rejected
@@ -209,7 +219,9 @@ private class AddButtonFeatureImpl : AddButtonFeature {
     }
 
     private sealed class ValidationResult {
-        data object Ok : ValidationResult()
+        data class Ok(
+            val mime: String?,
+        ) : ValidationResult()
 
         data object Rejected : ValidationResult()
 
@@ -225,5 +237,22 @@ private class AddButtonFeatureImpl : AddButtonFeature {
         const val MAX_AUDIO_BYTES = 50L * 1024 * 1024
         const val AUDIO_MIME_PREFIX = "audio/"
         val ALLOWED_SCHEMES = setOf(ContentResolver.SCHEME_CONTENT, ContentResolver.SCHEME_FILE)
+
+        /**
+         * Destination extension per validated MIME. Explicit map rather than
+         * `MimeTypeMap.getExtensionFromMimeType` (which returns `mp4`, not `m4a`, for `audio/mp4`).
+         * Unknown audio MIME falls back to [DEFAULT_AUDIO_EXT].
+         */
+        const val DEFAULT_AUDIO_EXT = "mp3"
+        val AUDIO_EXT_BY_MIME =
+            mapOf(
+                "audio/mp4" to "m4a",
+                "audio/aac" to "m4a",
+                "audio/mpeg" to "mp3",
+                "audio/opus" to "opus",
+                "audio/ogg" to "ogg",
+                "audio/wav" to "wav",
+                "audio/x-wav" to "wav",
+            )
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
@@ -74,6 +74,7 @@ import com.github.barriosnahuel.vossosunboton.commons.android.analytics.Analytic
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.commons.file.getFile
+import com.github.barriosnahuel.vossosunboton.feature.recorder.RecorderDraftStoreProvider
 import com.github.barriosnahuel.vossosunboton.feature.vault.bumpVaultUnlockCounter
 import com.github.barriosnahuel.vossosunboton.feature.vault.security.BiometricGate
 import com.github.barriosnahuel.vossosunboton.feature.vault.security.BiometricGateResult
@@ -216,6 +217,11 @@ fun AddButtonScreen(
                             ).await()
                     if (feedbackId == R.string.app_addbutton_feedback_saved_ok) {
                         stopActivePreviewPlayback()
+                        // The recording is now a persisted Sound — forget its recoverable draft so the
+                        // Landing banner doesn't re-offer an already-saved clip (ADR 0019 § Draft recovery).
+                        if (source == AddButtonActivity.SOURCE_RECORD) {
+                            RecorderDraftStoreProvider.get(context).clear()
+                        }
                         trackSoundAdd(context, trimmedName, source, tracker)
                         saveOutcome = SaveOutcome.Success(trimmedName)
                     } else {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
@@ -81,6 +81,7 @@ import com.github.barriosnahuel.vossosunboton.feature.vault.security.BiometricGa
 import com.github.barriosnahuel.vossosunboton.feature.vault.security.VaultSessionState
 import com.github.barriosnahuel.vossosunboton.model.Collection
 import com.github.barriosnahuel.vossosunboton.model.CollectionAccess
+import com.github.barriosnahuel.vossosunboton.model.SoundSource
 import com.github.barriosnahuel.vossosunboton.model.data.manager.CollectionsRepository
 import com.github.barriosnahuel.vossosunboton.model.data.manager.SoundsRepository
 import com.github.barriosnahuel.vossosunboton.ui.haptics.performRejectHaptic
@@ -195,6 +196,14 @@ fun AddButtonScreen(
             val feature = AddButtonFeatureProvider.get()
             when (val m = mode) {
                 is AddButtonMode.Create -> {
+                    // A recording carries its provenance into persistence; every other entry point is
+                    // an import (ADR 0019). The same `source` string keeps feeding `trackSoundAdd`.
+                    val provenance =
+                        if (source == AddButtonActivity.SOURCE_RECORD) {
+                            SoundSource.RECORDED
+                        } else {
+                            SoundSource.IMPORTED
+                        }
                     val feedbackId =
                         feature
                             .saveNewButtonAsync(
@@ -203,6 +212,7 @@ fun AddButtonScreen(
                                 uri = m.uri.toString(),
                                 publicCollectionIds = collectionsState.publicSelection.value,
                                 privateCollectionIds = collectionsState.privateSelection.value,
+                                source = provenance,
                             ).await()
                     if (feedbackId == R.string.app_addbutton_feedback_saved_ok) {
                         stopActivePreviewPlayback()

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderDraftStore.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderDraftStore.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.recorder
+
+import android.content.Context
+import androidx.annotation.VisibleForTesting
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/** A captured-but-unsaved clip that survived the process: its temp [file] and recorded [durationMs]. */
+data class RecorderDraft(
+    val file: File,
+    val durationMs: Long,
+)
+
+/**
+ * Persists the *pending recording draft* — a clip the user captured but neither saved nor discarded —
+ * so it survives backgrounding, a launcher re-entry (which `clearTop`s [RecordingActivity]), and a
+ * process death (ADR 0019 § Draft recovery). The clip bytes already live in `cacheDir/recordings/`;
+ * this only records which file is the draft and its duration, so the Landing banner can offer to
+ * resume it. Interface + [DataStoreRecorderDraftStore] impl mirrors the `FirstFlagStore` precedent so
+ * the ViewModels can take a deterministic fake.
+ */
+interface RecorderDraftStore {
+    /** Reactive pending draft — emits the draft while its temp file exists, `null` otherwise. */
+    val draft: Flow<RecorderDraft?>
+
+    /** The pending draft right now, file-existence-validated. Clears stale metadata and returns null. */
+    suspend fun current(): RecorderDraft?
+
+    /** Records [file] (under `cacheDir/recordings/`) and its [durationMs] as the pending draft. */
+    fun save(
+        file: File,
+        durationMs: Long,
+    )
+
+    /** Forgets the pending draft (after save/discard). Does not delete the file — the caller owns that. */
+    fun clear()
+}
+
+/**
+ * DataStore-backed [RecorderDraftStore]. The draft file lives in the OS-evictable cache, so
+ * [draft]/[current] re-validate existence on every read and self-heal (clear the stale metadata) when
+ * the OS reclaimed the bytes — the caller then sees "no draft" rather than a dangling resume.
+ * File-existence checks run on [Dispatchers.IO] ([flowOn]) so a main-thread collector never trips
+ * StrictMode.
+ */
+class DataStoreRecorderDraftStore(
+    context: Context,
+    // Process-lived so save/clear complete even when the Activity finishes right after (back-discard,
+    // handoff). limitedParallelism(1) serialises them so a save() then clear() can't reorder on disk.
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO.limitedParallelism(1)),
+) : RecorderDraftStore {
+    private val appContext = context.applicationContext
+    private val store: DataStore<Preferences> = appContext.recorderDraftStore
+
+    override val draft: Flow<RecorderDraft?> =
+        store.data
+            .map { prefs -> prefs.toDraft() }
+            .flowOn(Dispatchers.IO)
+
+    override suspend fun current(): RecorderDraft? =
+        withContext(Dispatchers.IO) {
+            val draft = store.data.first().toDraft()
+            if (draft == null) clear()
+            draft
+        }
+
+    override fun save(
+        file: File,
+        durationMs: Long,
+    ) {
+        scope.launch {
+            store.edit {
+                it[KEY_FILE] = file.name
+                it[KEY_DURATION] = durationMs
+            }
+        }
+    }
+
+    override fun clear() {
+        scope.launch { store.edit { it.clear() } }
+    }
+
+    private fun Preferences.toDraft(): RecorderDraft? {
+        val name = this[KEY_FILE]
+        val duration = this[KEY_DURATION]
+        if (name == null || duration == null) return null
+        val file = RecorderTempFiles.resolve(appContext, name)
+        return if (file.exists()) RecorderDraft(file, duration) else null
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    suspend fun clearForTest() {
+        withContext(Dispatchers.IO) { store.edit { it.clear() } }
+    }
+
+    companion object {
+        const val DATASTORE_NAME = "recorder-draft"
+        private val KEY_FILE = stringPreferencesKey("draft_file")
+        private val KEY_DURATION = longPreferencesKey("draft_duration_ms")
+    }
+}
+
+/**
+ * Process-singleton [RecorderDraftStore] so the recorder and the Landing banner share ONE instance —
+ * one write scope, one ordering domain (a save then clear from different ViewModels can't reorder),
+ * and no per-ViewModel-construction scope leak. Manual DI (ADR 0002), mirroring `RecorderEngineProvider`.
+ */
+object RecorderDraftStoreProvider {
+    @Volatile private var instance: RecorderDraftStore? = null
+
+    fun get(context: Context): RecorderDraftStore =
+        instance ?: synchronized(this) {
+            instance ?: DataStoreRecorderDraftStore(context).also { instance = it }
+        }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    fun setForTest(store: RecorderDraftStore?) {
+        instance = store
+    }
+}
+
+private val Context.recorderDraftStore: DataStore<Preferences> by preferencesDataStore(
+    name = DataStoreRecorderDraftStore.DATASTORE_NAME,
+    corruptionHandler =
+        ReplaceFileCorruptionHandler { exception ->
+            Tracker.track(RuntimeException("Recorder draft DataStore corruption recovered", exception))
+            emptyPreferences()
+        },
+)

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderEngine.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderEngine.kt
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.recorder
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import android.media.MediaRecorder
+import android.os.Build
+import androidx.annotation.VisibleForTesting
+import java.io.File
+
+/**
+ * Captures microphone audio to a single AAC/MP4 (`.m4a`) file — the in-app recorder's only platform
+ * surface (ADR 0019). Synchronous and blocking on purpose: [RecorderViewModel] owns the dispatcher and
+ * calls [start]/[stop]/[release] off the main thread; [maxAmplitude] is an in-memory read safe on main.
+ *
+ * Lifecycle contract (the ADR's main care point): the caller MUST [release] in `onCleared` *and* the
+ * Activity's `onStop` — an unreleased recorder can hold the mic globally until reboot on some OEMs.
+ * [release] is idempotent. Audio focus (`AUDIOFOCUS_GAIN_TRANSIENT`) is requested on [start] and
+ * abandoned on [release]; losing it (an incoming call, another app grabbing the mic) fires
+ * [onInterrupted] so the VM can auto-stop and preserve what was captured.
+ */
+interface RecorderEngine {
+    /** Auto-stop fired by the platform when [MAX_DURATION_MS] is reached. Set by the VM. */
+    var onMaxDurationReached: (() -> Unit)?
+
+    /** A fatal recorder error or an audio-focus loss. Set by the VM to auto-stop + preserve. */
+    var onInterrupted: (() -> Unit)?
+
+    /** Starts capturing into [outputFile]. Throws if the mic is unavailable (in use by another app). */
+    fun start(outputFile: File)
+
+    /** Stops capturing and releases the recorder. Returns false if no valid clip was produced. */
+    fun stop(): Boolean
+
+    /** Peak amplitude since the previous call, normalized to `0f..1f`; `0f` when not recording. */
+    fun maxAmplitude(): Float
+
+    /** Releases the recorder and abandons audio focus. Idempotent — safe to call repeatedly. */
+    fun release()
+
+    companion object {
+        const val MAX_DURATION_MS = 60_000
+        private const val SAMPLE_RATE_HZ = 44_100
+        private const val BIT_RATE_BPS = 64_000
+        private const val MAX_AMPLITUDE = 32_767f
+
+        fun create(context: Context): RecorderEngine = MediaRecorderEngine(context.applicationContext)
+
+        @VisibleForTesting
+        internal val SAMPLE_RATE: Int = SAMPLE_RATE_HZ
+
+        @VisibleForTesting
+        internal val BIT_RATE: Int = BIT_RATE_BPS
+
+        internal const val NORMALIZER: Float = MAX_AMPLITUDE
+    }
+}
+
+private class MediaRecorderEngine(
+    private val context: Context,
+) : RecorderEngine {
+    override var onMaxDurationReached: (() -> Unit)? = null
+    override var onInterrupted: (() -> Unit)? = null
+
+    private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    private var recorder: MediaRecorder? = null
+    private var focusRequest: AudioFocusRequest? = null
+    private var recording = false
+
+    private val focusListener =
+        AudioManager.OnAudioFocusChangeListener { change ->
+            if (change == AudioManager.AUDIOFOCUS_LOSS || change == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT) {
+                onInterrupted?.invoke()
+            }
+        }
+
+    override fun start(outputFile: File) {
+        requestFocus()
+        val mediaRecorder = newRecorder()
+        recorder = mediaRecorder
+        mediaRecorder.apply {
+            setAudioSource(MediaRecorder.AudioSource.MIC)
+            setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+            setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
+            setAudioChannels(1)
+            setAudioSamplingRate(RecorderEngine.SAMPLE_RATE)
+            setAudioEncodingBitRate(RecorderEngine.BIT_RATE)
+            setMaxDuration(RecorderEngine.MAX_DURATION_MS)
+            setOutputFile(outputFile.absolutePath)
+            setOnInfoListener { _, what, _ ->
+                if (what == MediaRecorder.MEDIA_RECORDER_INFO_MAX_DURATION_REACHED) onMaxDurationReached?.invoke()
+            }
+            setOnErrorListener { _, _, _ -> onInterrupted?.invoke() }
+            prepare()
+            start()
+        }
+        recording = true
+    }
+
+    override fun stop(): Boolean {
+        val mediaRecorder = recorder ?: return false
+        val produced =
+            try {
+                mediaRecorder.stop()
+                true
+            } catch (ignored: RuntimeException) {
+                // MediaRecorder.stop() throws if stopped before any frame was written (a sub-second
+                // tap); the partial file is unusable. Treat as "no valid clip".
+                false
+            }
+        release()
+        return produced
+    }
+
+    override fun maxAmplitude(): Float =
+        if (recording) {
+            (recorder?.maxAmplitude ?: 0) / RecorderEngine.NORMALIZER
+        } else {
+            0f
+        }
+
+    override fun release() {
+        recording = false
+        recorder?.let { mediaRecorder ->
+            runCatching {
+                mediaRecorder.reset()
+                mediaRecorder.release()
+            }
+        }
+        recorder = null
+        abandonFocus()
+    }
+
+    private fun newRecorder(): MediaRecorder =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            MediaRecorder(context)
+        } else {
+            @Suppress("DEPRECATION")
+            MediaRecorder()
+        }
+
+    private fun requestFocus() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val request =
+                AudioFocusRequest
+                    .Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
+                    .setAudioAttributes(
+                        AudioAttributes
+                            .Builder()
+                            .setUsage(AudioAttributes.USAGE_MEDIA)
+                            .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                            .build(),
+                    ).setOnAudioFocusChangeListener(focusListener)
+                    .build()
+            focusRequest = request
+            audioManager.requestAudioFocus(request)
+        } else {
+            @Suppress("DEPRECATION")
+            audioManager.requestAudioFocus(
+                focusListener,
+                AudioManager.STREAM_MUSIC,
+                AudioManager.AUDIOFOCUS_GAIN_TRANSIENT,
+            )
+        }
+    }
+
+    private fun abandonFocus() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            focusRequest?.let { audioManager.abandonAudioFocusRequest(it) }
+            focusRequest = null
+        } else {
+            @Suppress("DEPRECATION")
+            audioManager.abandonAudioFocus(focusListener)
+        }
+    }
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderEngineProvider.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderEngineProvider.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.recorder
+
+import android.content.Context
+import androidx.annotation.VisibleForTesting
+
+/**
+ * Substitution seam for [RecorderEngine], mirroring `AddButtonFeatureProvider`: production resolves a
+ * real [MediaRecorder][android.media.MediaRecorder]-backed engine; tests swap a fake via [setForTest]
+ * so a `RecordingActivity` smoke test (or VM test through the factory) never touches the real mic.
+ */
+object RecorderEngineProvider {
+    @Volatile
+    private var override: RecorderEngine? = null
+
+    fun get(context: Context): RecorderEngine = override ?: RecorderEngine.create(context)
+
+    @VisibleForTesting
+    fun setForTest(engine: RecorderEngine?) {
+        override = engine
+    }
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderEnvelope.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderEnvelope.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.recorder
+
+import kotlin.math.max
+
+/**
+ * Builds the recorder review envelope from the amplitude samples captured live during recording (one
+ * per poll tick), so the review wave renders **instantly** without re-decoding the file — killing the
+ * post-stop placeholder gap (ADR 0019). [barCount] bars normalized to loudest = 1.0 with a [MIN_BAR]
+ * floor (same floor as the decoded `PeakAccumulator`, so a live-fed envelope looks like a decoded one).
+ *
+ * Returns `null` — caller decodes the real file instead — when there is **no usable live signal**:
+ * empty input, or every sample silent. The all-silent case matters because some devices' MediaRecorder
+ * always reports `getMaxAmplitude() == 0`; a flat live envelope would otherwise hide the real waveform.
+ * Pure (no Android) so the bucketing/interpolation is unit-tested.
+ */
+internal fun buildRecorderEnvelope(
+    samples: List<Float>,
+    barCount: Int,
+): FloatArray? {
+    if (samples.isEmpty()) return null
+    val raw = FloatArray(barCount)
+    if (samples.size >= barCount) {
+        // Downsample: max per positional bucket, preserving peaks (same idea as the PCM bucketing).
+        samples.forEachIndexed { i, sample ->
+            val bucket = (i.toLong() * barCount / samples.size).toInt().coerceAtMost(barCount - 1)
+            if (sample > raw[bucket]) raw[bucket] = sample
+        }
+    } else {
+        // Upsample a short clip: linear interpolation across the series so there are no sparse gaps.
+        val lastSample = samples.size - 1
+        val lastBar = (barCount - 1).coerceAtLeast(1)
+        for (i in 0 until barCount) {
+            val pos = i.toFloat() * lastSample / lastBar
+            val lo = pos.toInt()
+            val hi = (lo + 1).coerceAtMost(lastSample)
+            raw[i] = samples[lo] + (samples[hi] - samples[lo]) * (pos - lo)
+        }
+    }
+    val loudest = raw.maxOrNull() ?: 0f
+    // No usable signal (true silence, or the getMaxAmplitude()-always-0 device quirk) → null so the
+    // caller decodes the real file instead of showing a fake flat line for a clip that has audio.
+    return if (loudest <= 0f) null else FloatArray(barCount) { max(MIN_BAR, raw[it] / loudest) }
+}
+
+/** Baseline floor for a normalized bar — matches the decoded envelope's floor (`PeakAccumulator`). */
+private const val MIN_BAR = 0.06f

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreen.kt
@@ -46,7 +46,9 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.progressBarRangeInfo
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -55,6 +57,8 @@ import com.github.barriosnahuel.vossosunboton.ui.AppIcons
 import com.github.barriosnahuel.vossosunboton.ui.home.formatDuration
 import com.github.barriosnahuel.vossosunboton.ui.theme.ImmersiveListenTheme
 import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
+import kotlin.math.abs
+import kotlin.math.sin
 
 /**
  * The immersive recorder (ADR 0019) — the listen screen "in reverse". Stateless: driven by
@@ -66,6 +70,7 @@ import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
 internal fun RecorderScreen(
     state: RecorderState,
     isPreviewPlaying: Boolean,
+    previewPositionMs: Long,
     onRecordTap: () -> Unit,
     onStopTap: () -> Unit,
     onPreviewToggle: () -> Unit,
@@ -83,8 +88,8 @@ internal fun RecorderScreen(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.SpaceBetween,
             ) {
-                RecorderHeadline(state)
-                RecorderVisual(state)
+                RecorderHeadline(state, isPreviewPlaying, previewPositionMs)
+                RecorderVisual(state, previewPositionMs)
                 RecorderTransport(
                     state = state,
                     isPreviewPlaying = isPreviewPlaying,
@@ -113,7 +118,11 @@ private fun RecorderTopBar(onClose: () -> Unit) {
 }
 
 @Composable
-private fun RecorderHeadline(state: RecorderState) {
+private fun RecorderHeadline(
+    state: RecorderState,
+    isPreviewPlaying: Boolean,
+    previewPositionMs: Long,
+) {
     val timerDescription = stringResource(R.string.app_recorder_cd_timer)
     Box(modifier = Modifier.height(HEADLINE_HEIGHT), contentAlignment = Alignment.Center) {
         when (state) {
@@ -127,20 +136,13 @@ private fun RecorderHeadline(state: RecorderState) {
                                 .clip(CircleShape)
                                 .background(MaterialTheme.colorScheme.error),
                     )
-                    Text(
-                        text = formatDuration(state.elapsedMs.toInt()),
-                        style = MaterialTheme.typography.displayMedium,
-                        fontWeight = FontWeight.Medium,
-                        color = MaterialTheme.colorScheme.onBackground,
-                        modifier = Modifier.semantics { contentDescription = timerDescription },
-                    )
+                    HeadlineTimer(state.elapsedMs, timerDescription)
                 }
             is RecorderState.Review ->
-                Text(
-                    text = formatDuration(state.durationMs.toInt()),
-                    style = MaterialTheme.typography.displayMedium,
-                    fontWeight = FontWeight.Medium,
-                    color = MaterialTheme.colorScheme.onBackground,
+                // While previewing, follow the playback position; otherwise rest at the clip length.
+                HeadlineTimer(
+                    millis = if (isPreviewPlaying) previewPositionMs else state.durationMs,
+                    description = timerDescription,
                 )
             RecorderState.Ready -> Unit
         }
@@ -148,11 +150,75 @@ private fun RecorderHeadline(state: RecorderState) {
 }
 
 @Composable
-private fun RecorderVisual(state: RecorderState) {
+private fun HeadlineTimer(
+    millis: Long,
+    description: String,
+) {
+    Text(
+        text = formatDuration(millis.toInt()),
+        style = MaterialTheme.typography.displayMedium,
+        fontWeight = FontWeight.Medium,
+        color = MaterialTheme.colorScheme.onBackground,
+        modifier = Modifier.semantics { contentDescription = description },
+    )
+}
+
+@Composable
+private fun RecorderVisual(
+    state: RecorderState,
+    previewPositionMs: Long,
+) {
     Box(modifier = Modifier.fillMaxWidth().height(WAVEFORM_HEIGHT), contentAlignment = Alignment.Center) {
         when (state) {
             is RecorderState.Recording -> LiveWaveform(amplitude = state.amplitude, tick = state.elapsedMs)
-            else -> LiveWaveform(amplitude = 0f, tick = 0L)
+            is RecorderState.Review ->
+                ReviewWaveform(
+                    progress = if (state.durationMs > 0L) previewPositionMs.toFloat() / state.durationMs else 0f,
+                )
+            RecorderState.Ready -> LiveWaveform(amplitude = 0f, tick = 0L)
+        }
+    }
+}
+
+/**
+ * Playback-progress waveform for the review state: a fixed decorative bar shape whose left portion
+ * fills with `primary` as the preview plays (the rest dimmed), mirroring the listen screen's fill +
+ * exposing [progress] via semantics. Distinct from [LiveWaveform] (the live input meter).
+ */
+@Composable
+private fun ReviewWaveform(
+    progress: Float,
+    modifier: Modifier = Modifier,
+) {
+    val fraction = progress.coerceIn(0f, 1f)
+    val playedColor = MaterialTheme.colorScheme.primary
+    val unplayedColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = WAVEFORM_UNPLAYED_ALPHA)
+    val label = stringResource(R.string.app_recorder_cd_waveform)
+    Canvas(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(WAVEFORM_HEIGHT)
+                .semantics {
+                    contentDescription = label
+                    progressBarRangeInfo = ProgressBarRangeInfo(fraction, 0f..1f)
+                },
+    ) {
+        val slot = size.width / WAVEFORM_BARS
+        val barWidth = slot * WAVEFORM_BAR_FILL
+        val centerY = size.height / 2f
+        val corner = CornerRadius(barWidth / 2f, barWidth / 2f)
+        for (i in 0 until WAVEFORM_BARS) {
+            val amplitude = (abs(sin(i * WAVE_SHAPE_FREQ)) * WAVE_SHAPE_RANGE + WAVE_SHAPE_BASE).toFloat()
+            val barHeight = amplitude.coerceIn(WAVEFORM_MIN_FRACTION, 1f) * size.height
+            val played = (i + WAVEFORM_BAR_CENTER) / WAVEFORM_BARS <= fraction
+            val x = i * slot + (slot - barWidth) / 2f
+            drawRoundRect(
+                color = if (played) playedColor else unplayedColor,
+                topLeft = Offset(x, centerY - barHeight / 2f),
+                size = Size(barWidth, barHeight),
+                cornerRadius = corner,
+            )
         }
     }
 }
@@ -436,6 +502,13 @@ private val WAVEFORM_HEIGHT = 120.dp
 private const val WAVEFORM_BARS = 48
 private const val WAVEFORM_BAR_FILL = 0.5f
 private const val WAVEFORM_MIN_FRACTION = 0.06f
+private const val WAVEFORM_UNPLAYED_ALPHA = 0.30f
+private const val WAVEFORM_BAR_CENTER = 0.5f
+
+// Fixed decorative envelope for the review waveform (deterministic — no randomness).
+private const val WAVE_SHAPE_FREQ = 1.7
+private const val WAVE_SHAPE_RANGE = 0.7
+private const val WAVE_SHAPE_BASE = 0.2
 private const val GLOW_CENTER_ALPHA = 0.16f
 private const val GLOW_MID_ALPHA = 0.04f
 private const val GLOW_STOP_CENTER = 0.0f

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreen.kt
@@ -1,0 +1,443 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+@file:Suppress("TooManyFunctions") // One cohesive immersive screen + its permission/discard chrome.
+
+package com.github.barriosnahuel.vossosunboton.feature.recorder
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.ui.AppIcons
+import com.github.barriosnahuel.vossosunboton.ui.home.formatDuration
+import com.github.barriosnahuel.vossosunboton.ui.theme.ImmersiveListenTheme
+import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
+
+/**
+ * The immersive recorder (ADR 0019) — the listen screen "in reverse". Stateless: driven by
+ * [RecorderState] and callbacks; the host (`RecordingActivity`) owns the VM, permission, and discard
+ * dialog. Always-dark via [ImmersiveListenTheme]; colours come from M3 roles only (acid record button,
+ * `error` REC dot) — no hardcoded literals (CLAUDE.md § Design system).
+ */
+@Composable
+internal fun RecorderScreen(
+    state: RecorderState,
+    isPreviewPlaying: Boolean,
+    onRecordTap: () -> Unit,
+    onStopTap: () -> Unit,
+    onPreviewToggle: () -> Unit,
+    onUseClip: () -> Unit,
+    onReRecord: () -> Unit,
+    onClose: () -> Unit,
+) {
+    RecorderBackdrop {
+        Column(
+            modifier = Modifier.fillMaxSize().safeDrawingPadding(),
+        ) {
+            RecorderTopBar(onClose = onClose)
+            Column(
+                modifier = Modifier.fillMaxSize().padding(horizontal = Spacing.XL),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.SpaceBetween,
+            ) {
+                RecorderHeadline(state)
+                RecorderVisual(state)
+                RecorderTransport(
+                    state = state,
+                    isPreviewPlaying = isPreviewPlaying,
+                    onRecordTap = onRecordTap,
+                    onStopTap = onStopTap,
+                    onPreviewToggle = onPreviewToggle,
+                    onUseClip = onUseClip,
+                    onReRecord = onReRecord,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RecorderTopBar(onClose: () -> Unit) {
+    Row(modifier = Modifier.fillMaxWidth().height(TOP_BAR_HEIGHT), verticalAlignment = Alignment.CenterVertically) {
+        IconButton(onClick = onClose) {
+            Icon(
+                painter = painterResource(R.drawable.app_ic_close),
+                contentDescription = stringResource(R.string.app_recorder_cd_close),
+                tint = MaterialTheme.colorScheme.onBackground,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RecorderHeadline(state: RecorderState) {
+    val timerDescription = stringResource(R.string.app_recorder_cd_timer)
+    Box(modifier = Modifier.height(HEADLINE_HEIGHT), contentAlignment = Alignment.Center) {
+        when (state) {
+            is RecorderState.Recording ->
+                // Timer with a live REC dot (error red).
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(Spacing.SM)) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(REC_DOT_SIZE)
+                                .clip(CircleShape)
+                                .background(MaterialTheme.colorScheme.error),
+                    )
+                    Text(
+                        text = formatDuration(state.elapsedMs.toInt()),
+                        style = MaterialTheme.typography.displayMedium,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onBackground,
+                        modifier = Modifier.semantics { contentDescription = timerDescription },
+                    )
+                }
+            is RecorderState.Review ->
+                Text(
+                    text = formatDuration(state.durationMs.toInt()),
+                    style = MaterialTheme.typography.displayMedium,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+            RecorderState.Ready -> Unit
+        }
+    }
+}
+
+@Composable
+private fun RecorderVisual(state: RecorderState) {
+    Box(modifier = Modifier.fillMaxWidth().height(WAVEFORM_HEIGHT), contentAlignment = Alignment.Center) {
+        when (state) {
+            is RecorderState.Recording -> LiveWaveform(amplitude = state.amplitude, tick = state.elapsedMs)
+            else -> LiveWaveform(amplitude = 0f, tick = 0L)
+        }
+    }
+}
+
+/**
+ * A live input meter: a rolling buffer of recent peak amplitudes, newest on the right. Acid bars
+ * (`primary`) while sound comes in; a flat baseline when idle. Distinct from the listen screen's
+ * scrubbable envelope — this reads as "recording now".
+ */
+@Composable
+private fun LiveWaveform(
+    amplitude: Float,
+    tick: Long,
+    modifier: Modifier = Modifier,
+) {
+    val bars: SnapshotStateList<Float> = remember { mutableStateListOf<Float>().apply { repeat(WAVEFORM_BARS) { add(0f) } } }
+    LaunchedEffect(tick) {
+        bars.removeAt(0)
+        bars.add(amplitude.coerceIn(0f, 1f))
+    }
+    val activeColor = MaterialTheme.colorScheme.primary
+    Canvas(modifier = modifier.fillMaxWidth().height(WAVEFORM_HEIGHT)) {
+        val slot = size.width / WAVEFORM_BARS
+        val barWidth = slot * WAVEFORM_BAR_FILL
+        val centerY = size.height / 2f
+        val corner = CornerRadius(barWidth / 2f, barWidth / 2f)
+        bars.forEachIndexed { i, raw ->
+            val barHeight = raw.coerceIn(WAVEFORM_MIN_FRACTION, 1f) * size.height
+            val x = i * slot + (slot - barWidth) / 2f
+            drawRoundRect(
+                color = activeColor,
+                topLeft = Offset(x, centerY - barHeight / 2f),
+                size = Size(barWidth, barHeight),
+                cornerRadius = corner,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RecorderTransport(
+    state: RecorderState,
+    isPreviewPlaying: Boolean,
+    onRecordTap: () -> Unit,
+    onStopTap: () -> Unit,
+    onPreviewToggle: () -> Unit,
+    onUseClip: () -> Unit,
+    onReRecord: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(bottom = Spacing.XXL),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(Spacing.MD),
+    ) {
+        when (state) {
+            RecorderState.Ready -> {
+                HeroButton(
+                    iconPainter = painterResource(R.drawable.app_ic_mic),
+                    contentDescription = stringResource(R.string.app_recorder_cd_record),
+                    onClick = onRecordTap,
+                )
+                Text(
+                    text = stringResource(R.string.app_recorder_ready_hint),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+            }
+            is RecorderState.Recording -> {
+                HeroButton(
+                    iconPainter = rememberVectorPainter(AppIcons.Stop),
+                    contentDescription = stringResource(R.string.app_recorder_cd_stop),
+                    onClick = onStopTap,
+                )
+                Text(
+                    text = stringResource(R.string.app_recorder_recording_hint),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+            }
+            is RecorderState.Review -> {
+                HeroButton(
+                    iconPainter =
+                        if (isPreviewPlaying) {
+                            rememberVectorPainter(AppIcons.Pause)
+                        } else {
+                            painterResource(R.drawable.app_ic_play_arrow)
+                        },
+                    contentDescription =
+                        stringResource(
+                            if (isPreviewPlaying) R.string.app_recorder_cd_pause else R.string.app_recorder_cd_play,
+                        ),
+                    onClick = onPreviewToggle,
+                )
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(top = Spacing.SM),
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.MD, Alignment.CenterHorizontally),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    TextButton(onClick = onReRecord) {
+                        Text(text = stringResource(R.string.app_recorder_rerecord))
+                    }
+                    Button(
+                        onClick = onUseClip,
+                        colors =
+                            ButtonDefaults.buttonColors(
+                                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                            ),
+                    ) {
+                        Text(text = stringResource(R.string.app_recorder_use))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HeroButton(
+    iconPainter: androidx.compose.ui.graphics.painter.Painter,
+    contentDescription: String,
+    onClick: () -> Unit,
+) {
+    FilledIconButton(
+        onClick = onClick,
+        modifier = Modifier.size(HERO_BUTTON_SIZE),
+        shape = CircleShape,
+        colors =
+            IconButtonDefaults.filledIconButtonColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            ),
+    ) {
+        Icon(
+            painter = iconPainter,
+            contentDescription = contentDescription,
+            modifier = Modifier.size(HERO_ICON_SIZE),
+        )
+    }
+}
+
+/** On-brand priming shown before the system permission dialog. */
+@Composable
+internal fun MicPermissionPriming(
+    onAllow: () -> Unit,
+    onNotNow: () -> Unit,
+) {
+    RecorderBackdrop {
+        Column(
+            modifier = Modifier.fillMaxSize().safeDrawingPadding().padding(Spacing.XL),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.app_ic_mic),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(PRIMING_ICON_SIZE),
+            )
+            Spacer(Modifier.height(Spacing.LG))
+            Text(
+                text = stringResource(R.string.app_recorder_permission_title),
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+            Spacer(Modifier.height(Spacing.SM))
+            Text(
+                text = stringResource(R.string.app_recorder_permission_body),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(Spacing.XL))
+            Button(
+                onClick = onAllow,
+                modifier = Modifier.fillMaxWidth(),
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    ),
+            ) {
+                Text(text = stringResource(R.string.app_recorder_permission_allow))
+            }
+            TextButton(onClick = onNotNow) {
+                Text(text = stringResource(R.string.app_recorder_permission_not_now))
+            }
+        }
+    }
+}
+
+/** Shown after a denial — routes to settings or an import escape so the user is never stuck. */
+@Composable
+internal fun MicPermissionDenied(
+    onOpenSettings: () -> Unit,
+    onImportInstead: () -> Unit,
+    onClose: () -> Unit,
+) {
+    RecorderBackdrop {
+        Column(modifier = Modifier.fillMaxSize().safeDrawingPadding()) {
+            RecorderTopBar(onClose = onClose)
+            Column(
+                modifier = Modifier.fillMaxSize().padding(Spacing.XL),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Text(
+                    text = stringResource(R.string.app_recorder_denied_message),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+                Spacer(Modifier.height(Spacing.XL))
+                Button(
+                    onClick = onOpenSettings,
+                    modifier = Modifier.fillMaxWidth(),
+                    colors =
+                        ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.primaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                        ),
+                ) {
+                    Text(text = stringResource(R.string.app_recorder_open_settings))
+                }
+                TextButton(onClick = onImportInstead) {
+                    Text(text = stringResource(R.string.app_recorder_import_instead))
+                }
+            }
+        }
+    }
+}
+
+/** Confirms discarding captured audio on back — losing a memory shouldn't be one accidental tap. */
+@Composable
+internal fun RecorderDiscardDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.app_recorder_discard_title)) },
+        text = { Text(stringResource(R.string.app_recorder_discard_message)) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) { Text(stringResource(R.string.app_recorder_discard_confirm)) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.app_recorder_discard_keep)) }
+        },
+    )
+}
+
+@Composable
+private fun RecorderBackdrop(content: @Composable () -> Unit) {
+    // Clone of the listen screen's always-dark wash (its ImmersiveBackdrop is private): legible status
+    // bars in both modes + the same warm glow, so creating a memory and re-living one share the light.
+    ImmersiveListenTheme {
+        val accent = MaterialTheme.colorScheme.primary
+        val backgroundColor = MaterialTheme.colorScheme.background
+        val wash =
+            remember(accent, backgroundColor) {
+                Brush.radialGradient(
+                    colorStops =
+                        arrayOf(
+                            GLOW_STOP_CENTER to accent.copy(alpha = GLOW_CENTER_ALPHA),
+                            GLOW_STOP_MID to accent.copy(alpha = GLOW_MID_ALPHA),
+                            GLOW_STOP_EDGE to backgroundColor,
+                        ),
+                )
+            }
+        Box(modifier = Modifier.fillMaxSize().background(backgroundColor).background(wash)) {
+            content()
+        }
+    }
+}
+
+private val TOP_BAR_HEIGHT = 64.dp
+private val HEADLINE_HEIGHT = 96.dp
+private val REC_DOT_SIZE = 10.dp
+private val HERO_BUTTON_SIZE = 104.dp
+private val HERO_ICON_SIZE = 44.dp
+private val PRIMING_ICON_SIZE = 64.dp
+private val WAVEFORM_HEIGHT = 120.dp
+private const val WAVEFORM_BARS = 48
+private const val WAVEFORM_BAR_FILL = 0.5f
+private const val WAVEFORM_MIN_FRACTION = 0.06f
+private const val GLOW_CENTER_ALPHA = 0.16f
+private const val GLOW_MID_ALPHA = 0.04f
+private const val GLOW_STOP_CENTER = 0.0f
+private const val GLOW_STOP_MID = 0.55f
+private const val GLOW_STOP_EDGE = 1.0f

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreen.kt
@@ -53,12 +53,11 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.feature.vault.WaveformExtractor
 import com.github.barriosnahuel.vossosunboton.ui.AppIcons
 import com.github.barriosnahuel.vossosunboton.ui.home.formatDuration
 import com.github.barriosnahuel.vossosunboton.ui.theme.ImmersiveListenTheme
 import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
-import kotlin.math.abs
-import kotlin.math.sin
 
 /**
  * The immersive recorder (ADR 0019) — the listen screen "in reverse". Stateless: driven by
@@ -71,6 +70,7 @@ internal fun RecorderScreen(
     state: RecorderState,
     isPreviewPlaying: Boolean,
     previewPositionMs: Long,
+    peaks: FloatArray?,
     onRecordTap: () -> Unit,
     onStopTap: () -> Unit,
     onPreviewToggle: () -> Unit,
@@ -89,7 +89,7 @@ internal fun RecorderScreen(
                 verticalArrangement = Arrangement.SpaceBetween,
             ) {
                 RecorderHeadline(state, isPreviewPlaying, previewPositionMs)
-                RecorderVisual(state, previewPositionMs)
+                RecorderVisual(state, previewPositionMs, peaks)
                 RecorderTransport(
                     state = state,
                     isPreviewPlaying = isPreviewPlaying,
@@ -167,6 +167,7 @@ private fun HeadlineTimer(
 private fun RecorderVisual(
     state: RecorderState,
     previewPositionMs: Long,
+    peaks: FloatArray?,
 ) {
     Box(modifier = Modifier.fillMaxWidth().height(WAVEFORM_HEIGHT), contentAlignment = Alignment.Center) {
         when (state) {
@@ -174,6 +175,7 @@ private fun RecorderVisual(
             is RecorderState.Review ->
                 ReviewWaveform(
                     progress = if (state.durationMs > 0L) previewPositionMs.toFloat() / state.durationMs else 0f,
+                    peaks = peaks,
                 )
             RecorderState.Ready -> LiveWaveform(amplitude = 0f, tick = 0L)
         }
@@ -181,13 +183,15 @@ private fun RecorderVisual(
 }
 
 /**
- * Playback-progress waveform for the review state: a fixed decorative bar shape whose left portion
- * fills with `primary` as the preview plays (the rest dimmed), mirroring the listen screen's fill +
- * exposing [progress] via semantics. Distinct from [LiveWaveform] (the live input meter).
+ * Playback-progress waveform for the review state: the clip's real amplitude envelope (decoded by
+ * [WaveformExtractor], same as the listen screen), whose left portion fills with `primary` as the
+ * preview plays (the rest dimmed) and exposes [progress] via semantics. A neutral placeholder
+ * baseline shows while [peaks] is still decoding. Distinct from [LiveWaveform] (the live input meter).
  */
 @Composable
 private fun ReviewWaveform(
     progress: Float,
+    peaks: FloatArray?,
     modifier: Modifier = Modifier,
 ) {
     val fraction = progress.coerceIn(0f, 1f)
@@ -204,14 +208,14 @@ private fun ReviewWaveform(
                     progressBarRangeInfo = ProgressBarRangeInfo(fraction, 0f..1f)
                 },
     ) {
-        val slot = size.width / WAVEFORM_BARS
+        val slot = size.width / RECORDER_WAVEFORM_BARS
         val barWidth = slot * WAVEFORM_BAR_FILL
         val centerY = size.height / 2f
         val corner = CornerRadius(barWidth / 2f, barWidth / 2f)
-        for (i in 0 until WAVEFORM_BARS) {
-            val amplitude = (abs(sin(i * WAVE_SHAPE_FREQ)) * WAVE_SHAPE_RANGE + WAVE_SHAPE_BASE).toFloat()
+        for (i in 0 until RECORDER_WAVEFORM_BARS) {
+            val amplitude = peaks?.getOrNull(i) ?: WAVEFORM_PLACEHOLDER_FRACTION
             val barHeight = amplitude.coerceIn(WAVEFORM_MIN_FRACTION, 1f) * size.height
-            val played = (i + WAVEFORM_BAR_CENTER) / WAVEFORM_BARS <= fraction
+            val played = (i + WAVEFORM_BAR_CENTER) / RECORDER_WAVEFORM_BARS <= fraction
             val x = i * slot + (slot - barWidth) / 2f
             drawRoundRect(
                 color = if (played) playedColor else unplayedColor,
@@ -234,14 +238,14 @@ private fun LiveWaveform(
     tick: Long,
     modifier: Modifier = Modifier,
 ) {
-    val bars: SnapshotStateList<Float> = remember { mutableStateListOf<Float>().apply { repeat(WAVEFORM_BARS) { add(0f) } } }
+    val bars: SnapshotStateList<Float> = remember { mutableStateListOf<Float>().apply { repeat(RECORDER_WAVEFORM_BARS) { add(0f) } } }
     LaunchedEffect(tick) {
         bars.removeAt(0)
         bars.add(amplitude.coerceIn(0f, 1f))
     }
     val activeColor = MaterialTheme.colorScheme.primary
     Canvas(modifier = modifier.fillMaxWidth().height(WAVEFORM_HEIGHT)) {
-        val slot = size.width / WAVEFORM_BARS
+        val slot = size.width / RECORDER_WAVEFORM_BARS
         val barWidth = slot * WAVEFORM_BAR_FILL
         val centerY = size.height / 2f
         val corner = CornerRadius(barWidth / 2f, barWidth / 2f)
@@ -499,16 +503,14 @@ private val HERO_BUTTON_SIZE = 104.dp
 private val HERO_ICON_SIZE = 44.dp
 private val PRIMING_ICON_SIZE = 64.dp
 private val WAVEFORM_HEIGHT = 120.dp
-private const val WAVEFORM_BARS = 48
+internal const val RECORDER_WAVEFORM_BARS = 48
 private const val WAVEFORM_BAR_FILL = 0.5f
 private const val WAVEFORM_MIN_FRACTION = 0.06f
 private const val WAVEFORM_UNPLAYED_ALPHA = 0.30f
 private const val WAVEFORM_BAR_CENTER = 0.5f
 
-// Fixed decorative envelope for the review waveform (deterministic — no randomness).
-private const val WAVE_SHAPE_FREQ = 1.7
-private const val WAVE_SHAPE_RANGE = 0.7
-private const val WAVE_SHAPE_BASE = 0.2
+// Neutral baseline shown while the real envelope is still decoding (matches the listen screen).
+private const val WAVEFORM_PLACEHOLDER_FRACTION = 0.12f
 private const val GLOW_CENTER_ALPHA = 0.16f
 private const val GLOW_MID_ALPHA = 0.04f
 private const val GLOW_STOP_CENTER = 0.0f

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderTempFiles.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderTempFiles.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.recorder
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.content.FileProvider
+import com.github.barriosnahuel.vossosunboton.BuildConfig
+import java.io.File
+
+/**
+ * The recorder's transient capture files. A clip lives in `cacheDir/recordings/` (OS-evictable, never
+ * external) until the user saves it — then the save pipeline copies it into `Music/` and this temp is
+ * dead weight the OS can reclaim. Exposed to the save flow as a FileProvider `content://` URI (same
+ * authority `ShareFeature` uses) so it passes the `AddButtonFeature` inbound validator (scheme +
+ * `audio/mp4` MIME) — the recorder does not fork the persistence/validation path (ADR 0019).
+ */
+object RecorderTempFiles {
+    private const val DIR = "recordings"
+    private const val PREFIX = "recording-"
+    private const val EXTENSION = ".m4a"
+    private val authority = BuildConfig.APPLICATION_ID + ".fileprovider"
+
+    /** A fresh, empty target file under `cacheDir/recordings/` (directory created if absent). */
+    fun newTempFile(context: Context): File {
+        val dir = File(context.cacheDir, DIR).apply { mkdirs() }
+        return File(dir, "$PREFIX${System.currentTimeMillis()}$EXTENSION")
+    }
+
+    /** Content URI for [file] under the shared FileProvider authority. */
+    fun contentUriFor(
+        context: Context,
+        file: File,
+    ): Uri = FileProvider.getUriForFile(context, authority, file)
+
+    /**
+     * Deletes every leftover capture. Called on recorder entry to clear clips a prior session handed
+     * off (the save pipeline has already copied those) or abandoned. Only one recording exists at a
+     * time, so a blanket purge is safe.
+     */
+    fun purge(context: Context) {
+        File(context.cacheDir, DIR).listFiles()?.forEach { it.delete() }
+    }
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderTempFiles.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderTempFiles.kt
@@ -24,11 +24,17 @@ object RecorderTempFiles {
     private const val EXTENSION = ".m4a"
     private val authority = BuildConfig.APPLICATION_ID + ".fileprovider"
 
+    /** The capture directory (`cacheDir/recordings/`), created if absent. */
+    fun dir(context: Context): File = File(context.cacheDir, DIR).apply { mkdirs() }
+
+    /** Resolves a capture [fileName] (as persisted in a draft) back to its file under [dir]. */
+    fun resolve(
+        context: Context,
+        fileName: String,
+    ): File = File(dir(context), fileName)
+
     /** A fresh, empty target file under `cacheDir/recordings/` (directory created if absent). */
-    fun newTempFile(context: Context): File {
-        val dir = File(context.cacheDir, DIR).apply { mkdirs() }
-        return File(dir, "$PREFIX${System.currentTimeMillis()}$EXTENSION")
-    }
+    fun newTempFile(context: Context): File = File(dir(context), "$PREFIX${System.currentTimeMillis()}$EXTENSION")
 
     /** Content URI for [file] under the shared FileProvider authority. */
     fun contentUriFor(
@@ -37,11 +43,14 @@ object RecorderTempFiles {
     ): Uri = FileProvider.getUriForFile(context, authority, file)
 
     /**
-     * Deletes every leftover capture. Called on recorder entry to clear clips a prior session handed
-     * off (the save pipeline has already copied those) or abandoned. Only one recording exists at a
-     * time, so a blanket purge is safe.
+     * Deletes leftover captures on recorder entry — clips a prior session handed off (already copied by
+     * the save pipeline) or abandoned. [keep] (the restored draft's file, ADR 0019 § Draft recovery) is
+     * spared; pass `null` for a fresh entry that should retain nothing.
      */
-    fun purge(context: Context) {
-        File(context.cacheDir, DIR).listFiles()?.forEach { it.delete() }
+    fun purge(
+        context: Context,
+        keep: File? = null,
+    ) {
+        dir(context).listFiles()?.forEach { if (it != keep) it.delete() }
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderViewModel.kt
@@ -14,6 +14,9 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsEvent
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTracker
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -71,6 +74,7 @@ class RecorderViewModel(
     private val engine: RecorderEngine,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val draftStore: RecorderDraftStore = RecorderDraftStoreProvider.get(application),
+    private val analytics: AnalyticsTracker = AnalyticsTrackerProvider.get(application),
     // Resolves the captured file to a shareable content URI. Default uses FileProvider; injected in
     // tests to avoid FileProvider's disk/manifest dependency under Robolectric. Always invoked off-main.
     private val uriProvider: (File) -> Uri = { RecorderTempFiles.contentUriFor(application, it) },
@@ -229,6 +233,7 @@ class RecorderViewModel(
                 // resume this clip instead of losing it (ADR 0019 § Draft recovery).
                 draftStore.save(file, elapsed)
                 mutableState.value = RecorderState.Review(uri = uri, durationMs = elapsed)
+                analytics.log(AnalyticsEvent.RecordingCompleted)
             }
         } finally {
             transitioning = false

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderViewModel.kt
@@ -6,6 +6,7 @@
 package com.github.barriosnahuel.vossosunboton.feature.recorder
 
 import android.app.Application
+import android.net.Uri
 import androidx.annotation.StringRes
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -38,10 +39,11 @@ sealed interface RecorderState {
         val amplitude: Float,
     ) : RecorderState
 
-    /** A captured clip awaiting review. Holds the raw [file]; the host turns it into a content URI
-     *  (FileProvider) for preview + handoff, keeping this ViewModel free of Android URI plumbing. */
+    /** A captured clip awaiting review. The content [uri] is resolved off the main thread when the
+     *  clip is produced (FileProvider's first `getUriForFile` reads the paths XML from disk), so the
+     *  host never touches FileProvider on the UI thread — see ADR 0019 / the stop-crash fix. */
     data class Review(
-        val file: File,
+        val uri: Uri,
         val durationMs: Long,
     ) : RecorderState
 }
@@ -53,9 +55,9 @@ sealed interface RecorderEvent {
         @StringRes val messageRes: Int,
     ) : RecorderEvent
 
-    /** The user kept the clip: hand [file] to the save flow and finish. */
+    /** The user kept the clip: hand its content [uri] to the save flow and finish. */
     data class Handoff(
-        val file: File,
+        val uri: Uri,
     ) : RecorderEvent
 }
 
@@ -68,6 +70,9 @@ class RecorderViewModel(
     application: Application,
     private val engine: RecorderEngine,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    // Resolves the captured file to a shareable content URI. Default uses FileProvider; injected in
+    // tests to avoid FileProvider's disk/manifest dependency under Robolectric. Always invoked off-main.
+    private val uriProvider: (File) -> Uri = { RecorderTempFiles.contentUriFor(application, it) },
 ) : AndroidViewModel(application) {
     private val mutableState = MutableStateFlow<RecorderState>(RecorderState.Ready)
     val state: StateFlow<RecorderState> = mutableState.asStateFlow()
@@ -130,7 +135,7 @@ class RecorderViewModel(
     fun onUseClip() {
         val review = mutableState.value as? RecorderState.Review ?: return
         handedOff = true
-        emit(RecorderEvent.Handoff(review.file))
+        emit(RecorderEvent.Handoff(review.uri))
     }
 
     /** Back while a clip exists (recording or review): drop it and return to ready. */
@@ -169,7 +174,8 @@ class RecorderViewModel(
             if (!preserve) emit(RecorderEvent.Message(R.string.app_recorder_feedback_too_short))
             return
         }
-        mutableState.value = RecorderState.Review(file = file, durationMs = elapsed)
+        val uri = withContext(ioDispatcher) { uriProvider(file) }
+        mutableState.value = RecorderState.Review(uri = uri, durationMs = elapsed)
     }
 
     private fun startPolling() {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderViewModel.kt
@@ -86,7 +86,8 @@ class RecorderViewModel(
 
     init {
         // Clear clips a prior session handed off (already copied by the save pipeline) or abandoned.
-        RecorderTempFiles.purge(application)
+        // Off the main thread — listing/deleting cache files is disk I/O (StrictMode).
+        viewModelScope.launch(ioDispatcher) { RecorderTempFiles.purge(application) }
         engine.onMaxDurationReached = { viewModelScope.launch { finishRecording(preserve = true) } }
         engine.onInterrupted = { viewModelScope.launch { finishRecording(preserve = true) } }
     }
@@ -100,7 +101,8 @@ class RecorderViewModel(
             return
         }
         viewModelScope.launch {
-            val file = RecorderTempFiles.newTempFile(context)
+            // newTempFile does mkdirs() (disk write) and engine.start touches the file — both off-main.
+            val file = withContext(ioDispatcher) { RecorderTempFiles.newTempFile(context) }
             val started =
                 runCatching { withContext(ioDispatcher) { engine.start(file) } }
                     .onFailure {
@@ -108,7 +110,7 @@ class RecorderViewModel(
                         Tracker.track(RuntimeException("Recorder could not start capturing audio", it))
                     }.isSuccess
             if (!started) {
-                file.delete()
+                withContext(ioDispatcher) { file.delete() }
                 emit(RecorderEvent.Message(R.string.app_recorder_feedback_mic_busy))
                 return@launch
             }
@@ -192,8 +194,12 @@ class RecorderViewModel(
     }
 
     private fun discardTemp() {
-        tempFile?.delete()
+        val file = tempFile ?: return
         tempFile = null
+        // File.delete is disk I/O — keep it off the main thread (StrictMode forbids disk on main, and
+        // the debug build crashes on it). Called from onCleared the scope is already cancelled, so this
+        // no-ops and the leftover temp is reclaimed by the purge-on-entry the next time the recorder opens.
+        viewModelScope.launch(ioDispatcher) { file.delete() }
     }
 
     private fun emit(event: RecorderEvent) {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderViewModel.kt
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.recorder
+
+import android.app.Application
+import androidx.annotation.StringRes
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/** Immersive recorder UI state (ADR 0019). Permission priming/denial is owned by the Composable. */
+sealed interface RecorderState {
+    data object Ready : RecorderState
+
+    data class Recording(
+        val elapsedMs: Long,
+        val amplitude: Float,
+    ) : RecorderState
+
+    /** A captured clip awaiting review. Holds the raw [file]; the host turns it into a content URI
+     *  (FileProvider) for preview + handoff, keeping this ViewModel free of Android URI plumbing. */
+    data class Review(
+        val file: File,
+        val durationMs: Long,
+    ) : RecorderState
+}
+
+/** One-shot effects (ADR 0003: `Channel` + `receiveAsFlow`, never `SharedFlow`). */
+sealed interface RecorderEvent {
+    /** Transient feedback (too short, no space, mic busy). */
+    data class Message(
+        @StringRes val messageRes: Int,
+    ) : RecorderEvent
+
+    /** The user kept the clip: hand [file] to the save flow and finish. */
+    data class Handoff(
+        val file: File,
+    ) : RecorderEvent
+}
+
+/**
+ * Drives the tap-to-toggle recorder: `Ready → Recording → Review` (no manual pause — ADR 0019). Owns
+ * the capture temp file, the elapsed/amplitude poll, and the min/max/disk guards; delegates the mic to
+ * [RecorderEngine] (off the main thread via [ioDispatcher]). Releases the engine in [onCleared].
+ */
+class RecorderViewModel(
+    application: Application,
+    private val engine: RecorderEngine,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : AndroidViewModel(application) {
+    private val mutableState = MutableStateFlow<RecorderState>(RecorderState.Ready)
+    val state: StateFlow<RecorderState> = mutableState.asStateFlow()
+
+    private val eventChannel = Channel<RecorderEvent>(Channel.BUFFERED)
+    val events: Flow<RecorderEvent> = eventChannel.receiveAsFlow()
+
+    private var tempFile: File? = null
+    private var pollJob: Job? = null
+    private var handedOff = false
+
+    init {
+        // Clear clips a prior session handed off (already copied by the save pipeline) or abandoned.
+        RecorderTempFiles.purge(application)
+        engine.onMaxDurationReached = { viewModelScope.launch { finishRecording(preserve = true) } }
+        engine.onInterrupted = { viewModelScope.launch { finishRecording(preserve = true) } }
+    }
+
+    /** Hero button in `Ready`: begin capturing (after the disk + mic guards). */
+    fun onRecordTapped() {
+        if (mutableState.value != RecorderState.Ready) return
+        val context = getApplication<Application>()
+        if (context.cacheDir.usableSpace < MIN_FREE_BYTES) {
+            emit(RecorderEvent.Message(R.string.app_recorder_feedback_no_space))
+            return
+        }
+        viewModelScope.launch {
+            val file = RecorderTempFiles.newTempFile(context)
+            val started =
+                runCatching { withContext(ioDispatcher) { engine.start(file) } }
+                    .onFailure {
+                        Tracker.log("recorder.start_failed=${it.javaClass.simpleName}")
+                        Tracker.track(RuntimeException("Recorder could not start capturing audio", it))
+                    }.isSuccess
+            if (!started) {
+                file.delete()
+                emit(RecorderEvent.Message(R.string.app_recorder_feedback_mic_busy))
+                return@launch
+            }
+            tempFile = file
+            mutableState.value = RecorderState.Recording(elapsedMs = 0L, amplitude = 0f)
+            startPolling()
+        }
+    }
+
+    /** Hero button in `Recording`: stop and (if long enough) move to review. */
+    fun onStopTapped() {
+        if (mutableState.value !is RecorderState.Recording) return
+        viewModelScope.launch { finishRecording(preserve = false) }
+    }
+
+    /** Review → "Re-record": discard the clip and return to ready. */
+    fun onReRecord() {
+        if (mutableState.value !is RecorderState.Review) return
+        discardTemp()
+        mutableState.value = RecorderState.Ready
+    }
+
+    /** Review → "Use this": hand the clip to the save flow. */
+    fun onUseClip() {
+        val review = mutableState.value as? RecorderState.Review ?: return
+        handedOff = true
+        emit(RecorderEvent.Handoff(review.file))
+    }
+
+    /** Back while a clip exists (recording or review): drop it and return to ready. */
+    fun onDiscard() {
+        if (mutableState.value is RecorderState.Recording) {
+            pollJob?.cancel()
+            viewModelScope.launch { withContext(ioDispatcher) { engine.stop() } }
+        }
+        discardTemp()
+        mutableState.value = RecorderState.Ready
+    }
+
+    /** True when there is unsaved captured audio — the Activity gates its back discard-confirm on this. */
+    fun hasUnsavedClip(): Boolean = mutableState.value !is RecorderState.Ready
+
+    /**
+     * The host went to the background. Recording is foreground-only (ADR 0019 § Out of scope): auto-stop
+     * and preserve so the mic is freed, mirroring an audio-focus loss. A no-op outside `Recording`.
+     */
+    fun onHostStopped() {
+        if (mutableState.value is RecorderState.Recording) {
+            viewModelScope.launch { finishRecording(preserve = true) }
+        }
+    }
+
+    private suspend fun finishRecording(preserve: Boolean) {
+        val recording = mutableState.value as? RecorderState.Recording ?: return
+        pollJob?.cancel()
+        val elapsed = recording.elapsedMs
+        val produced = withContext(ioDispatcher) { engine.stop() }
+        val file = tempFile
+        if (!produced || file == null || elapsed < MIN_DURATION_MS) {
+            discardTemp()
+            mutableState.value = RecorderState.Ready
+            // A deliberate too-short tap is worth a nudge; an interruption-preserve under 1 s isn't.
+            if (!preserve) emit(RecorderEvent.Message(R.string.app_recorder_feedback_too_short))
+            return
+        }
+        mutableState.value = RecorderState.Review(file = file, durationMs = elapsed)
+    }
+
+    private fun startPolling() {
+        pollJob =
+            viewModelScope.launch {
+                var elapsed = 0L
+                while (isActive) {
+                    delay(POLL_INTERVAL_MS)
+                    elapsed += POLL_INTERVAL_MS
+                    mutableState.value =
+                        RecorderState.Recording(elapsedMs = elapsed, amplitude = engine.maxAmplitude())
+                }
+            }
+    }
+
+    private fun discardTemp() {
+        tempFile?.delete()
+        tempFile = null
+    }
+
+    private fun emit(event: RecorderEvent) {
+        eventChannel.trySend(event)
+    }
+
+    override fun onCleared() {
+        pollJob?.cancel()
+        engine.release()
+        if (!handedOff) discardTemp()
+    }
+
+    @androidx.annotation.VisibleForTesting
+    internal fun clearForTest() = onCleared()
+
+    companion object {
+        /** A clip shorter than this is discarded (a Bomp is a sticker, not a misfire). */
+        const val MIN_DURATION_MS = 1_000L
+        private const val POLL_INTERVAL_MS = 80L
+
+        /** Refuse to start with less than this free in cache — a 60 s clip is ≈0.5 MB; 5 MB is ample. */
+        private const val MIN_FREE_BYTES = 5L * 1024 * 1024
+
+        val Factory: ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer {
+                    val app = this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY] as Application
+                    RecorderViewModel(app, RecorderEngineProvider.get(app))
+                }
+            }
+    }
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderViewModel.kt
@@ -89,6 +89,27 @@ class RecorderViewModel(
     private var pollJob: Job? = null
     private var entered = false
 
+    // Amplitude samples captured live during recording (one per poll tick) and the envelope built from
+    // them on stop — so the review wave renders instantly instead of re-decoding the file (ADR 0019). A
+    // restored draft has no live samples, leaving [capturedEnvelope] null so the host decodes instead.
+    private val amplitudes = mutableListOf<Float>()
+
+    /**
+     * The review envelope: live-built on stop, or backfilled (via [cacheDecodedEnvelope]) by the host's
+     * decode for a restored draft. Null until known — the host then decodes the file.
+     */
+    var capturedEnvelope: FloatArray? = null
+        private set
+
+    /**
+     * Backfills the envelope a restored draft decoded from the file, so a later config recreate reuses
+     * it instead of re-decoding (and re-flashing the placeholder). No-op on null / for a fresh recording
+     * (which already built one live); reset by [onRecordTapped] / [onReRecord].
+     */
+    fun cacheDecodedEnvelope(envelope: FloatArray?) {
+        if (envelope != null) capturedEnvelope = envelope
+    }
+
     // Guards the start ↔ stop transition across its suspension points so a rapid double-tap (or a stop
     // racing onHostStopped) can't run the transition twice — leaking a second MediaRecorder or deleting
     // a valid clip down the discard branch.
@@ -152,6 +173,8 @@ class RecorderViewModel(
                     return@launch
                 }
                 tempFile = file
+                amplitudes.clear()
+                capturedEnvelope = null
                 mutableState.value = RecorderState.Recording(elapsedMs = 0L, amplitude = 0f)
                 startPolling()
             } finally {
@@ -171,6 +194,8 @@ class RecorderViewModel(
         if (mutableState.value !is RecorderState.Review) return
         discardTemp()
         draftStore.clear()
+        amplitudes.clear()
+        capturedEnvelope = null
         mutableState.value = RecorderState.Ready
     }
 
@@ -224,11 +249,16 @@ class RecorderViewModel(
             if (!produced || file == null || elapsed < MIN_DURATION_MS) {
                 discardTemp()
                 draftStore.clear()
+                amplitudes.clear()
                 mutableState.value = RecorderState.Ready
                 // A deliberate too-short tap is worth a nudge; an interruption-preserve under 1 s isn't.
                 if (!preserve) emit(RecorderEvent.Message(R.string.app_recorder_feedback_too_short))
             } else {
                 val uri = withContext(ioDispatcher) { uriProvider(file) }
+                // Build the review envelope from the live samples BEFORE emitting Review, so the host
+                // reads it on the resulting recompose and skips the decode (instant, no placeholder gap).
+                capturedEnvelope = buildRecorderEnvelope(amplitudes, RECORDER_WAVEFORM_BARS)
+                amplitudes.clear() // the 48-bar envelope is all we keep through the Review session.
                 // Persist as a recoverable draft so a background / launcher re-entry / process death can
                 // resume this clip instead of losing it (ADR 0019 § Draft recovery).
                 draftStore.save(file, elapsed)
@@ -247,8 +277,11 @@ class RecorderViewModel(
                 while (isActive) {
                     delay(POLL_INTERVAL_MS)
                     elapsed += POLL_INTERVAL_MS
-                    mutableState.value =
-                        RecorderState.Recording(elapsedMs = elapsed, amplitude = engine.maxAmplitude())
+                    // One read per tick (maxAmplitude resets the peak) — reuse it for the live meter AND
+                    // the accumulating envelope so review can render it instantly on stop.
+                    val amplitude = engine.maxAmplitude()
+                    amplitudes.add(amplitude)
+                    mutableState.value = RecorderState.Recording(elapsedMs = elapsed, amplitude = amplitude)
                 }
             }
     }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderViewModel.kt
@@ -70,6 +70,7 @@ class RecorderViewModel(
     application: Application,
     private val engine: RecorderEngine,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val draftStore: RecorderDraftStore = RecorderDraftStoreProvider.get(application),
     // Resolves the captured file to a shareable content URI. Default uses FileProvider; injected in
     // tests to avoid FileProvider's disk/manifest dependency under Robolectric. Always invoked off-main.
     private val uriProvider: (File) -> Uri = { RecorderTempFiles.contentUriFor(application, it) },
@@ -82,41 +83,76 @@ class RecorderViewModel(
 
     private var tempFile: File? = null
     private var pollJob: Job? = null
-    private var handedOff = false
+    private var entered = false
+
+    // Guards the start ↔ stop transition across its suspension points so a rapid double-tap (or a stop
+    // racing onHostStopped) can't run the transition twice — leaking a second MediaRecorder or deleting
+    // a valid clip down the discard branch.
+    private var transitioning = false
 
     init {
-        // Clear clips a prior session handed off (already copied by the save pipeline) or abandoned.
-        // Off the main thread — listing/deleting cache files is disk I/O (StrictMode).
-        viewModelScope.launch(ioDispatcher) { RecorderTempFiles.purge(application) }
         engine.onMaxDurationReached = { viewModelScope.launch { finishRecording(preserve = true) } }
         engine.onInterrupted = { viewModelScope.launch { finishRecording(preserve = true) } }
     }
 
+    /**
+     * Called once by the host on first creation (ADR 0019 § Draft recovery). [resumeDraft] true — the
+     * Landing draft banner launched us — restores a persisted clip into `Review`, sparing its file from
+     * the purge; false starts fresh and purges every leftover capture. Guarded so a config-change
+     * recreate (which keeps this VM) does not re-run it.
+     */
+    fun onEnter(resumeDraft: Boolean) {
+        if (entered) return
+        entered = true
+        viewModelScope.launch {
+            val draft = draftStore.current()
+            // [resumeDraft] only decides whether to *restore into Review*; the draft's file is ALWAYS
+            // spared from the purge. A fresh entry (resumeDraft=false) with a pending draft must not
+            // delete the clip out from under the Landing banner — restore and preserve are independent.
+            if (resumeDraft && draft != null) {
+                val uri = withContext(ioDispatcher) { uriProvider(draft.file) }
+                tempFile = draft.file
+                mutableState.value = RecorderState.Review(uri = uri, durationMs = draft.durationMs)
+            }
+            // Off the main thread — listing/deleting cache files is disk I/O (StrictMode).
+            withContext(ioDispatcher) { RecorderTempFiles.purge(getApplication(), keep = draft?.file) }
+        }
+    }
+
     /** Hero button in `Ready`: begin capturing (after the disk + mic guards). */
     fun onRecordTapped() {
-        if (mutableState.value != RecorderState.Ready) return
+        if (mutableState.value != RecorderState.Ready || transitioning) return
+        transitioning = true
         val context = getApplication<Application>()
-        if (context.cacheDir.usableSpace < MIN_FREE_BYTES) {
-            emit(RecorderEvent.Message(R.string.app_recorder_feedback_no_space))
-            return
-        }
         viewModelScope.launch {
-            // newTempFile does mkdirs() (disk write) and engine.start touches the file — both off-main.
-            val file = withContext(ioDispatcher) { RecorderTempFiles.newTempFile(context) }
-            val started =
-                runCatching { withContext(ioDispatcher) { engine.start(file) } }
-                    .onFailure {
-                        Tracker.log("recorder.start_failed=${it.javaClass.simpleName}")
-                        Tracker.track(RuntimeException("Recorder could not start capturing audio", it))
-                    }.isSuccess
-            if (!started) {
-                withContext(ioDispatcher) { file.delete() }
-                emit(RecorderEvent.Message(R.string.app_recorder_feedback_mic_busy))
-                return@launch
+            try {
+                // usableSpace is a blocking statvfs syscall and newTempFile does mkdirs() — both disk I/O,
+                // kept off the main thread (StrictMode crashes the debug build on a main-thread read).
+                val file =
+                    withContext(ioDispatcher) {
+                        if (context.cacheDir.usableSpace < MIN_FREE_BYTES) null else RecorderTempFiles.newTempFile(context)
+                    }
+                if (file == null) {
+                    emit(RecorderEvent.Message(R.string.app_recorder_feedback_no_space))
+                    return@launch
+                }
+                val started =
+                    runCatching { withContext(ioDispatcher) { engine.start(file) } }
+                        .onFailure {
+                            Tracker.log("recorder.start_failed=${it.javaClass.simpleName}")
+                            Tracker.track(RuntimeException("Recorder could not start capturing audio", it))
+                        }.isSuccess
+                if (!started) {
+                    withContext(ioDispatcher) { file.delete() }
+                    emit(RecorderEvent.Message(R.string.app_recorder_feedback_mic_busy))
+                    return@launch
+                }
+                tempFile = file
+                mutableState.value = RecorderState.Recording(elapsedMs = 0L, amplitude = 0f)
+                startPolling()
+            } finally {
+                transitioning = false
             }
-            tempFile = file
-            mutableState.value = RecorderState.Recording(elapsedMs = 0L, amplitude = 0f)
-            startPolling()
         }
     }
 
@@ -130,24 +166,33 @@ class RecorderViewModel(
     fun onReRecord() {
         if (mutableState.value !is RecorderState.Review) return
         discardTemp()
+        draftStore.clear()
         mutableState.value = RecorderState.Ready
     }
 
     /** Review → "Use this": hand the clip to the save flow. */
     fun onUseClip() {
         val review = mutableState.value as? RecorderState.Review ?: return
-        handedOff = true
+        // Deliberately NOT clearing the draft here — the save pipeline clears it once the Sound is
+        // actually persisted (RecorderDraftSaveCleanup). Backing out of the save screen therefore leaves
+        // the clip recoverable from the Landing banner instead of silently lost.
         emit(RecorderEvent.Handoff(review.uri))
     }
 
     /** Back while a clip exists (recording or review): drop it and return to ready. */
     fun onDiscard() {
-        if (mutableState.value is RecorderState.Recording) {
-            pollJob?.cancel()
-            viewModelScope.launch { withContext(ioDispatcher) { engine.stop() } }
-        }
-        discardTemp()
+        val wasRecording = mutableState.value is RecorderState.Recording
+        pollJob?.cancel()
+        val file = tempFile
+        tempFile = null
+        draftStore.clear()
         mutableState.value = RecorderState.Ready
+        // Stop (if recording) THEN delete, in one ordered coroutine, so engine.stop() finalizing the
+        // output file can't race the delete and leave an orphan (or throw on a vanished path).
+        viewModelScope.launch(ioDispatcher) {
+            if (wasRecording) runCatching { engine.stop() }
+            file?.delete()
+        }
     }
 
     /** True when there is unsaved captured audio — the Activity gates its back discard-confirm on this. */
@@ -164,20 +209,30 @@ class RecorderViewModel(
     }
 
     private suspend fun finishRecording(preserve: Boolean) {
+        if (transitioning) return
         val recording = mutableState.value as? RecorderState.Recording ?: return
-        pollJob?.cancel()
-        val elapsed = recording.elapsedMs
-        val produced = withContext(ioDispatcher) { engine.stop() }
-        val file = tempFile
-        if (!produced || file == null || elapsed < MIN_DURATION_MS) {
-            discardTemp()
-            mutableState.value = RecorderState.Ready
-            // A deliberate too-short tap is worth a nudge; an interruption-preserve under 1 s isn't.
-            if (!preserve) emit(RecorderEvent.Message(R.string.app_recorder_feedback_too_short))
-            return
+        transitioning = true
+        try {
+            pollJob?.cancel()
+            val elapsed = recording.elapsedMs
+            val produced = withContext(ioDispatcher) { engine.stop() }
+            val file = tempFile
+            if (!produced || file == null || elapsed < MIN_DURATION_MS) {
+                discardTemp()
+                draftStore.clear()
+                mutableState.value = RecorderState.Ready
+                // A deliberate too-short tap is worth a nudge; an interruption-preserve under 1 s isn't.
+                if (!preserve) emit(RecorderEvent.Message(R.string.app_recorder_feedback_too_short))
+            } else {
+                val uri = withContext(ioDispatcher) { uriProvider(file) }
+                // Persist as a recoverable draft so a background / launcher re-entry / process death can
+                // resume this clip instead of losing it (ADR 0019 § Draft recovery).
+                draftStore.save(file, elapsed)
+                mutableState.value = RecorderState.Review(uri = uri, durationMs = elapsed)
+            }
+        } finally {
+            transitioning = false
         }
-        val uri = withContext(ioDispatcher) { uriProvider(file) }
-        mutableState.value = RecorderState.Review(uri = uri, durationMs = elapsed)
     }
 
     private fun startPolling() {
@@ -209,7 +264,10 @@ class RecorderViewModel(
     override fun onCleared() {
         pollJob?.cancel()
         engine.release()
-        if (!handedOff) discardTemp()
+        // Deliberately NOT discarding the temp file: a clip in Review is a persisted draft that must
+        // survive this Activity being destroyed (launcher clearTop, process death) so Landing can offer
+        // to resume it (ADR 0019 § Draft recovery). Explicit discard/re-record already deleted it;
+        // orphans (no draft metadata) are reclaimed by the purge-on-entry next time.
     }
 
     @androidx.annotation.VisibleForTesting

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsEvent
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
 import com.github.barriosnahuel.vossosunboton.feature.addbutton.AddButtonActivity
@@ -86,6 +87,7 @@ class RecordingActivity : FragmentActivity() {
         val permissionLauncher =
             rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { ok ->
                 granted = ok
+                AnalyticsTrackerProvider.get(this).log(AnalyticsEvent.RecordPermissionResult(granted = ok))
                 if (!ok) permanentlyDenied = !shouldShowRequestPermissionRationale(Manifest.permission.RECORD_AUDIO)
             }
         val importLauncher =

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
@@ -88,8 +88,7 @@ class RecordingActivity : FragmentActivity() {
 
         val state by viewModel.state.collectAsStateWithLifecycle()
         val playback by PlayerControllerFactory.instance.playbackState.collectAsStateWithLifecycle()
-        val reviewFile = (state as? RecorderState.Review)?.file
-        val reviewUri = remember(reviewFile) { reviewFile?.let { RecorderTempFiles.contentUriFor(this, it) } }
+        val reviewUri = (state as? RecorderState.Review)?.uri
         val isPreviewPlaying = playback?.let { it.isPlaying && it.uri == reviewUri } == true
 
         LaunchedEffect(Unit) {
@@ -97,8 +96,7 @@ class RecordingActivity : FragmentActivity() {
                 when (event) {
                     is RecorderEvent.Message -> snackbarHostState.showSnackbar(getString(event.messageRes))
                     is RecorderEvent.Handoff -> {
-                        val uri = RecorderTempFiles.contentUriFor(this@RecordingActivity, event.file)
-                        startActivity(AddButtonActivity.createIntent(this@RecordingActivity, uri, AddButtonActivity.SOURCE_RECORD))
+                        startActivity(AddButtonActivity.createIntent(this@RecordingActivity, event.uri, AddButtonActivity.SOURCE_RECORD))
                         finish()
                     }
                 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
@@ -41,6 +41,7 @@ import com.github.barriosnahuel.vossosunboton.commons.android.analytics.Analytic
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
 import com.github.barriosnahuel.vossosunboton.feature.addbutton.AddButtonActivity
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
+import com.github.barriosnahuel.vossosunboton.feature.vault.WaveformExtractor
 import com.github.barriosnahuel.vossosunboton.ui.theme.ImmersiveListenTheme
 
 /**
@@ -96,6 +97,16 @@ class RecordingActivity : FragmentActivity() {
         val isPreviewPlaying = preview?.isPlaying == true
         val previewPositionMs = preview?.positionMs?.toLong() ?: 0L
 
+        // Real amplitude envelope of the recorded clip — decoded off the main thread (a neutral
+        // placeholder shows until it arrives), reusing the listen screen's extractor. Re-keyed per
+        // clip so a re-record (new URI) re-decodes and discards the previous wave.
+        var peaks by remember(reviewUri) { mutableStateOf(reviewUri?.let { WaveformExtractor.cached(it.toString()) }) }
+        LaunchedEffect(reviewUri) {
+            if (reviewUri != null && peaks == null) {
+                peaks = WaveformExtractor.extract(this@RecordingActivity, reviewUri, RECORDER_WAVEFORM_BARS)
+            }
+        }
+
         LaunchedEffect(Unit) {
             viewModel.events.collect { event ->
                 when (event) {
@@ -118,6 +129,7 @@ class RecordingActivity : FragmentActivity() {
                             state = state,
                             isPreviewPlaying = isPreviewPlaying,
                             previewPositionMs = previewPositionMs,
+                            peaks = peaks,
                             onRecordTap = viewModel::onRecordTapped,
                             onStopTap = viewModel::onStopTapped,
                             onPreviewToggle = { togglePreview(reviewUri) },

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
@@ -60,7 +60,10 @@ class RecordingActivity : FragmentActivity() {
 
     override fun onStop() {
         super.onStop()
-        // Recording is foreground-only: free the mic if backgrounded mid-capture, and stop any preview.
+        // A config-change recreate (rotation is handled in-place via configChanges; locale/theme still
+        // recreate) also routes through onStop — don't treat it as backgrounding, or the recording would
+        // be auto-stopped on every such change. Only a genuine background frees the mic + stops preview.
+        if (isChangingConfigurations) return
         viewModel.onHostStopped()
         PlayerControllerFactory.instance.stopPlayingSound()
     }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
@@ -92,7 +92,9 @@ class RecordingActivity : FragmentActivity() {
         val state by viewModel.state.collectAsStateWithLifecycle()
         val playback by PlayerControllerFactory.instance.playbackState.collectAsStateWithLifecycle()
         val reviewUri = (state as? RecorderState.Review)?.uri
-        val isPreviewPlaying = playback?.let { it.isPlaying && it.uri == reviewUri } == true
+        val preview = playback?.takeIf { it.uri == reviewUri }
+        val isPreviewPlaying = preview?.isPlaying == true
+        val previewPositionMs = preview?.positionMs?.toLong() ?: 0L
 
         LaunchedEffect(Unit) {
             viewModel.events.collect { event ->
@@ -115,6 +117,7 @@ class RecordingActivity : FragmentActivity() {
                         RecorderScreen(
                             state = state,
                             isPreviewPlaying = isPreviewPlaying,
+                            previewPositionMs = previewPositionMs,
                             onRecordTap = viewModel::onRecordTapped,
                             onStopTap = viewModel::onStopTapped,
                             onPreviewToggle = { togglePreview(reviewUri) },

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
@@ -105,13 +105,16 @@ class RecordingActivity : FragmentActivity() {
         val isPreviewPlaying = preview?.isPlaying == true
         val previewPositionMs = preview?.positionMs?.toLong() ?: 0L
 
-        // Real amplitude envelope of the recorded clip — decoded off the main thread (a neutral
-        // placeholder shows until it arrives), reusing the listen screen's extractor. Re-keyed per
-        // clip so a re-record (new URI) re-decodes and discards the previous wave.
-        var peaks by remember(reviewUri) { mutableStateOf<FloatArray?>(null) }
+        // Real amplitude envelope of the recorded clip. A fresh recording carries the live-captured
+        // envelope (instant — no placeholder gap); only a restored draft (no live samples) falls back to
+        // decoding the file off the main thread. Re-keyed per clip so a re-record swaps the wave.
+        var peaks by remember(reviewUri) { mutableStateOf(viewModel.capturedEnvelope) }
         LaunchedEffect(reviewUri) {
-            if (reviewUri != null) {
-                peaks = WaveformExtractor.extract(this@RecordingActivity, reviewUri, RECORDER_WAVEFORM_BARS)
+            if (reviewUri != null && peaks == null) {
+                val decoded = WaveformExtractor.extract(this@RecordingActivity, reviewUri, RECORDER_WAVEFORM_BARS)
+                peaks = decoded
+                // Cache it on the VM so a config recreate reuses it instead of re-decoding (restored drafts).
+                viewModel.cacheDecodedEnvelope(decoded)
             }
         }
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -56,6 +57,9 @@ class RecordingActivity : FragmentActivity() {
         enableEdgeToEdge(statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT))
         super.onCreate(savedInstanceState)
         AnalyticsTrackerProvider.get(this).logScreen(CanonicalScreenName.RECORD_SOUND)
+        // Restore a pending draft when launched from the Landing banner; otherwise start fresh. Guarded
+        // inside the VM so a config-change recreate (which keeps the VM) doesn't re-run it.
+        viewModel.onEnter(resumeDraft = intent.getBooleanExtra(EXTRA_RESUME_DRAFT, false))
         setContent { RecorderHost() }
     }
 
@@ -74,8 +78,10 @@ class RecordingActivity : FragmentActivity() {
         val context = LocalContext.current
         val snackbarHostState = remember { SnackbarHostState() }
         var granted by remember { mutableStateOf(hasMicPermission()) }
-        var permanentlyDenied by remember { mutableStateOf(false) }
-        var showDiscard by remember { mutableStateOf(false) }
+        // Saveable: durable progress (the denied/settings screen, an open discard dialog) must survive an
+        // Activity recreate — locale/theme switch, system kill (CLAUDE.md § Stateful Composables).
+        var permanentlyDenied by rememberSaveable { mutableStateOf(false) }
+        var showDiscard by rememberSaveable { mutableStateOf(false) }
 
         val permissionLauncher =
             rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { ok ->
@@ -100,9 +106,9 @@ class RecordingActivity : FragmentActivity() {
         // Real amplitude envelope of the recorded clip — decoded off the main thread (a neutral
         // placeholder shows until it arrives), reusing the listen screen's extractor. Re-keyed per
         // clip so a re-record (new URI) re-decodes and discards the previous wave.
-        var peaks by remember(reviewUri) { mutableStateOf(reviewUri?.let { WaveformExtractor.cached(it.toString()) }) }
+        var peaks by remember(reviewUri) { mutableStateOf<FloatArray?>(null) }
         LaunchedEffect(reviewUri) {
-            if (reviewUri != null && peaks == null) {
+            if (reviewUri != null) {
                 peaks = WaveformExtractor.extract(this@RecordingActivity, reviewUri, RECORDER_WAVEFORM_BARS)
             }
         }
@@ -160,6 +166,9 @@ class RecordingActivity : FragmentActivity() {
                     RecorderDiscardDialog(
                         onConfirm = {
                             showDiscard = false
+                            // Durably drop the clip + its persisted draft before finishing — onCleared no
+                            // longer cleans up (a Review clip is now a recoverable draft).
+                            viewModel.onDiscard()
                             PlayerControllerFactory.instance.stopPlayingSound()
                             finish()
                         },
@@ -192,7 +201,14 @@ class RecordingActivity : FragmentActivity() {
 
     companion object {
         private const val AUDIO_MIME = "audio/*"
+        private const val EXTRA_RESUME_DRAFT = "extra_resume_draft"
 
-        fun createIntent(context: Context): Intent = Intent(context, RecordingActivity::class.java)
+        /** [resumeDraft] true (from the Landing draft banner) restores the pending recording into Review. */
+        fun createIntent(
+            context: Context,
+            resumeDraft: Boolean = false,
+        ): Intent =
+            Intent(context, RecordingActivity::class.java)
+                .putExtra(EXTRA_RESUME_DRAFT, resumeDraft)
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.recorder
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.graphics.Color
+import android.net.Uri
+import android.os.Bundle
+import android.provider.Settings
+import androidx.activity.SystemBarStyle
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
+import com.github.barriosnahuel.vossosunboton.feature.addbutton.AddButtonActivity
+import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
+import com.github.barriosnahuel.vossosunboton.ui.theme.ImmersiveListenTheme
+
+/**
+ * Full-screen host for the in-app recorder (ADR 0019). Owns the `RECORD_AUDIO` permission flow (priming
+ * → request → denied/settings/import-escape), the [RecorderViewModel], preview playback, and the handoff
+ * to [AddButtonActivity] (Create mode, `SOURCE_RECORD`) once the user keeps a clip. Not exported.
+ */
+class RecordingActivity : FragmentActivity() {
+    private val viewModel: RecorderViewModel by viewModels { RecorderViewModel.Factory }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge(statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT))
+        super.onCreate(savedInstanceState)
+        AnalyticsTrackerProvider.get(this).logScreen(CanonicalScreenName.RECORD_SOUND)
+        setContent { RecorderHost() }
+    }
+
+    override fun onStop() {
+        super.onStop()
+        // Recording is foreground-only: free the mic if backgrounded mid-capture, and stop any preview.
+        viewModel.onHostStopped()
+        PlayerControllerFactory.instance.stopPlayingSound()
+    }
+
+    @Composable
+    private fun RecorderHost() {
+        val context = LocalContext.current
+        val snackbarHostState = remember { SnackbarHostState() }
+        var granted by remember { mutableStateOf(hasMicPermission()) }
+        var permanentlyDenied by remember { mutableStateOf(false) }
+        var showDiscard by remember { mutableStateOf(false) }
+
+        val permissionLauncher =
+            rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { ok ->
+                granted = ok
+                if (!ok) permanentlyDenied = !shouldShowRequestPermissionRationale(Manifest.permission.RECORD_AUDIO)
+            }
+        val importLauncher =
+            rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+                if (uri != null) {
+                    startActivity(AddButtonActivity.createIntent(this, uri))
+                    finish()
+                }
+            }
+
+        val state by viewModel.state.collectAsStateWithLifecycle()
+        val playback by PlayerControllerFactory.instance.playbackState.collectAsStateWithLifecycle()
+        val reviewFile = (state as? RecorderState.Review)?.file
+        val reviewUri = remember(reviewFile) { reviewFile?.let { RecorderTempFiles.contentUriFor(this, it) } }
+        val isPreviewPlaying = playback?.let { it.isPlaying && it.uri == reviewUri } == true
+
+        LaunchedEffect(Unit) {
+            viewModel.events.collect { event ->
+                when (event) {
+                    is RecorderEvent.Message -> snackbarHostState.showSnackbar(getString(event.messageRes))
+                    is RecorderEvent.Handoff -> {
+                        val uri = RecorderTempFiles.contentUriFor(this@RecordingActivity, event.file)
+                        startActivity(AddButtonActivity.createIntent(this@RecordingActivity, uri, AddButtonActivity.SOURCE_RECORD))
+                        finish()
+                    }
+                }
+            }
+        }
+
+        BackHandler { if (viewModel.hasUnsavedClip()) showDiscard = true else finish() }
+
+        ImmersiveListenTheme {
+            Box(modifier = Modifier.fillMaxSize()) {
+                when {
+                    granted ->
+                        RecorderScreen(
+                            state = state,
+                            isPreviewPlaying = isPreviewPlaying,
+                            onRecordTap = viewModel::onRecordTapped,
+                            onStopTap = viewModel::onStopTapped,
+                            onPreviewToggle = { togglePreview(reviewUri) },
+                            onUseClip = viewModel::onUseClip,
+                            onReRecord = {
+                                PlayerControllerFactory.instance.stopPlayingSound()
+                                viewModel.onReRecord()
+                            },
+                            onClose = { if (viewModel.hasUnsavedClip()) showDiscard = true else finish() },
+                        )
+                    permanentlyDenied ->
+                        MicPermissionDenied(
+                            onOpenSettings = { openAppSettings(context) },
+                            onImportInstead = { importLauncher.launch(arrayOf(AUDIO_MIME)) },
+                            onClose = { finish() },
+                        )
+                    else ->
+                        MicPermissionPriming(
+                            onAllow = { permissionLauncher.launch(Manifest.permission.RECORD_AUDIO) },
+                            onNotNow = { finish() },
+                        )
+                }
+                SnackbarHost(
+                    hostState = snackbarHostState,
+                    modifier = Modifier.align(Alignment.BottomCenter).safeDrawingPadding(),
+                )
+                if (showDiscard) {
+                    RecorderDiscardDialog(
+                        onConfirm = {
+                            showDiscard = false
+                            PlayerControllerFactory.instance.stopPlayingSound()
+                            finish()
+                        },
+                        onDismiss = { showDiscard = false },
+                    )
+                }
+            }
+        }
+    }
+
+    private fun togglePreview(reviewUri: Uri?) {
+        val uri = reviewUri ?: return
+        val controller = PlayerControllerFactory.instance
+        val current = controller.playbackState.value
+        when {
+            current?.isPlaying == true -> controller.pause()
+            current != null && current.uri == uri -> controller.resume()
+            else -> controller.startPlayingUri(this, uri)
+        }
+    }
+
+    private fun hasMicPermission(): Boolean =
+        ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED
+
+    private fun openAppSettings(context: Context) {
+        val intent =
+            Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, Uri.fromParts("package", context.packageName, null))
+        runCatching { context.startActivity(intent) }
+    }
+
+    companion object {
+        private const val AUDIO_MIME = "audio/*"
+
+        fun createIntent(context: Context): Intent = Intent(context, RecordingActivity::class.java)
+    }
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/WaveformExtractor.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/WaveformExtractor.kt
@@ -63,25 +63,23 @@ internal object WaveformExtractor {
 
     /**
      * Same envelope, decoded from a `content://`/`file://` [uri] instead of a saved [Sound] — for the
-     * recorder review, where the clip is a temp FileProvider URI not yet persisted as a Sound. Cached
-     * per URI string so a config-change recreate reuses the decode.
+     * recorder review, where the clip is a temp FileProvider URI not yet persisted as a Sound.
+     *
+     * Deliberately NOT cached: every recording is a new timestamped temp file → a unique, short-lived
+     * URI key that would accumulate in [cache] forever. The host decodes once per `reviewUri` and a
+     * config-change recreate just re-decodes the short clip — cheap, and bounded unlike a leaking cache.
      */
     suspend fun extract(
         context: Context,
         uri: Uri,
         barCount: Int,
         dispatcher: CoroutineDispatcher = Dispatchers.IO,
-    ): FloatArray? {
-        val key = uri.toString()
-        cache[key]?.let { return it }
-        val peaks =
-            decode(barCount, dispatcher, "Recorder waveform extraction failed", "recorder") { extractor ->
-                // Content-resolver overload: handles a content:// FileProvider URI directly, where an
-                // AssetFileDescriptor's declaredLength is often UNKNOWN and would break the fd overload.
-                extractor.setDataSource(context, uri, null)
-            }
-        return peaks?.also { cache[key] = it }
-    }
+    ): FloatArray? =
+        decode(barCount, dispatcher, "Recorder waveform extraction failed", "recorder") { extractor ->
+            // Content-resolver overload: handles a content:// FileProvider URI directly, where an
+            // AssetFileDescriptor's declaredLength is often UNKNOWN and would break the fd overload.
+            extractor.setDataSource(context, uri, null)
+        }
 
     /** Visible for the cold-start / no-data fallback path and tests. */
     fun cached(soundId: String): FloatArray? = cache[soundId]

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/WaveformExtractor.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/WaveformExtractor.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.media.MediaCodec
 import android.media.MediaExtractor
 import android.media.MediaFormat
+import android.net.Uri
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.commons.file.getFile
 import com.github.barriosnahuel.vossosunboton.model.Sound
@@ -48,34 +49,66 @@ internal object WaveformExtractor {
     ): FloatArray? {
         cache[sound.id]?.let { return it }
         val peaks =
-            withContext(dispatcher) {
-                runCatching { decodeEnvelope(context, sound, barCount) }
-                    .onFailure { error ->
-                        if (error is CancellationException) throw error
-                        Tracker.log("immersive.waveform_fail=${error.javaClass.simpleName}")
-                        Tracker.track(RuntimeException("Vault waveform extraction failed", error))
-                    }.getOrNull()
+            decode(barCount, dispatcher, "Vault waveform extraction failed", "immersive") { extractor ->
+                if (sound.file != null) {
+                    extractor.setDataSource(getFile(context, sound.file!!).path)
+                } else {
+                    context.resources.openRawResourceFd(sound.rawRes).use { afd ->
+                        extractor.setDataSource(afd.fileDescriptor, afd.startOffset, afd.declaredLength)
+                    }
+                }
             }
         return peaks?.also { cache[sound.id] = it }
+    }
+
+    /**
+     * Same envelope, decoded from a `content://`/`file://` [uri] instead of a saved [Sound] — for the
+     * recorder review, where the clip is a temp FileProvider URI not yet persisted as a Sound. Cached
+     * per URI string so a config-change recreate reuses the decode.
+     */
+    suspend fun extract(
+        context: Context,
+        uri: Uri,
+        barCount: Int,
+        dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    ): FloatArray? {
+        val key = uri.toString()
+        cache[key]?.let { return it }
+        val peaks =
+            decode(barCount, dispatcher, "Recorder waveform extraction failed", "recorder") { extractor ->
+                // Content-resolver overload: handles a content:// FileProvider URI directly, where an
+                // AssetFileDescriptor's declaredLength is often UNKNOWN and would break the fd overload.
+                extractor.setDataSource(context, uri, null)
+            }
+        return peaks?.also { cache[key] = it }
     }
 
     /** Visible for the cold-start / no-data fallback path and tests. */
     fun cached(soundId: String): FloatArray? = cache[soundId]
 
-    private suspend fun decodeEnvelope(
-        context: Context,
-        sound: Sound,
+    private suspend fun decode(
         barCount: Int,
+        dispatcher: CoroutineDispatcher,
+        failureMessage: String,
+        failureModule: String,
+        configureSource: (MediaExtractor) -> Unit,
+    ): FloatArray? =
+        withContext(dispatcher) {
+            runCatching { decodeEnvelope(barCount, configureSource) }
+                .onFailure { error ->
+                    if (error is CancellationException) throw error
+                    Tracker.log("$failureModule.waveform_fail=${error.javaClass.simpleName}")
+                    Tracker.track(RuntimeException(failureMessage, error))
+                }.getOrNull()
+        }
+
+    private suspend fun decodeEnvelope(
+        barCount: Int,
+        configureSource: (MediaExtractor) -> Unit,
     ): FloatArray {
         val extractor = MediaExtractor()
         try {
-            if (sound.file != null) {
-                extractor.setDataSource(getFile(context, sound.file!!).path)
-            } else {
-                context.resources.openRawResourceFd(sound.rawRes).use { afd ->
-                    extractor.setDataSource(afd.fileDescriptor, afd.startOffset, afd.declaredLength)
-                }
-            }
+            configureSource(extractor)
             val trackIndex = audioTrackIndex(extractor)
             require(trackIndex >= 0) { "no audio track" }
             extractor.selectTrack(trackIndex)

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/ImportHubSheet.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/ImportHubSheet.kt
@@ -39,26 +39,26 @@ import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
 import kotlinx.coroutines.launch
 
-// Dim applied to the inert "Grabar" row's icon + text. Standard Material disabled opacity; a
-// disabled control is exempt from the WCAG 1.4.3 contrast minimum (§ Accessibility). The acid
-// "Pronto" badge stays at full strength so it reads as "coming", not "broken".
+// Dim applied to a disabled row's icon + text. Standard Material disabled opacity; a disabled
+// control is exempt from the WCAG 1.4.3 contrast minimum (§ Accessibility). All Hub rows are live
+// today; the nullable-onClick path is kept for future inert rows.
 private const val HUB_DISABLED_ALPHA = 0.38f
 private val HUB_ICON_TILE = 44.dp
 private val HUB_TILE_RADIUS = 12.dp
 
 /**
- * The import Hub — a [ModalBottomSheet] opened by the + FAB on My Bomps. Three paths: a live "import
- * audio from your device" row ([onImport]); a visible-but-inert "record" row badged "Soon" (its
- * destination is a later release; designing it now means enabling it later won't reshape the sheet);
- * and a "see how it works" row ([onHowItWorks]) that opens the onboarding tour, re-openable any time.
+ * The import Hub — a [ModalBottomSheet] opened by the + FAB on My Bomps. Three creation paths: "import
+ * audio from your device" ([onImport]), "record" a new Bomp in-app ([onRecord], ADR 0019), and "see how
+ * it works" ([onHowItWorks]) that opens the onboarding tour, re-openable any time.
  *
- * Presentational only: the caller dismisses on [onImport]/[onHowItWorks]/[onDismiss] and owns the
- * file picker and the tour state.
+ * Presentational only: the caller dismisses on [onImport]/[onRecord]/[onHowItWorks]/[onDismiss] and owns
+ * the file picker, the recorder Activity, and the tour state.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun ImportHubSheet(
     onImport: () -> Unit,
+    onRecord: () -> Unit,
     onHowItWorks: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -108,8 +108,12 @@ internal fun ImportHubSheet(
                 subtitle = stringResource(R.string.app_hub_record_sub),
                 tileColor = MaterialTheme.colorScheme.surfaceVariant,
                 iconColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                badge = stringResource(R.string.app_hub_record_badge),
-                onClick = null,
+                onClick = {
+                    scope.launch {
+                        sheetState.hide()
+                        onRecord()
+                    }
+                },
             )
             // Soft secondary helper — neutral tile (not acid) so it never competes with the import
             // primary. Animate the sheet closed first, then hand off, mirroring the import row.
@@ -138,7 +142,6 @@ private fun HubRow(
     tileColor: Color,
     iconColor: Color,
     onClick: (() -> Unit)?,
-    badge: String? = null,
 ) {
     val enabled = onClick != null
     val contentAlpha = if (enabled) 1f else HUB_DISABLED_ALPHA
@@ -183,18 +186,6 @@ private fun HubRow(
                 text = subtitle,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = contentAlpha),
-            )
-        }
-        if (badge != null) {
-            Text(
-                text = badge,
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onPrimaryContainer,
-                modifier =
-                    Modifier
-                        .clip(RoundedCornerShape(percent = 50))
-                        .background(MaterialTheme.colorScheme.primaryContainer)
-                        .padding(horizontal = Spacing.MD, vertical = Spacing.XS),
             )
         }
     }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -938,6 +938,9 @@ private fun MySoundsBody(
 ) {
     val activeCollection = publicCollections.firstOrNull { it.id == activeFilterId }
     val welcomeHintPending by viewModel.welcomeHintPending.collectAsStateWithLifecycle()
+    // Re-collected on each resume so a draft created/cleared while the user was in the recorder (or
+    // dropped by a process death) re-evaluates the banner without an explicit onResume hook (ADR 0019).
+    val pendingDraft by viewModel.pendingDraft.collectAsStateWithLifecycle(initialValue = null)
     val isOnMySounds = selectedTab == AppTab.MY_SOUNDS
     val showFilterEmptyState = isOnMySounds && activeFilterId != null && sounds.isEmpty() && activeCollection != null
     val showWelcomeEmptyState = sounds.isEmpty() && isOnMySounds && !showFilterEmptyState
@@ -947,6 +950,12 @@ private fun MySoundsBody(
     val showHeader = isOnMySounds && !showWelcomeEmptyState && !showFilterEmptyState
 
     androidx.compose.foundation.layout.Column(modifier = Modifier.padding(innerPadding)) {
+        pendingDraft?.let {
+            RecorderDraftBanner(
+                onContinue = { context.startActivity(RecordingActivity.createIntent(context, resumeDraft = true)) },
+                onDiscard = { viewModel.discardDraft() },
+            )
+        }
         if (isOnMySounds) {
             // Always rendered on My Sounds — even with no public collections the user still needs
             // the "+ Nueva" chip to bootstrap one. Hiding the whole row left the create affordance

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -68,6 +68,7 @@ import com.github.barriosnahuel.vossosunboton.commons.android.analytics.Analytic
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
 import com.github.barriosnahuel.vossosunboton.feature.addbutton.AddButtonActivity
 import com.github.barriosnahuel.vossosunboton.feature.addbutton.findFragmentActivity
+import com.github.barriosnahuel.vossosunboton.feature.recorder.RecordingActivity
 import com.github.barriosnahuel.vossosunboton.feature.share.ShareAppIntent
 import com.github.barriosnahuel.vossosunboton.feature.share.ShareFeature
 import com.github.barriosnahuel.vossosunboton.feature.vault.requestUnlock
@@ -283,6 +284,13 @@ fun LandingScreen(viewModel: SoundsViewModel) {
                     tracker.log(AnalyticsEvent.ImportHubImportSelected)
                     isHubVisible = false
                     importPicker.launch(arrayOf("audio/*"))
+                }
+            },
+            onRecord = {
+                if (isHubVisible) {
+                    tracker.log(AnalyticsEvent.ImportHubRecordSelected)
+                    isHubVisible = false
+                    context.startActivity(RecordingActivity.createIntent(context))
                 }
             },
             onHowItWorks = {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -941,6 +941,12 @@ private fun MySoundsBody(
     // Re-collected on each resume so a draft created/cleared while the user was in the recorder (or
     // dropped by a process death) re-evaluates the banner without an explicit onResume hook (ADR 0019).
     val pendingDraft by viewModel.pendingDraft.collectAsStateWithLifecycle(initialValue = null)
+    val draftTracker = remember(context) { AnalyticsTrackerProvider.get(context.applicationContext) }
+    // Impression — once per distinct draft (keyed on its file), so returning to Landing with the same
+    // draft doesn't inflate the denominator of the resume rate.
+    LaunchedEffect(pendingDraft?.file?.name) {
+        if (pendingDraft != null) draftTracker.log(AnalyticsEvent.RecordingDraftBannerShown)
+    }
     val isOnMySounds = selectedTab == AppTab.MY_SOUNDS
     val showFilterEmptyState = isOnMySounds && activeFilterId != null && sounds.isEmpty() && activeCollection != null
     val showWelcomeEmptyState = sounds.isEmpty() && isOnMySounds && !showFilterEmptyState
@@ -952,8 +958,14 @@ private fun MySoundsBody(
     androidx.compose.foundation.layout.Column(modifier = Modifier.padding(innerPadding)) {
         pendingDraft?.let {
             RecorderDraftBanner(
-                onContinue = { context.startActivity(RecordingActivity.createIntent(context, resumeDraft = true)) },
-                onDiscard = { viewModel.discardDraft() },
+                onContinue = {
+                    draftTracker.log(AnalyticsEvent.RecordingDraftResumed)
+                    context.startActivity(RecordingActivity.createIntent(context, resumeDraft = true))
+                },
+                onDiscard = {
+                    draftTracker.log(AnalyticsEvent.RecordingDraftDiscarded)
+                    viewModel.discardDraft()
+                },
             )
         }
         if (isOnMySounds) {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/RecorderDraftBanner.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/RecorderDraftBanner.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
+
+/**
+ * Non-intrusive banner offering to resume a recording the user captured but never saved (ADR 0019 §
+ * Draft recovery). Shown on the My Sounds list when [RecorderDraftStore] reports a pending draft —
+ * surviving a launcher re-entry or process death that would otherwise silently drop the clip.
+ *
+ * Stateless: [onContinue] reopens the recorder on the draft; [onDiscard] drops it. Text-tier actions
+ * (ADR 0010) on a `surfaceVariant` container with a divider — separation from the scrolling list
+ * without a border.
+ */
+@Composable
+internal fun RecorderDraftBanner(
+    onContinue: () -> Unit,
+    onDiscard: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+    ) {
+        Column {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(start = Spacing.LG, end = Spacing.SM, top = Spacing.XS, bottom = Spacing.XS),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(Spacing.SM),
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.app_ic_mic),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(ICON_SIZE),
+                )
+                Text(
+                    text = stringResource(R.string.app_recorder_draft_banner_message),
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                TextButton(onClick = onDiscard) {
+                    Text(stringResource(R.string.app_recorder_draft_discard))
+                }
+                TextButton(onClick = onContinue) {
+                    Text(stringResource(R.string.app_recorder_draft_continue))
+                }
+            }
+            HorizontalDivider()
+        }
+    }
+}
+
+private val ICON_SIZE = 20.dp

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -118,8 +118,27 @@ class SoundsViewModel(
     private val dualHomeCoachStore: com.github.barriosnahuel.vossosunboton.feature.collections.DualHomeCoachStore =
         com.github.barriosnahuel.vossosunboton.feature.collections
             .DualHomeCoachStore(application),
+    private val draftStore: com.github.barriosnahuel.vossosunboton.feature.recorder.RecorderDraftStore =
+        com.github.barriosnahuel.vossosunboton.feature.recorder.RecorderDraftStoreProvider
+            .get(application),
 ) : AndroidViewModel(application),
     PlayerControllerListener {
+    /**
+     * The pending recording draft, or null (ADR 0019 § Draft recovery). A cold flow so the Landing
+     * collector re-validates the temp file's existence on every resume — self-healing if the OS evicted
+     * the cached clip while the user was away.
+     */
+    val pendingDraft: kotlinx.coroutines.flow.Flow<com.github.barriosnahuel.vossosunboton.feature.recorder.RecorderDraft?> =
+        draftStore.draft
+
+    /** Banner "Descartar": delete the draft clip and forget it. */
+    fun discardDraft() {
+        viewModelScope.launch(ioDispatcher) {
+            draftStore.current()?.file?.delete()
+            draftStore.clear()
+        }
+    }
+
     private val repo =
         SoundsRepository(
             application,

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -256,6 +256,9 @@
     <string name="app_recorder_discard_message">Vas a perder lo que acabás de grabar.</string>
     <string name="app_recorder_discard_confirm">Descartar</string>
     <string name="app_recorder_discard_keep">Seguir grabando</string>
+    <string name="app_recorder_draft_banner_message">Tenés una grabación sin guardar</string>
+    <string name="app_recorder_draft_continue">Continuar</string>
+    <string name="app_recorder_draft_discard">Descartar</string>
 
     <!-- Onboarding (tour de 3 pasos, on-demand desde el Hub y el estado vacío) -->
     <string name="app_onboarding_skip">Saltar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -237,6 +237,7 @@
     <string name="app_recorder_cd_stop">Detener la grabación</string>
     <string name="app_recorder_cd_close">Cerrar</string>
     <string name="app_recorder_cd_timer">Tiempo de grabación</string>
+    <string name="app_recorder_cd_waveform">Progreso de reproducción</string>
     <string name="app_recorder_use">Usar este</string>
     <string name="app_recorder_rerecord">Regrabar</string>
     <string name="app_recorder_cd_play">Reproducir</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -225,11 +225,36 @@
     <string name="app_hub_subtitle">Una voz se guarda y la tenés cerca, para escucharla cuando quieras.</string>
     <string name="app_hub_import">Importar audio del dispositivo</string>
     <string name="app_hub_import_sub">Notas de voz, grabaciones, lo que ya tengas guardado.</string>
-    <string name="app_hub_record">Grabar tu primer Bomp</string>
-    <string name="app_hub_record_sub">Apretá y hablá. Lo estamos cocinando.</string>
-    <string name="app_hub_record_badge">Pronto</string>
+    <string name="app_hub_record">Grabar un Bomp</string>
+    <string name="app_hub_record_sub">Tu voz, un momento que no querés perder.</string>
     <string name="app_hub_how">Ver cómo funciona</string>
     <string name="app_hub_how_sub">Un minuto y le tomás la mano.</string>
+
+    <!-- Grabador in-app (ADR 0019) -->
+    <string name="app_recorder_ready_hint">Tocá para grabar</string>
+    <string name="app_recorder_recording_hint">Tocá para detener</string>
+    <string name="app_recorder_cd_record">Empezar a grabar</string>
+    <string name="app_recorder_cd_stop">Detener la grabación</string>
+    <string name="app_recorder_cd_close">Cerrar</string>
+    <string name="app_recorder_cd_timer">Tiempo de grabación</string>
+    <string name="app_recorder_use">Usar este</string>
+    <string name="app_recorder_rerecord">Regrabar</string>
+    <string name="app_recorder_cd_play">Reproducir</string>
+    <string name="app_recorder_cd_pause">Pausar</string>
+    <string name="app_recorder_permission_title">Bomp necesita tu micrófono</string>
+    <string name="app_recorder_permission_body">Solo mientras grabás. El audio se queda en tu teléfono hasta que vos decidas dónde vive.</string>
+    <string name="app_recorder_permission_allow">Permitir micrófono</string>
+    <string name="app_recorder_permission_not_now">Ahora no</string>
+    <string name="app_recorder_denied_message">El micrófono está desactivado. Activalo en Ajustes para grabar, o importá un archivo.</string>
+    <string name="app_recorder_open_settings">Abrir ajustes</string>
+    <string name="app_recorder_import_instead">Importar en su lugar</string>
+    <string name="app_recorder_feedback_too_short">Muy corto — probá de nuevo</string>
+    <string name="app_recorder_feedback_no_space">No hay espacio suficiente para grabar</string>
+    <string name="app_recorder_feedback_mic_busy">El micrófono lo está usando otra app</string>
+    <string name="app_recorder_discard_title">¿Descartar esta grabación?</string>
+    <string name="app_recorder_discard_message">Vas a perder lo que acabás de grabar.</string>
+    <string name="app_recorder_discard_confirm">Descartar</string>
+    <string name="app_recorder_discard_keep">Seguir grabando</string>
 
     <!-- Onboarding (tour de 3 pasos, on-demand desde el Hub y el estado vacío) -->
     <string name="app_onboarding_skip">Saltar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -243,6 +243,7 @@
     <string name="app_recorder_cd_stop">Stop recording</string>
     <string name="app_recorder_cd_close">Close</string>
     <string name="app_recorder_cd_timer">Recording time</string>
+    <string name="app_recorder_cd_waveform">Playback progress</string>
     <string name="app_recorder_use">Use this</string>
     <string name="app_recorder_rerecord">Re-record</string>
     <string name="app_recorder_cd_play">Play</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -262,6 +262,9 @@
     <string name="app_recorder_discard_message">You\'ll lose what you just recorded.</string>
     <string name="app_recorder_discard_confirm">Discard</string>
     <string name="app_recorder_discard_keep">Keep recording</string>
+    <string name="app_recorder_draft_banner_message">You have an unsaved recording</string>
+    <string name="app_recorder_draft_continue">Continue</string>
+    <string name="app_recorder_draft_discard">Discard</string>
 
     <!-- Onboarding tour (3 steps, on-demand from the Hub and the empty state) -->
     <string name="app_onboarding_skip">Skip</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -231,11 +231,36 @@
     <string name="app_hub_subtitle">A voice gets saved and stays close, ready whenever you want to hear it.</string>
     <string name="app_hub_import">Import audio from your device</string>
     <string name="app_hub_import_sub">Voice notes, recordings, whatever you already have saved.</string>
-    <string name="app_hub_record">Record your first Bomp</string>
-    <string name="app_hub_record_sub">Press and talk. We\'re cooking it up.</string>
-    <string name="app_hub_record_badge">Soon</string>
+    <string name="app_hub_record">Record a Bomp</string>
+    <string name="app_hub_record_sub">Your voice, a moment you don\'t want to lose.</string>
     <string name="app_hub_how">See how it works</string>
     <string name="app_hub_how_sub">A minute and you\'ve got it.</string>
+
+    <!-- In-app recorder (ADR 0019) -->
+    <string name="app_recorder_ready_hint">Tap to record</string>
+    <string name="app_recorder_recording_hint">Tap to stop</string>
+    <string name="app_recorder_cd_record">Start recording</string>
+    <string name="app_recorder_cd_stop">Stop recording</string>
+    <string name="app_recorder_cd_close">Close</string>
+    <string name="app_recorder_cd_timer">Recording time</string>
+    <string name="app_recorder_use">Use this</string>
+    <string name="app_recorder_rerecord">Re-record</string>
+    <string name="app_recorder_cd_play">Play</string>
+    <string name="app_recorder_cd_pause">Pause</string>
+    <string name="app_recorder_permission_title">Bomp needs your mic</string>
+    <string name="app_recorder_permission_body">Only while you record. The audio stays on your phone until you choose where it lives.</string>
+    <string name="app_recorder_permission_allow">Allow microphone</string>
+    <string name="app_recorder_permission_not_now">Not now</string>
+    <string name="app_recorder_denied_message">Microphone access is off. Turn it on in Settings to record, or import a file instead.</string>
+    <string name="app_recorder_open_settings">Open settings</string>
+    <string name="app_recorder_import_instead">Import instead</string>
+    <string name="app_recorder_feedback_too_short">Too short — give it another go</string>
+    <string name="app_recorder_feedback_no_space">Not enough space to record</string>
+    <string name="app_recorder_feedback_mic_busy">The mic is busy in another app</string>
+    <string name="app_recorder_discard_title">Discard this recording?</string>
+    <string name="app_recorder_discard_message">You\'ll lose what you just recorded.</string>
+    <string name="app_recorder_discard_confirm">Discard</string>
+    <string name="app_recorder_discard_keep">Keep recording</string>
 
     <!-- Onboarding tour (3 steps, on-demand from the Hub and the empty state) -->
     <string name="app_onboarding_skip">Skip</string>

--- a/app/src/main/res/xml/app_file_provider_paths.xml
+++ b/app/src/main/res/xml/app_file_provider_paths.xml
@@ -4,4 +4,8 @@
     <external-files-path
         name="buttons"
         path="Music/" />
+    <!-- In-app recorder temp clips (ADR 0019): shared to AddButtonActivity as a content:// URI. -->
+    <cache-path
+        name="recordings"
+        path="recordings/" />
 </paths>

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivityIntentDispatchTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivityIntentDispatchTest.kt
@@ -16,6 +16,7 @@ import com.github.barriosnahuel.vossosunboton.commons.android.analytics.Analytic
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.FakeAnalyticsTracker
 import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.github.barriosnahuel.vossosunboton.model.SoundSource
 import com.github.barriosnahuel.vossosunboton.testSound
 import com.github.barriosnahuel.vossosunboton.ui.home.LandingActivity
 import com.google.common.truth.Truth.assertThat
@@ -205,6 +206,7 @@ internal class AddButtonActivityIntentDispatchTest : AbstractRobolectricTest() {
             uri: String,
             publicCollectionIds: Set<String>,
             privateCollectionIds: Set<String>,
+            source: SoundSource,
         ): Deferred<Int> = CompletableDeferred(0)
 
         override fun renameButtonAsync(

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivitySdkBoundaryTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivitySdkBoundaryTest.kt
@@ -15,6 +15,7 @@ import com.github.barriosnahuel.vossosunboton.commons.android.analytics.Analytic
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.FakeAnalyticsTracker
 import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.github.barriosnahuel.vossosunboton.model.SoundSource
 import com.github.barriosnahuel.vossosunboton.testSound
 import com.github.barriosnahuel.vossosunboton.ui.home.LandingActivity
 import com.google.common.truth.Truth.assertThat
@@ -106,6 +107,7 @@ internal class AddButtonActivitySdkBoundaryTest : AbstractRobolectricTest() {
             uri: String,
             publicCollectionIds: Set<String>,
             privateCollectionIds: Set<String>,
+            source: SoundSource,
         ): Deferred<Int> = CompletableDeferred(0)
 
         override fun renameButtonAsync(

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeatureTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeatureTest.kt
@@ -14,6 +14,8 @@ import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
+import com.github.barriosnahuel.vossosunboton.model.SoundSource
+import com.github.barriosnahuel.vossosunboton.model.data.manager.SoundsRepository
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
@@ -21,6 +23,7 @@ import io.mockk.mockkConstructor
 import io.mockk.spyk
 import io.mockk.unmockkAll
 import io.mockk.verify
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Test
@@ -48,6 +51,41 @@ internal class AddButtonFeatureTest : AbstractRobolectricTest() {
             }
 
         assertThat(result).isEqualTo(R.string.app_addbutton_feedback_saved_ok)
+    }
+
+    @Test
+    fun `saveNewButtonAsync tags a recorded clip with the RECORDED source`() {
+        val uri = Uri.parse("content://test/recorded-clip")
+        val context = contextWith(uri, mime = "audio/mp4", sizeBytes = 1024L)
+
+        val saved =
+            runBlocking {
+                SoundsRepository(realContext).clearForTest()
+                AddButtonFeature.instance
+                    .saveNewButtonAsync(context, "rec", uri.toString(), source = SoundSource.RECORDED)
+                    .await()
+                SoundsRepository(realContext).sounds.first().first { it.name == "rec" }
+            }
+
+        assertThat(saved.source).isEqualTo(SoundSource.RECORDED)
+    }
+
+    @Test
+    fun `saveNewButtonAsync derives the destination extension from the MIME`() {
+        val cases = mapOf("audio/mp4" to ".m4a", "audio/mpeg" to ".mp3", "audio/opus" to ".opus")
+        cases.forEach { (mime, expectedExt) ->
+            val uri = Uri.parse("content://test/ext-${mime.substringAfter('/')}")
+            val context = contextWith(uri, mime = mime, sizeBytes = 1024L)
+
+            val saved =
+                runBlocking {
+                    SoundsRepository(realContext).clearForTest()
+                    AddButtonFeature.instance.saveNewButtonAsync(context, "ext", uri.toString()).await()
+                    SoundsRepository(realContext).sounds.first().first { it.name == "ext" }
+                }
+
+            assertThat(saved.file).endsWith(expectedExt)
+        }
     }
 
     /** OWASP MASVS-CODE-4 / CWE-434 (Unrestricted Upload of File with Dangerous Type — non-audio MIME). */

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenAnalyticsTest.kt
@@ -30,6 +30,9 @@ import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.FakeAnalyticsTracker
+import com.github.barriosnahuel.vossosunboton.feature.recorder.RecorderDraft
+import com.github.barriosnahuel.vossosunboton.feature.recorder.RecorderDraftStore
+import com.github.barriosnahuel.vossosunboton.feature.recorder.RecorderDraftStoreProvider
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.model.SoundSource
 import com.github.barriosnahuel.vossosunboton.testSound
@@ -37,11 +40,14 @@ import com.github.barriosnahuel.vossosunboton.ui.home.LandingActivity
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.robolectric.annotation.Config
+import java.io.File
 
 @Config(sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
 internal class AddButtonScreenAnalyticsTest : AbstractRobolectricTest() {
@@ -52,6 +58,7 @@ internal class AddButtonScreenAnalyticsTest : AbstractRobolectricTest() {
 
     private lateinit var fake: FakeAnalyticsTracker
     private lateinit var feature: FakeAddButtonFeature
+    private lateinit var draftStore: FakeRecorderDraftStore
 
     @Before
     fun setUp() {
@@ -59,12 +66,15 @@ internal class AddButtonScreenAnalyticsTest : AbstractRobolectricTest() {
         AnalyticsTrackerProvider.setForTest(fake)
         feature = FakeAddButtonFeature()
         AddButtonFeatureProvider.setForTest(feature)
+        draftStore = FakeRecorderDraftStore()
+        RecorderDraftStoreProvider.setForTest(draftStore)
     }
 
     @After
     fun tearDown() {
         AnalyticsTrackerProvider.setForTest(null)
         AddButtonFeatureProvider.setForTest(null)
+        RecorderDraftStoreProvider.setForTest(null)
     }
 
     @Test
@@ -133,6 +143,31 @@ internal class AddButtonScreenAnalyticsTest : AbstractRobolectricTest() {
 
             val event = fake.assertEmitted("sound_add")
             assertThat(event.params["source"]).isEqualTo(AddButtonActivity.SOURCE_IMPORT)
+        }
+    }
+
+    @Test
+    fun `saving a recorded Bomp clears its recovery draft so the banner won't re-offer it`() {
+        val intent = AddButtonActivity.createIntent(context, SAMPLE_URI, AddButtonActivity.SOURCE_RECORD)
+        ActivityScenario.launch<AddButtonActivity>(intent).use {
+            composeTestRule.waitForIdle()
+            composeTestRule.onNode(hasSetTextAction()).performTextInput(NEW_NAME)
+            composeTestRule.onNodeWithText(context.getString(R.string.app_addbutton_save)).performClick()
+            composeTestRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) { fake.events.isNotEmpty() }
+
+            assertThat(draftStore.clearCount).isAtLeast(1)
+        }
+    }
+
+    @Test
+    fun `saving an imported Bomp leaves the recorder draft untouched`() {
+        ActivityScenario.launch<AddButtonActivity>(AddButtonActivity.createIntent(context, SAMPLE_URI)).use {
+            composeTestRule.waitForIdle()
+            composeTestRule.onNode(hasSetTextAction()).performTextInput(NEW_NAME)
+            composeTestRule.onNodeWithText(context.getString(R.string.app_addbutton_save)).performClick()
+            composeTestRule.waitUntil(timeoutMillis = WAIT_TIMEOUT_MS) { fake.events.isNotEmpty() }
+
+            assertThat(draftStore.clearCount).isEqualTo(0)
         }
     }
 
@@ -403,6 +438,23 @@ internal class AddButtonScreenAnalyticsTest : AbstractRobolectricTest() {
             sound: Sound,
             newName: String,
         ): Deferred<Unit> = CompletableDeferred(Unit)
+    }
+
+    /** Records whether the save pipeline cleared the recorder draft (ADR 0019 § Draft recovery). */
+    private class FakeRecorderDraftStore : RecorderDraftStore {
+        var clearCount = 0
+        override val draft: Flow<RecorderDraft?> = MutableStateFlow(null)
+
+        override suspend fun current(): RecorderDraft? = null
+
+        override fun save(
+            file: File,
+            durationMs: Long,
+        ) = Unit
+
+        override fun clear() {
+            clearCount += 1
+        }
     }
 
     private companion object {

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenAnalyticsTest.kt
@@ -31,6 +31,7 @@ import com.github.barriosnahuel.vossosunboton.commons.android.analytics.Analytic
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.FakeAnalyticsTracker
 import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.github.barriosnahuel.vossosunboton.model.SoundSource
 import com.github.barriosnahuel.vossosunboton.testSound
 import com.github.barriosnahuel.vossosunboton.ui.home.LandingActivity
 import com.google.common.truth.Truth.assertThat
@@ -391,6 +392,7 @@ internal class AddButtonScreenAnalyticsTest : AbstractRobolectricTest() {
             uri: String,
             publicCollectionIds: Set<String>,
             privateCollectionIds: Set<String>,
+            source: SoundSource,
         ): Deferred<Int> {
             saveNewCalls += 1
             return CompletableDeferred(saveNewFeedback)

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenDuplicateNameHintTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenDuplicateNameHintTest.kt
@@ -31,6 +31,7 @@ import com.github.barriosnahuel.vossosunboton.commons.file.getFile
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlaybackState
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
 import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.github.barriosnahuel.vossosunboton.model.SoundSource
 import com.github.barriosnahuel.vossosunboton.model.data.manager.SoundsRepository
 import com.github.barriosnahuel.vossosunboton.testSound
 import com.github.barriosnahuel.vossosunboton.ui.home.LandingActivity
@@ -375,6 +376,7 @@ internal class AddButtonScreenDuplicateNameHintTest : AbstractRobolectricTest() 
             uri: String,
             publicCollectionIds: Set<String>,
             privateCollectionIds: Set<String>,
+            source: SoundSource,
         ): Deferred<Int> {
             saveNewCalls += 1
             return CompletableDeferred(saveNewFeedback)

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenHapticTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenHapticTest.kt
@@ -25,6 +25,7 @@ import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.FakeAnalyticsTracker
 import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.github.barriosnahuel.vossosunboton.model.SoundSource
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
@@ -133,6 +134,7 @@ internal class AddButtonScreenHapticTest : AbstractRobolectricTest() {
             uri: String,
             publicCollectionIds: Set<String>,
             privateCollectionIds: Set<String>,
+            source: SoundSource,
         ): Deferred<Int> {
             saveNewCalls += 1
             return CompletableDeferred(saveNewFeedback)

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenPlaybackTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenPlaybackTest.kt
@@ -24,6 +24,7 @@ import com.github.barriosnahuel.vossosunboton.feature.playback.PlaybackState
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerController
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
 import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.github.barriosnahuel.vossosunboton.model.SoundSource
 import com.github.barriosnahuel.vossosunboton.testSound
 import com.github.barriosnahuel.vossosunboton.ui.home.LandingActivity
 import io.mockk.every
@@ -131,6 +132,7 @@ internal class AddButtonScreenPlaybackTest : AbstractRobolectricTest() {
                     uri: String,
                     publicCollectionIds: Set<String>,
                     privateCollectionIds: Set<String>,
+                    source: SoundSource,
                 ): Deferred<Int> = CompletableDeferred(R.string.app_addbutton_feedback_save_failed)
 
                 override fun renameButtonAsync(
@@ -193,6 +195,7 @@ internal class AddButtonScreenPlaybackTest : AbstractRobolectricTest() {
             uri: String,
             publicCollectionIds: Set<String>,
             privateCollectionIds: Set<String>,
+            source: SoundSource,
         ): Deferred<Int> = CompletableDeferred(R.string.app_addbutton_feedback_saved_ok)
 
         override fun renameButtonAsync(

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/DataStoreRecorderDraftStoreTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/DataStoreRecorderDraftStoreTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.recorder
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.job
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+internal class DataStoreRecorderDraftStoreTest : AbstractRobolectricTest() {
+    private val app: Application get() = ApplicationProvider.getApplicationContext()
+    private lateinit var writebackScope: CoroutineScope
+    private lateinit var store: DataStoreRecorderDraftStore
+
+    @Before
+    fun setUp() {
+        writebackScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        store = DataStoreRecorderDraftStore(app, writebackScope)
+        runBlocking {
+            store.clearForTest()
+            RecorderTempFiles.purge(app)
+        }
+    }
+
+    @After
+    fun tearDown() {
+        runBlocking { store.clearForTest() }
+        writebackScope.cancel()
+    }
+
+    @Test
+    fun `save then current returns the clip while its file exists`() =
+        runBlocking {
+            val file = RecorderTempFiles.newTempFile(app).apply { createNewFile() }
+
+            store.save(file, durationMs = 4_000)
+            drainWritebacks()
+
+            val draft = store.current()!!
+            assertThat(draft.file.name).isEqualTo(file.name)
+            assertThat(draft.durationMs).isEqualTo(4_000)
+        }
+
+    @Test
+    fun `current returns null and self-heals once the file is gone`() =
+        runBlocking {
+            val file = RecorderTempFiles.newTempFile(app).apply { createNewFile() }
+            store.save(file, durationMs = 4_000)
+            drainWritebacks()
+
+            file.delete()
+
+            assertThat(store.current()).isNull()
+        }
+
+    @Test
+    fun `clear forgets the draft`() =
+        runBlocking {
+            val file = RecorderTempFiles.newTempFile(app).apply { createNewFile() }
+            store.save(file, durationMs = 4_000)
+            drainWritebacks()
+
+            store.clear()
+            drainWritebacks()
+
+            assertThat(store.current()).isNull()
+        }
+
+    /** Joins every fire-and-forget `scope.launch { store.edit { ... } }` so disk reads run post-commit. */
+    private suspend fun drainWritebacks() {
+        writebackScope.coroutineContext.job.children
+            .toList()
+            .joinAll()
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderEnvelopeTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderEnvelopeTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.recorder
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+internal class RecorderEnvelopeTest {
+    @Test
+    fun `empty samples yield null so the caller decodes instead`() {
+        assertThat(buildRecorderEnvelope(emptyList(), BARS)).isNull()
+    }
+
+    @Test
+    fun `more samples than bars downsample to barCount with the loudest normalized to 1`() {
+        // 200 samples, a single loud spike among quiet ones.
+        val samples = List(200) { if (it == 120) 0.8f else 0.1f }
+
+        val envelope = buildRecorderEnvelope(samples, BARS)!!
+
+        assertThat(envelope.size).isEqualTo(BARS)
+        assertThat(envelope.maxOrNull()).isEqualTo(1f)
+        assertThat(envelope.all { it >= FLOOR }).isTrue()
+    }
+
+    @Test
+    fun `fewer samples than bars interpolate to barCount with no gaps`() {
+        val samples = listOf(0.2f, 0.9f, 0.3f, 0.7f, 0.4f)
+
+        val envelope = buildRecorderEnvelope(samples, BARS)!!
+
+        assertThat(envelope.size).isEqualTo(BARS)
+        // Interpolation must fill every bar — a short clip never renders as sparse spikes.
+        assertThat(envelope.none { it < FLOOR }).isTrue()
+        assertThat(envelope.maxOrNull()).isEqualTo(1f)
+    }
+
+    @Test
+    fun `all-silent samples yield null so the caller decodes the real file`() {
+        // Covers the getMaxAmplitude()-always-0 device quirk: a flat live wave would hide real audio.
+        assertThat(buildRecorderEnvelope(List(100) { 0f }, BARS)).isNull()
+    }
+
+    private companion object {
+        const val BARS = 48
+        const val FLOOR = 0.06f
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreenTest.kt
@@ -108,12 +108,14 @@ internal class RecorderScreenTest : AbstractRobolectricTest() {
         state: RecorderState,
         isPreviewPlaying: Boolean = false,
         previewPositionMs: Long = 0L,
+        peaks: FloatArray? = null,
         onRecordTap: () -> Unit = {},
     ) {
         RecorderScreen(
             state = state,
             isPreviewPlaying = isPreviewPlaying,
             previewPositionMs = previewPositionMs,
+            peaks = peaks,
             onRecordTap = onRecordTap,
             onStopTap = {},
             onPreviewToggle = {},

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreenTest.kt
@@ -5,6 +5,7 @@
  */
 package com.github.barriosnahuel.vossosunboton.feature.recorder
 
+import android.net.Uri
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
@@ -16,7 +17,6 @@ import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
 import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
 import org.junit.Test
-import java.io.File
 
 internal class RecorderScreenTest : AbstractRobolectricTest() {
     @get:Rule
@@ -42,7 +42,7 @@ internal class RecorderScreenTest : AbstractRobolectricTest() {
 
     @Test
     fun `review state offers use and re-record`() {
-        val review = RecorderState.Review(File("clip.m4a"), durationMs = 4_000)
+        val review = RecorderState.Review(Uri.parse("content://clip"), durationMs = 4_000)
         composeTestRule.setContent { AppTheme { recorder(review) } }
 
         composeTestRule.onNodeWithText("Use this").assertIsDisplayed()

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreenTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.recorder
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+
+internal class RecorderScreenTest : AbstractRobolectricTest() {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `ready state shows the record affordance`() {
+        composeTestRule.setContent { AppTheme { recorder(RecorderState.Ready) } }
+
+        composeTestRule.onNodeWithText("Tap to record").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Start recording").assertIsDisplayed()
+    }
+
+    @Test
+    fun `tapping the hero in ready invokes onRecordTap`() {
+        var tapped = false
+        composeTestRule.setContent { AppTheme { recorder(RecorderState.Ready, onRecordTap = { tapped = true }) } }
+
+        composeTestRule.onNodeWithContentDescription("Start recording").performClick()
+
+        assertThat(tapped).isTrue()
+    }
+
+    @Test
+    fun `review state offers use and re-record`() {
+        val review = RecorderState.Review(File("clip.m4a"), durationMs = 4_000)
+        composeTestRule.setContent { AppTheme { recorder(review) } }
+
+        composeTestRule.onNodeWithText("Use this").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Re-record").assertIsDisplayed()
+    }
+
+    /**
+     * OWASP MASVS-PLATFORM-1 / CWE-284 (Improper Access Control — a denied mic permission must never
+     * dead-end; the user can still create via import). Guards the denial escape affordance.
+     */
+    @Test
+    fun `a denied microphone offers an import escape`() {
+        var imported = false
+        composeTestRule.setContent {
+            AppTheme {
+                MicPermissionDenied(onOpenSettings = {}, onImportInstead = { imported = true }, onClose = {})
+            }
+        }
+
+        composeTestRule.onNodeWithText("Open settings").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Import instead").performClick()
+
+        assertThat(imported).isTrue()
+    }
+
+    @Composable
+    private fun recorder(
+        state: RecorderState,
+        onRecordTap: () -> Unit = {},
+    ) {
+        RecorderScreen(
+            state = state,
+            isPreviewPlaying = false,
+            onRecordTap = onRecordTap,
+            onStopTap = {},
+            onPreviewToggle = {},
+            onUseClip = {},
+            onReRecord = {},
+            onClose = {},
+        )
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreenTest.kt
@@ -7,7 +7,9 @@ package com.github.barriosnahuel.vossosunboton.feature.recorder
 
 import android.net.Uri
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertRangeInfoEquals
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -68,14 +70,50 @@ internal class RecorderScreenTest : AbstractRobolectricTest() {
         assertThat(imported).isTrue()
     }
 
+    @Test
+    fun `review timer follows the playback position while previewing`() {
+        val review = RecorderState.Review(Uri.parse("content://clip"), durationMs = 5_000)
+        composeTestRule.setContent {
+            AppTheme { recorder(review, isPreviewPlaying = true, previewPositionMs = 2_000) }
+        }
+
+        // Progress, not the static final duration (the stuck-timer bug).
+        composeTestRule.onNodeWithText("0:02").assertIsDisplayed()
+    }
+
+    @Test
+    fun `review timer shows the clip duration when not previewing`() {
+        val review = RecorderState.Review(Uri.parse("content://clip"), durationMs = 5_000)
+        composeTestRule.setContent {
+            AppTheme { recorder(review, isPreviewPlaying = false, previewPositionMs = 0) }
+        }
+
+        composeTestRule.onNodeWithText("0:05").assertIsDisplayed()
+    }
+
+    @Test
+    fun `review waveform reflects the playback progress`() {
+        val review = RecorderState.Review(Uri.parse("content://clip"), durationMs = 5_000)
+        composeTestRule.setContent {
+            AppTheme { recorder(review, isPreviewPlaying = true, previewPositionMs = 2_000) }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("Playback progress")
+            .assertRangeInfoEquals(ProgressBarRangeInfo(0.4f, 0f..1f))
+    }
+
     @Composable
     private fun recorder(
         state: RecorderState,
+        isPreviewPlaying: Boolean = false,
+        previewPositionMs: Long = 0L,
         onRecordTap: () -> Unit = {},
     ) {
         RecorderScreen(
             state = state,
-            isPreviewPlaying = false,
+            isPreviewPlaying = isPreviewPlaying,
+            previewPositionMs = previewPositionMs,
             onRecordTap = onRecordTap,
             onStopTap = {},
             onPreviewToggle = {},

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderViewModelTest.kt
@@ -6,6 +6,7 @@
 package com.github.barriosnahuel.vossosunboton.feature.recorder
 
 import android.app.Application
+import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.google.common.truth.Truth.assertThat
@@ -41,7 +42,7 @@ internal class RecorderViewModelTest : AbstractRobolectricTest() {
         Dispatchers.resetMain()
     }
 
-    private fun viewModel() = RecorderViewModel(application, engine, dispatcher)
+    private fun viewModel() = RecorderViewModel(application, engine, dispatcher, uriProvider = { Uri.parse("content://test/${it.name}") })
 
     @Test
     fun `tapping record moves to Recording and starts the engine`() =

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderViewModelTest.kt
@@ -9,6 +9,7 @@ import android.app.Application
 import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.FakeAnalyticsTracker
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -32,12 +33,14 @@ internal class RecorderViewModelTest : AbstractRobolectricTest() {
     private val dispatcher = StandardTestDispatcher()
     private lateinit var engine: FakeRecorderEngine
     private lateinit var draftStore: FakeRecorderDraftStore
+    private lateinit var analytics: FakeAnalyticsTracker
 
     @Before
     fun setUp() {
         Dispatchers.setMain(dispatcher)
         engine = FakeRecorderEngine()
         draftStore = FakeRecorderDraftStore()
+        analytics = FakeAnalyticsTracker()
         File(application.cacheDir, "recordings").deleteRecursively()
     }
 
@@ -47,7 +50,14 @@ internal class RecorderViewModelTest : AbstractRobolectricTest() {
     }
 
     private fun viewModel() =
-        RecorderViewModel(application, engine, dispatcher, draftStore, uriProvider = { Uri.parse("content://test/${it.name}") })
+        RecorderViewModel(
+            application,
+            engine,
+            dispatcher,
+            draftStore,
+            analytics,
+            uriProvider = { Uri.parse("content://test/${it.name}") },
+        )
 
     @Test
     fun `tapping record moves to Recording and starts the engine`() =
@@ -285,6 +295,32 @@ internal class RecorderViewModelTest : AbstractRobolectricTest() {
 
             assertThat(vm.state.value).isInstanceOf(RecorderState.Review::class.java)
             assertThat(engine.stopCount).isEqualTo(1)
+        }
+
+    @Test
+    fun `reaching Review emits recording_completed`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            vm.onRecordTapped()
+            advanceTimeBy(1_200)
+
+            vm.onStopTapped()
+            advanceUntilIdle()
+
+            analytics.assertEmitted("recording_completed")
+        }
+
+    @Test
+    fun `restoring a draft does not emit recording_completed`() =
+        runTest(dispatcher) {
+            draftStore.currentDraft = RecorderDraft(File(application.cacheDir, "recordings/clip.m4a"), durationMs = 4_000)
+            val vm = viewModel()
+
+            vm.onEnter(resumeDraft = true)
+            advanceUntilIdle()
+
+            // A restored draft is a recovered prior completion, not a new one — the funnel must not double-count.
+            analytics.assertNotEmitted("recording_completed")
         }
 }
 

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderViewModelTest.kt
@@ -12,6 +12,8 @@ import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
@@ -29,11 +31,13 @@ internal class RecorderViewModelTest : AbstractRobolectricTest() {
     private val application: Application get() = ApplicationProvider.getApplicationContext()
     private val dispatcher = StandardTestDispatcher()
     private lateinit var engine: FakeRecorderEngine
+    private lateinit var draftStore: FakeRecorderDraftStore
 
     @Before
     fun setUp() {
         Dispatchers.setMain(dispatcher)
         engine = FakeRecorderEngine()
+        draftStore = FakeRecorderDraftStore()
         File(application.cacheDir, "recordings").deleteRecursively()
     }
 
@@ -42,7 +46,8 @@ internal class RecorderViewModelTest : AbstractRobolectricTest() {
         Dispatchers.resetMain()
     }
 
-    private fun viewModel() = RecorderViewModel(application, engine, dispatcher, uriProvider = { Uri.parse("content://test/${it.name}") })
+    private fun viewModel() =
+        RecorderViewModel(application, engine, dispatcher, draftStore, uriProvider = { Uri.parse("content://test/${it.name}") })
 
     @Test
     fun `tapping record moves to Recording and starts the engine`() =
@@ -152,6 +157,135 @@ internal class RecorderViewModelTest : AbstractRobolectricTest() {
 
             assertThat(engine.releaseCount).isAtLeast(1)
         }
+
+    @Test
+    fun `reaching Review persists the clip as a recoverable draft`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            vm.onRecordTapped()
+            advanceTimeBy(1_200)
+
+            vm.onStopTapped()
+            advanceUntilIdle()
+
+            assertThat(draftStore.saved).isNotNull()
+            assertThat(draftStore.saved!!.durationMs).isAtLeast(1_000)
+        }
+
+    @Test
+    fun `re-record clears the persisted draft`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            vm.onRecordTapped()
+            advanceTimeBy(1_200)
+            vm.onStopTapped()
+            advanceUntilIdle()
+
+            vm.onReRecord()
+
+            assertThat(draftStore.cleared).isTrue()
+        }
+
+    @Test
+    fun `using the clip keeps the draft until the save pipeline persists it`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            vm.onRecordTapped()
+            advanceTimeBy(1_200)
+            vm.onStopTapped()
+            advanceUntilIdle()
+
+            vm.onUseClip()
+
+            // The draft survives handoff — backing out of the save screen must still be recoverable.
+            assertThat(draftStore.cleared).isFalse()
+            assertThat(vm.events.first()).isInstanceOf(RecorderEvent.Handoff::class.java)
+        }
+
+    @Test
+    fun `a too-short clip clears any persisted draft`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            vm.onRecordTapped()
+            advanceTimeBy(400)
+
+            vm.onStopTapped()
+            advanceUntilIdle()
+
+            assertThat(draftStore.cleared).isTrue()
+        }
+
+    @Test
+    fun `onEnter with resumeDraft restores the persisted clip into Review`() =
+        runTest(dispatcher) {
+            draftStore.currentDraft = RecorderDraft(File(application.cacheDir, "recordings/clip.m4a"), durationMs = 4_000)
+            val vm = viewModel()
+
+            vm.onEnter(resumeDraft = true)
+            advanceUntilIdle()
+
+            val state = vm.state.value
+            assertThat(state).isInstanceOf(RecorderState.Review::class.java)
+            assertThat((state as RecorderState.Review).durationMs).isEqualTo(4_000)
+        }
+
+    @Test
+    fun `onEnter without resumeDraft stays Ready and purges leftovers`() =
+        runTest(dispatcher) {
+            val stray = File(application.cacheDir, "recordings").apply { mkdirs() }.let { File(it, "stray.m4a") }
+            stray.createNewFile()
+            val vm = viewModel()
+
+            vm.onEnter(resumeDraft = false)
+            advanceUntilIdle()
+
+            assertThat(vm.state.value).isEqualTo(RecorderState.Ready)
+            assertThat(stray.exists()).isFalse()
+        }
+
+    @Test
+    fun `onEnter without resumeDraft preserves an existing draft's file`() =
+        runTest(dispatcher) {
+            val draftFile = File(application.cacheDir, "recordings").apply { mkdirs() }.let { File(it, "draft.m4a") }
+            draftFile.createNewFile()
+            draftStore.currentDraft = RecorderDraft(draftFile, durationMs = 3_000)
+            val vm = viewModel()
+
+            vm.onEnter(resumeDraft = false)
+            advanceUntilIdle()
+
+            // A fresh entry must NOT delete an unsaved draft's bytes — the Landing banner still needs it.
+            assertThat(draftFile.exists()).isTrue()
+            assertThat(vm.state.value).isEqualTo(RecorderState.Ready)
+        }
+
+    @Test
+    fun `double-tapping record starts the engine only once`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+
+            vm.onRecordTapped()
+            vm.onRecordTapped()
+            advanceTimeBy(200)
+
+            assertThat(engine.startCount).isEqualTo(1)
+            vm.clearForTest()
+        }
+
+    @Test
+    fun `double-tapping stop reaches Review once without discarding the clip`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            vm.onRecordTapped()
+            advanceTimeBy(1_200)
+
+            vm.onStopTapped()
+            vm.onStopTapped()
+            advanceUntilIdle()
+
+            assertThat(vm.state.value).isInstanceOf(RecorderState.Review::class.java)
+            assertThat(engine.stopCount).isEqualTo(1)
+        }
 }
 
 private class FakeRecorderEngine : RecorderEngine {
@@ -180,5 +314,31 @@ private class FakeRecorderEngine : RecorderEngine {
 
     override fun release() {
         releaseCount++
+    }
+}
+
+private class FakeRecorderDraftStore : RecorderDraftStore {
+    private val _draft = MutableStateFlow<RecorderDraft?>(null)
+    override val draft: Flow<RecorderDraft?> = _draft
+
+    var saved: RecorderDraft? = null
+    var cleared = false
+    var currentDraft: RecorderDraft? = null
+
+    override suspend fun current(): RecorderDraft? = currentDraft
+
+    override fun save(
+        file: File,
+        durationMs: Long,
+    ) {
+        saved = RecorderDraft(file, durationMs)
+        _draft.value = saved
+    }
+
+    override fun clear() {
+        cleared = true
+        saved = null
+        currentDraft = null
+        _draft.value = null
     }
 }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderViewModelTest.kt
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.recorder
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class RecorderViewModelTest : AbstractRobolectricTest() {
+    private val application: Application get() = ApplicationProvider.getApplicationContext()
+    private val dispatcher = StandardTestDispatcher()
+    private lateinit var engine: FakeRecorderEngine
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        engine = FakeRecorderEngine()
+        File(application.cacheDir, "recordings").deleteRecursively()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun viewModel() = RecorderViewModel(application, engine, dispatcher)
+
+    @Test
+    fun `tapping record moves to Recording and starts the engine`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+
+            vm.onRecordTapped()
+            // Bounded advance only: the amplitude poll is an unbounded delay loop, so advanceUntilIdle
+            // would spin forever. Cancel the loop (clearForTest → onCleared) before the test ends.
+            advanceTimeBy(200)
+
+            assertThat(vm.state.value).isInstanceOf(RecorderState.Recording::class.java)
+            assertThat(engine.startCount).isEqualTo(1)
+            vm.clearForTest()
+        }
+
+    @Test
+    fun `a mic-in-use failure keeps Ready and emits a message`() =
+        runTest(dispatcher) {
+            engine.failOnStart = true
+            val vm = viewModel()
+
+            vm.onRecordTapped()
+            advanceUntilIdle()
+
+            assertThat(vm.state.value).isEqualTo(RecorderState.Ready)
+            assertThat(vm.events.first()).isInstanceOf(RecorderEvent.Message::class.java)
+        }
+
+    @Test
+    fun `stopping after at least a second moves to Review`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            vm.onRecordTapped()
+            advanceTimeBy(1_200)
+
+            vm.onStopTapped()
+            advanceUntilIdle()
+
+            assertThat(vm.state.value).isInstanceOf(RecorderState.Review::class.java)
+            assertThat(engine.stopCount).isEqualTo(1)
+        }
+
+    @Test
+    fun `stopping under a second discards and nudges`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            vm.onRecordTapped()
+            advanceTimeBy(400)
+
+            vm.onStopTapped()
+            advanceUntilIdle()
+
+            assertThat(vm.state.value).isEqualTo(RecorderState.Ready)
+            assertThat(vm.events.first()).isInstanceOf(RecorderEvent.Message::class.java)
+        }
+
+    @Test
+    fun `an interruption preserves a long-enough clip into Review`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            vm.onRecordTapped()
+            advanceTimeBy(2_000)
+
+            engine.onInterrupted?.invoke()
+            advanceUntilIdle()
+
+            assertThat(vm.state.value).isInstanceOf(RecorderState.Review::class.java)
+        }
+
+    @Test
+    fun `re-record from Review returns to Ready`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            vm.onRecordTapped()
+            advanceTimeBy(1_200)
+            vm.onStopTapped()
+            advanceUntilIdle()
+
+            vm.onReRecord()
+
+            assertThat(vm.state.value).isEqualTo(RecorderState.Ready)
+        }
+
+    @Test
+    fun `using the clip emits a handoff with the clip uri`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            vm.onRecordTapped()
+            advanceTimeBy(1_200)
+            vm.onStopTapped()
+            advanceUntilIdle()
+
+            vm.onUseClip()
+
+            assertThat(vm.events.first()).isInstanceOf(RecorderEvent.Handoff::class.java)
+        }
+
+    @Test
+    fun `clearing the ViewModel releases the engine`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            vm.onRecordTapped()
+            advanceTimeBy(200)
+
+            vm.clearForTest()
+
+            assertThat(engine.releaseCount).isAtLeast(1)
+        }
+}
+
+private class FakeRecorderEngine : RecorderEngine {
+    override var onMaxDurationReached: (() -> Unit)? = null
+    override var onInterrupted: (() -> Unit)? = null
+
+    var startCount = 0
+    var stopCount = 0
+    var releaseCount = 0
+    var failOnStart = false
+    var produced = true
+
+    override fun start(outputFile: File) {
+        if (failOnStart) error("mic busy")
+        startCount++
+        outputFile.parentFile?.mkdirs()
+        outputFile.createNewFile()
+    }
+
+    override fun stop(): Boolean {
+        stopCount++
+        return produced
+    }
+
+    override fun maxAmplitude(): Float = 0.5f
+
+    override fun release() {
+        releaseCount++
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderViewModelTest.kt
@@ -322,6 +322,73 @@ internal class RecorderViewModelTest : AbstractRobolectricTest() {
             // A restored draft is a recovered prior completion, not a new one — the funnel must not double-count.
             analytics.assertNotEmitted("recording_completed")
         }
+
+    @Test
+    fun `reaching Review builds the live envelope so review renders without decoding`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            vm.onRecordTapped()
+            advanceTimeBy(1_200)
+
+            vm.onStopTapped()
+            advanceUntilIdle()
+
+            val envelope = vm.capturedEnvelope
+            assertThat(envelope).isNotNull()
+            assertThat(envelope!!.size).isEqualTo(RECORDER_WAVEFORM_BARS)
+        }
+
+    @Test
+    fun `restoring a draft leaves no live envelope so the host decodes the file`() =
+        runTest(dispatcher) {
+            draftStore.currentDraft = RecorderDraft(File(application.cacheDir, "recordings/clip.m4a"), durationMs = 4_000)
+            val vm = viewModel()
+
+            vm.onEnter(resumeDraft = true)
+            advanceUntilIdle()
+
+            assertThat(vm.capturedEnvelope).isNull()
+        }
+
+    @Test
+    fun `re-record clears the live envelope`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            vm.onRecordTapped()
+            advanceTimeBy(1_200)
+            vm.onStopTapped()
+            advanceUntilIdle()
+
+            vm.onReRecord()
+
+            assertThat(vm.capturedEnvelope).isNull()
+        }
+
+    @Test
+    fun `an all-silent capture leaves no live envelope so the host decodes the real file`() =
+        runTest(dispatcher) {
+            engine.nextAmplitude = 0f // the getMaxAmplitude()-always-0 device quirk
+            val vm = viewModel()
+            vm.onRecordTapped()
+            advanceTimeBy(1_200)
+
+            vm.onStopTapped()
+            advanceUntilIdle()
+
+            assertThat(vm.state.value).isInstanceOf(RecorderState.Review::class.java)
+            assertThat(vm.capturedEnvelope).isNull()
+        }
+
+    @Test
+    fun `caching a decoded envelope lets a restored draft survive a recreate without re-decoding`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            val decoded = FloatArray(RECORDER_WAVEFORM_BARS) { 0.5f }
+
+            vm.cacheDecodedEnvelope(decoded)
+
+            assertThat(vm.capturedEnvelope).isSameInstanceAs(decoded)
+        }
 }
 
 private class FakeRecorderEngine : RecorderEngine {
@@ -333,6 +400,7 @@ private class FakeRecorderEngine : RecorderEngine {
     var releaseCount = 0
     var failOnStart = false
     var produced = true
+    var nextAmplitude = 0.5f
 
     override fun start(outputFile: File) {
         if (failOnStart) error("mic busy")
@@ -346,7 +414,7 @@ private class FakeRecorderEngine : RecorderEngine {
         return produced
     }
 
-    override fun maxAmplitude(): Float = 0.5f
+    override fun maxAmplitude(): Float = nextAmplitude
 
     override fun release() {
         releaseCount++

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivitySmokeTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivitySmokeTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.recorder
+
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.FakeAnalyticsTracker
+import com.github.barriosnahuel.vossosunboton.feature.playback.PlaybackState
+import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+
+internal class RecordingActivitySmokeTest : AbstractRobolectricTest() {
+    @get:Rule
+    val composeTestRule = createEmptyComposeRule()
+
+    private lateinit var engine: FakeEngine
+    private lateinit var fake: FakeAnalyticsTracker
+
+    @Before
+    fun setUp() {
+        mockkObject(PlayerControllerFactory)
+        every { PlayerControllerFactory.instance.playbackState } returns MutableStateFlow<PlaybackState?>(null)
+        every { PlayerControllerFactory.instance.stopPlayingSound() } answers { nothing }
+        engine = FakeEngine()
+        RecorderEngineProvider.setForTest(engine)
+        fake = FakeAnalyticsTracker()
+        AnalyticsTrackerProvider.setForTest(fake)
+    }
+
+    @After
+    fun tearDown() {
+        RecorderEngineProvider.setForTest(null)
+        AnalyticsTrackerProvider.setForTest(null)
+        unmockkAll()
+    }
+
+    @Test
+    fun emitsTheRecordSoundScreenView() {
+        ActivityScenario.launch(RecordingActivity::class.java).use {
+            fake.assertScreenView(CanonicalScreenName.RECORD_SOUND)
+        }
+    }
+
+    @Test
+    fun reachesResumedWithoutCrashing() {
+        ActivityScenario.launch(RecordingActivity::class.java).use { scenario ->
+            assertThat(scenario.state).isEqualTo(Lifecycle.State.RESUMED)
+        }
+    }
+
+    @Test
+    fun releasesTheEngineWhenDestroyed() {
+        ActivityScenario.launch(RecordingActivity::class.java).use { /* closing destroys the Activity */ }
+
+        assertThat(engine.releaseCount).isAtLeast(1)
+    }
+
+    private class FakeEngine : RecorderEngine {
+        override var onMaxDurationReached: (() -> Unit)? = null
+        override var onInterrupted: (() -> Unit)? = null
+        var releaseCount = 0
+
+        override fun start(outputFile: File) = Unit
+
+        override fun stop(): Boolean = true
+
+        override fun maxAmplitude(): Float = 0f
+
+        override fun release() {
+            releaseCount++
+        }
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/ImportHubSheetTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/ImportHubSheetTest.kt
@@ -7,7 +7,6 @@ package com.github.barriosnahuel.vossosunboton.ui.home
 
 import android.os.Build
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -43,13 +42,15 @@ internal class ImportHubSheetTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `record row is present, badged Soon, and disabled`() {
-        setHub()
+    fun `tapping the record row invokes onRecord`() {
+        var recorded = false
+        setHub(onRecord = { recorded = true })
 
-        composeTestRule.onNodeWithText("Record your first Bomp").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Soon").assertIsDisplayed()
-        // Inert by design: the merged row node carries the disabled semantic so TalkBack announces it.
-        composeTestRule.onNodeWithText("Record your first Bomp").assertIsNotEnabled()
+        composeTestRule.onNodeWithText("Record a Bomp").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Record a Bomp").performClick()
+        composeTestRule.waitForIdle() // the row animates the sheet closed before invoking onRecord
+
+        assertThat(recorded).isTrue()
     }
 
     @Test
@@ -73,12 +74,18 @@ internal class ImportHubSheetTest : AbstractRobolectricTest() {
 
     private fun setHub(
         onImport: () -> Unit = {},
+        onRecord: () -> Unit = {},
         onHowItWorks: () -> Unit = {},
         onDismiss: () -> Unit = {},
     ) {
         composeTestRule.setContent {
             AppTheme {
-                ImportHubSheet(onImport = onImport, onHowItWorks = onHowItWorks, onDismiss = onDismiss)
+                ImportHubSheet(
+                    onImport = onImport,
+                    onRecord = onRecord,
+                    onHowItWorks = onHowItWorks,
+                    onDismiss = onDismiss,
+                )
             }
         }
         composeTestRule.waitForIdle()

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenAnalyticsTest.kt
@@ -190,6 +190,22 @@ internal class LandingScreenAnalyticsTest : AbstractRobolectricTest() {
     }
 
     @Test
+    fun `tapping the record row in the Hub emits import_hub_record_selected`() {
+        val viewModel = givenAViewModel()
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithContentDescription(context.getString(R.string.app_hub_fab_description)).performClick()
+        composeTestRule.waitForIdle()
+        // The row animates the sheet closed before invoking onRecord (see ImportHubSheetTest).
+        composeTestRule.onNodeWithText(context.getString(R.string.app_hub_record)).performClick()
+        composeTestRule.waitForIdle()
+
+        fake.assertEmitted("import_hub_record_selected")
+    }
+
+    @Test
     fun `finishing the onboarding tour opens the Hub with source onboarding_finish`() {
         val viewModel = givenAViewModel()
         val context = ApplicationProvider.getApplicationContext<Context>()

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/RecorderDraftBannerTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/RecorderDraftBannerTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+
+internal class RecorderDraftBannerTest : AbstractRobolectricTest() {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `shows the unsaved-recording prompt`() {
+        composeTestRule.setContent { AppTheme { RecorderDraftBanner(onContinue = {}, onDiscard = {}) } }
+
+        composeTestRule.onNodeWithText("You have an unsaved recording").assertIsDisplayed()
+    }
+
+    @Test
+    fun `tapping continue invokes onContinue`() {
+        var continued = false
+        composeTestRule.setContent { AppTheme { RecorderDraftBanner(onContinue = { continued = true }, onDiscard = {}) } }
+
+        composeTestRule.onNodeWithText("Continue").performClick()
+
+        assertThat(continued).isTrue()
+    }
+
+    @Test
+    fun `tapping discard invokes onDiscard`() {
+        var discarded = false
+        composeTestRule.setContent { AppTheme { RecorderDraftBanner(onContinue = {}, onDiscard = { discarded = true }) } }
+
+        composeTestRule.onNodeWithText("Discard").performClick()
+
+        assertThat(discarded).isTrue()
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelDraftTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelDraftTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.feature.recorder.RecorderDraft
+import com.github.barriosnahuel.vossosunboton.feature.recorder.RecorderDraftStore
+import com.github.barriosnahuel.vossosunboton.model.data.manager.SoundsRepository
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class SoundsViewModelDraftTest : AbstractRobolectricTest() {
+    private val app: Application get() = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        runBlocking { SoundsRepository(app).clearForTest() }
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `discardDraft deletes the clip file and clears the draft store`() {
+        val clip =
+            File(app.cacheDir, "recordings")
+                .apply { mkdirs() }
+                .let { File(it, "draft.m4a") }
+                .apply { createNewFile() }
+        val draftStore = FakeDraftStore(RecorderDraft(clip, durationMs = 3_000))
+        val viewModel = SoundsViewModel(app, ioDispatcher = UnconfinedTestDispatcher(), draftStore = draftStore)
+
+        viewModel.discardDraft()
+
+        assertThat(clip.exists()).isFalse()
+        assertThat(draftStore.cleared).isTrue()
+    }
+
+    private class FakeDraftStore(
+        private val draftValue: RecorderDraft?,
+    ) : RecorderDraftStore {
+        var cleared = false
+        override val draft: Flow<RecorderDraft?> = MutableStateFlow(draftValue)
+
+        override suspend fun current(): RecorderDraft? = draftValue
+
+        override fun save(
+            file: File,
+            durationMs: Long,
+        ) = Unit
+
+        override fun clear() {
+            cleared = true
+        }
+    }
+}

--- a/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsEvent.kt
+++ b/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsEvent.kt
@@ -428,9 +428,16 @@ sealed class AnalyticsEvent(
      * Import-Hub funnel · INTENT. The user tapped the live "import audio from your device" row,
      * committing to pick a file (the system picker launches next). The genuine middle funnel step:
      * separates "opened the Hub but never engaged its CTA" from "engaged but bailed in the picker /
-     * naming screen". `hasFirstVariant = true`. The inert "record" row (badged "Soon") emits nothing.
+     * naming screen". `hasFirstVariant = true`.
      */
     object ImportHubImportSelected : AnalyticsEvent(name = "import_hub_import_selected", hasFirstVariant = true)
+
+    /**
+     * Import-Hub funnel · INTENT (record). The user tapped the live "record" row, committing to the
+     * in-app recorder (ADR 0019). Sibling of [ImportHubImportSelected]; together they split Hub intent
+     * between the two creation channels. `hasFirstVariant = true`.
+     */
+    object ImportHubRecordSelected : AnalyticsEvent(name = "import_hub_record_selected", hasFirstVariant = true)
 
     /**
      * Pre-stable-id `sounds_json` data was found on disk and recovered on read — the install carried

--- a/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsEvent.kt
+++ b/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsEvent.kt
@@ -440,6 +440,41 @@ sealed class AnalyticsEvent(
     object ImportHubRecordSelected : AnalyticsEvent(name = "import_hub_record_selected", hasFirstVariant = true)
 
     /**
+     * In-app recorder funnel · COMPLETION (ADR 0019). A capture reached the review state — via
+     * tap-to-stop, the 60 s auto-stop, or an interruption-preserve. The missing middle between the
+     * INTENT ([ImportHubRecordSelected]) and the conversion (`sound_add {source=record}`): lets us see
+     * where users drop (granted the mic but never recorded? recorded but never saved?). Not emitted on
+     * a draft *restore* — that is a recovered prior completion, not a new one.
+     */
+    object RecordingCompleted : AnalyticsEvent(name = "recording_completed", hasFirstVariant = true)
+
+    /**
+     * Outcome of the app's first runtime permission, `RECORD_AUDIO` (ADR 0019). [granted] is true on
+     * allow, false on deny — the grant rate of the recorder's gate. No first-variant: every result
+     * counts, not just the first request.
+     */
+    data class RecordPermissionResult(
+        val granted: Boolean,
+    ) : AnalyticsEvent(name = "record_permission_result", hasFirstVariant = false) {
+        override fun params(): Bundle =
+            Bundle().apply {
+                putBoolean(AnalyticsParam.GRANTED, granted)
+            }
+    }
+
+    /**
+     * Draft recovery (ADR 0019 § Draft recovery). The resume banner was offered on My Bomps for an
+     * unsaved recording. Denominator for the resume rate ([RecordingDraftResumed] / this).
+     */
+    object RecordingDraftBannerShown : AnalyticsEvent(name = "recording_draft_banner_shown", hasFirstVariant = true)
+
+    /** Draft recovery. The user resumed an unsaved recording from the banner ("Continue"). */
+    object RecordingDraftResumed : AnalyticsEvent(name = "recording_draft_resumed", hasFirstVariant = true)
+
+    /** Draft recovery. The user discarded an unsaved recording from the banner ("Discard"). */
+    object RecordingDraftDiscarded : AnalyticsEvent(name = "recording_draft_discarded", hasFirstVariant = true)
+
+    /**
      * Pre-stable-id `sounds_json` data was found on disk and recovered on read — the install carried
      * audio saved before sound records had a stable id (ADR 0008 → 0018), which now heals on read
      * instead of wiping the list. Gated one-shot via `tracker.markFiredOnce("legacy_sounds_recovered")`

--- a/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/CanonicalScreenName.kt
+++ b/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/CanonicalScreenName.kt
@@ -36,6 +36,9 @@ object CanonicalScreenName {
     /** On-demand onboarding tour (3 steps) opened from the import Hub or the My Bomps empty state. */
     const val ONBOARDING = "onboarding"
 
+    /** Immersive in-app recorder opened from the import Hub's Record row (ADR 0019). */
+    const val RECORD_SOUND = "record_sound"
+
     val ALL: List<String> =
         listOf(
             MY_SOUNDS,
@@ -50,5 +53,6 @@ object CanonicalScreenName {
             COLLECTION_CREATE,
             MANAGE_COLLECTIONS,
             ONBOARDING,
+            RECORD_SOUND,
         )
 }

--- a/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsCoverageMatrixTest.kt
+++ b/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsCoverageMatrixTest.kt
@@ -95,6 +95,7 @@ internal class AnalyticsCoverageMatrixTest {
                 "OnboardingDismissed",
                 "ImportHubOpened",
                 "ImportHubImportSelected",
+                "ImportHubRecordSelected",
                 "LegacySoundsRecovered",
             )
 
@@ -112,6 +113,7 @@ internal class AnalyticsCoverageMatrixTest {
                 CanonicalScreenName.COLLECTION_CREATE,
                 CanonicalScreenName.MANAGE_COLLECTIONS,
                 CanonicalScreenName.ONBOARDING,
+                CanonicalScreenName.RECORD_SOUND,
             )
 
         private val USER_PROPERTIES_WITH_REGRESSION_TEST: Set<String> =

--- a/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsCoverageMatrixTest.kt
+++ b/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsCoverageMatrixTest.kt
@@ -96,6 +96,11 @@ internal class AnalyticsCoverageMatrixTest {
                 "ImportHubOpened",
                 "ImportHubImportSelected",
                 "ImportHubRecordSelected",
+                "RecordingCompleted",
+                "RecordPermissionResult",
+                "RecordingDraftBannerShown",
+                "RecordingDraftResumed",
+                "RecordingDraftDiscarded",
                 "LegacySoundsRecovered",
             )
 

--- a/docs/adr/0019-in-app-bomp-recorder.md
+++ b/docs/adr/0019-in-app-bomp-recorder.md
@@ -89,13 +89,19 @@ is recorded **internally** so a future PR can decide on a UI treatment without a
 - New enum `SoundSource { RECORDED, IMPORTED, BUNDLED }` on `Sound` and (persisted) `StoredSound`,
   defaulting to `IMPORTED`. With `encodeDefaults = false` (existing `SoundsRepository.json` config),
   pre-existing payloads carry no `source` field and decode as `IMPORTED` — correct, since *all*
-  pre-recorder user content was imported. Bundled audio is `BUNDLED` (derivable: `file == null`).
-  The recorder save path sets `RECORDED`.
-- A one-shot `migrateSourceIfNeeded()` sweeps existing records on next app open and persists the
-  marking (file-backed → `IMPORTED`, file-less stub → `BUNDLED`, preserving any `RECORDED`), guarded
-  by a `source_migrated_v1` key. This mirrors `migrateVisibilityIfNeeded` exactly (ADR 0012) and rides
-  the recovery machinery of ADR 0018 (a missing/unknown enum coerces to the default via
-  `coerceInputValues = true`, so it can never wipe the list).
+  pre-recorder user content was imported. Bundled audio is `BUNDLED` (derivable: `file == null`, set
+  by the bundled constructor and re-derived in `mergeWithBundled`). The recorder save path sets
+  `RECORDED`. A missing/unknown enum coerces to the default via `coerceInputValues = true`, so the
+  field can never break ADR 0018's recovery.
+- **No backfill migration.** Unlike `isVisibleInMySounds` (ADR 0012), where the correct legacy value
+  (`false` for private-only) differs from the default (`true`) and *must* be seeded, `source`'s
+  correct legacy value (`IMPORTED`) **equals** the default — so every existing audio already reads the
+  right value with no sweep (file-backed → `IMPORTED` default; bundled → constructor). A
+  `migrateSourceIfNeeded()` was prototyped and dropped: it rewrote bytes nothing reads (the only value
+  it persisted, `BUNDLED` on file-less stubs, is never read — bundled domain `Sound`s come from
+  `PackagedAudios`). The default-on-read mechanism is the same one the codebase already trusts for
+  `durationMs`/`isFavorite`/`isPinned`. If a future need to pin a physical value arises (e.g. a default
+  change, or a raw out-of-app reader), add a targeted migration then.
 
 ### Out of scope (v1)
 Background/foreground-service recording (a Bomp is short and foreground), trimming (that's the
@@ -128,13 +134,13 @@ trimmer's waveform lib when it lands — preview is play/pause + timer for now).
   unreleased recorder can hold the mic globally until reboot on some Samsung/Xiaomi devices); audio
   focus loss must auto-stop. The Activity smoke test covers `onStop` with an active recorder.
 - **Device iteration is unavoidable and unaccelerable** — mic gain/quality across OEMs needs a human
-  ear (spec § 9.3). Headless tests cover the model/migration, permission-denial logic, and state
-  machine; the capture/preview loop is verified on a real device in a supervised pass.
+  ear (spec § 9.3). Headless tests cover the model + `source` provenance, permission-denial logic, and
+  state machine; the capture/preview loop is verified on a real device in a supervised pass.
 - **Ship gate (legal, not technical):** `privacy-policy.html` + `data-safety.html` in
   `push-me-ghpages` must be updated to disclose mic capture **before** release. Coordinate that merge
   with the ship.
-- **`RECORDED` has no producer until the recorder PR** — the enum value and migration land first
-  (model groundwork) so the recorder PR only sets `source = RECORDED`.
+- **`RECORDED` has no producer until the recorder PR** — the enum value + the `source` field land
+  first (model groundwork) so the recorder PR only sets `source = RECORDED`.
 
 ## Invariants
 
@@ -157,9 +163,9 @@ trimmer's waveform lib when it lands — preview is play/pause + timer for now).
 
 - Backlog spec: `../push-me-backlog/backlog/v2.3.0-03-bomp-recorder.md` (the "why" + estimates).
 - [ADR 0012](0012-explicit-my-sounds-visibility.md) (`migrateVisibilityIfNeeded`, the one-shot
-  backfill precedent) and [ADR 0018](0018-legacy-sounds-schema-migration.md) (the read-time recovery
-  the `source` default rides on).
-- [ADR 0008](0008-stable-sound-id.md) (the `Sound.id` scheme the migration keys on).
+  backfill precedent this decision deliberately diverges from) and
+  [ADR 0018](0018-legacy-sounds-schema-migration.md) (the read-time recovery the `source` default
+  rides on).
 - `WaveformExtractor.kt` (the Vault Visualizer/`RECORD_AUDIO` note this ADR clarifies).
 - `MediaRecorder`: https://developer.android.com/reference/android/media/MediaRecorder ;
   runtime permissions: https://developer.android.com/training/permissions/requesting

--- a/docs/adr/0019-in-app-bomp-recorder.md
+++ b/docs/adr/0019-in-app-bomp-recorder.md
@@ -3,6 +3,7 @@
 - **Status:** Accepted
 - **Date:** 2026-06-21
 - **Supersedes:** —
+- **Amended:** 2026-06-23 (§ Draft recovery)
 
 ## Context
 
@@ -108,6 +109,44 @@ Background/foreground-service recording (a Bomp is short and foreground), trimmi
 trimmer, `v2.3.0-04`), filters/noise-cancel/effects, multi-track, and a preview waveform (reuses the
 trimmer's waveform lib when it lands — preview is play/pause + timer for now).
 
+### Draft recovery (amendment 2026-06-23)
+The original design treated an unsaved clip as *ephemeral*: the temp file was blanket-purged on
+recorder entry and dropped in `onCleared`. On device this lost work in a normal flow — capturing a
+clip, leaving the app via **Home**, then re-opening from the **launcher** (not Recents). Because both
+`LandingActivity` and `RecordingActivity` are `singleTask` in one task, the launcher intent re-targets
+the root (`LandingActivity`) and `clearTop`s `RecordingActivity` — destroying the in-progress Review.
+A process death has the same effect. This is the natural extension of this ADR's existing **auto-stop
+*and preserve*** stance (§ Pause/resume): "preserve" now survives the Activity/process, not just an
+audio-focus blip. It is **not** background recording (still out of scope) and **not** resume-from-where-
+you-left of an in-progress capture (still no `MediaRecorder.pause()`); the recovered clip lands in
+**Review**, exactly where the user left it.
+
+- **What persists:** a *pending draft* = the temp clip's filename + its `durationMs`, in a dedicated
+  DataStore Preferences file (`RecorderDraftStore`). Persisted on entering Review; cleared on save
+  (handoff), re-record, explicit discard, or too-short. The clip bytes already live in
+  `cacheDir/recordings/`; the draft only points at them.
+- **Recovery UX:** a non-intrusive banner on the My Sounds list ("unsaved recording — Continue /
+  Discard"); Continue relaunches `RecordingActivity` with a resume flag → restores Review (file spared
+  from the purge); Discard deletes the clip + clears the draft.
+- **`cacheDir`, not `filesDir`:** the clip stays OS-evictable. If the OS reclaims the cache under real
+  storage pressure while the user is away, the draft self-heals to "none" (existence re-validated on
+  every read) rather than dangling. Accepted trade-off: a draft is a short-lived "you were mid-thing,"
+  not durable storage — and the alternative (`filesDir`) would need its own GC for abandoned clips.
+- **Durability of the clear:** `RecorderDraftStore` writes on a process-lived,
+  `limitedParallelism(1)` scope so a save-then-clear can't reorder and a clear survives the Activity
+  finishing immediately after (back-discard / handoff). A single process-singleton instance
+  (`RecorderDraftStoreProvider`) is shared by the recorder and the Landing banner so the two never race
+  across separate scopes.
+- **Clear at save-completion, not handoff:** "Use this" hands the clip to `AddButtonActivity` but does
+  **not** clear the draft; the save pipeline clears it only once the `Sound` is actually persisted. So
+  backing out of the name/save screen still leaves the clip recoverable from the banner.
+- **Best-effort boundary (backgrounding *mid-recording*):** if the OS reclaims the stopped Activity
+  *during* the auto-stop (before `engine.stop()` finalizes the `.m4a` moov atom), the clip is
+  unrecoverable — an unfinalized MediaRecorder file is corrupt regardless of any metadata we persist.
+  Guaranteeing this would need a foreground service, which is explicitly out of scope (recording is
+  foreground-only). Draft recovery covers the common cases (Review reached, launcher re-entry, process
+  death *after* a clip exists); the narrow mid-finalize kill is accepted.
+
 ## Options considered (and rejected)
 
 - **Wait for Nav3 before building** — avoids a retrofit, but blocks an independent, low-risk creation
@@ -149,6 +188,9 @@ trimmer's waveform lib when it lands — preview is play/pause + timer for now).
 - `SoundSource` is **internal** — no UI branches on it until a separate, deliberate decision.
 - Recorded files enter `AddButtonFeature.saveNewButtonAsync`; the recorder does not fork the
   persistence/validation path.
+- A draft (§ Draft recovery) is a *pointer* to a `cacheDir` clip, never durable storage — it must
+  re-validate file existence on read and self-heal to "none", and it must be cleared on every terminal
+  outcome (save, discard, re-record, too-short) so the banner never offers a clip the user resolved.
 
 ## Revisit criteria
 
@@ -157,7 +199,12 @@ trimmer's waveform lib when it lands — preview is play/pause + timer for now).
 - **Format tuning** — if the average recorded Bomp exceeds ~500 KB, drop the sample rate/bitrate or
   evaluate OPUS on devices that support it.
 - **Push-to-talk** — add as an optional setting if capture-speed data justifies it.
-- **Nav3** — fold `RecordingActivity` into the graph once `v2.3.0-02` migrates the rest.
+- **Nav3** — fold `RecordingActivity` into the graph once `v2.3.0-02` migrates the rest. The draft
+  banner's launcher-re-entry problem (§ Draft recovery) is a task-model artifact of the standalone
+  Activity; a Nav3 destination would not `clearTop` the recorder, so revisit whether the draft store is
+  still needed (the process-death case would remain — likely keep it).
+- **Durable drafts** — if telemetry shows OS cache eviction loses drafts often enough to matter, move
+  the clip to `filesDir` with its own abandoned-clip GC.
 
 ## Cross-references
 

--- a/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/Sound.kt
+++ b/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/Sound.kt
@@ -35,12 +35,19 @@ data class Sound(
      * Defaults to `true`; a sound created straight into the Vault flow is the only born-`false` case.
      */
     val isVisibleInMySounds: Boolean = true,
+    /**
+     * Internal provenance (ADR 0019). Defaults to [SoundSource.IMPORTED] — the case for every audio
+     * created via the import path (`Sound(id, name, file)`); the bundled constructor below sets
+     * [SoundSource.BUNDLED], and the recorder save path sets [SoundSource.RECORDED]. No UI branches
+     * on it yet.
+     */
+    val source: SoundSource = SoundSource.IMPORTED,
 ) : Parcelable {
     constructor(id: String, name: String, file: String?) : this(id, name, file, 0, false, false)
     constructor(
         name: String,
         @RawRes rawRes: Int = 0,
-    ) : this("bundled:$rawRes", name, null, rawRes, false, false)
+    ) : this("bundled:$rawRes", name, null, rawRes, false, false, source = SoundSource.BUNDLED)
 
     /**
      * Indicates whether or not this sound is bundled in the app or is a user's custom sound.

--- a/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/SoundSource.kt
+++ b/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/SoundSource.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Where a [Sound] came from. **Internal** provenance only — no UI branches on it yet (ADR 0019); it
+ * exists so a recorded audio is distinguishable from an imported one without a second data migration
+ * when a UI treatment is eventually decided.
+ *
+ * [IMPORTED] is the persisted default: every pre-recorder user audio arrived via the share sheet or
+ * the import picker, so a payload written before this field decodes as [IMPORTED] (the desired
+ * post-update state). [BUNDLED] is derivable (`file == null`) and set on packaged audio; [RECORDED]
+ * is set by the in-app recorder save path. An unknown value coerces to [IMPORTED] (the repository's
+ * `coerceInputValues = true`), so a forward-incompatible payload can never break decoding.
+ */
+@Serializable
+enum class SoundSource {
+    RECORDED,
+    IMPORTED,
+    BUNDLED,
+}

--- a/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/StoredSound.kt
+++ b/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/StoredSound.kt
@@ -5,6 +5,7 @@
  */
 package com.github.barriosnahuel.vossosunboton.model.data
 
+import com.github.barriosnahuel.vossosunboton.model.SoundSource
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -19,4 +20,9 @@ internal data class StoredSound(
     // disk, so payloads written before this field decode as `true` — the desired post-update state
     // for every already-visible audio. The one-time migration flips private-only audios to `false`.
     val isVisibleInMySounds: Boolean = true,
+    // ADR 0019. Same `encodeDefaults = false` mechanic: pre-recorder payloads carry no `source` and
+    // decode as IMPORTED — correct, since all existing user content was imported, so no backfill
+    // migration is needed (the default already yields the right value on read). The recorder save
+    // path stores RECORDED; bundled audio derives BUNDLED from its constructor.
+    val source: SoundSource = SoundSource.IMPORTED,
 )

--- a/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepository.kt
+++ b/model/src/main/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepository.kt
@@ -396,6 +396,7 @@ class SoundsRepository(
             dateAdded = dateAdded,
             isPinned = isPinned,
             isVisibleInMySounds = isVisibleInMySounds,
+            source = source,
         )
     }
 
@@ -411,6 +412,10 @@ class SoundsRepository(
             // upsert so a generic `save` can never silently reset a hidden audio back to visible.
             // A brand-new audio (previous == null) takes the Sound's value (default `true`).
             isVisibleInMySounds = previous?.isVisibleInMySounds ?: isVisibleInMySounds,
+            // Provenance is immutable per audio (ADR 0019): preserve the stored value on an upsert so
+            // a generic `save` can't reset a RECORDED audio to the IMPORTED default. New audio takes
+            // the Sound's value (recorder passes RECORDED; import keeps the default).
+            source = previous?.source ?: source,
         )
 
     private fun validateName(name: String) {

--- a/model/src/test/java/com/github/barriosnahuel/vossosunboton/model/SoundSourceTest.kt
+++ b/model/src/test/java/com/github/barriosnahuel/vossosunboton/model/SoundSourceTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.model
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Constructor → [SoundSource] mapping (ADR 0019): the bundled constructor is the sole BUNDLED
+ * producer; the import constructor and the default land on IMPORTED. RECORDED is set explicitly by
+ * the recorder save path, never by a constructor.
+ */
+class SoundSourceTest {
+    @Test
+    fun `bundled constructor tags the sound as BUNDLED`() {
+        assertThat(Sound("bell", 42).source).isEqualTo(SoundSource.BUNDLED)
+    }
+
+    @Test
+    fun `import constructor defaults the source to IMPORTED`() {
+        assertThat(Sound("custom:bell", "bell", "bell.mp3").source).isEqualTo(SoundSource.IMPORTED)
+    }
+
+    @Test
+    fun `primary constructor defaults the source to IMPORTED`() {
+        assertThat(Sound("custom:bell", "bell", "bell.mp3", 0, false).source).isEqualTo(SoundSource.IMPORTED)
+    }
+}

--- a/model/src/test/java/com/github/barriosnahuel/vossosunboton/model/TestSounds.kt
+++ b/model/src/test/java/com/github/barriosnahuel/vossosunboton/model/TestSounds.kt
@@ -20,6 +20,7 @@ internal fun testSound(
     dateAdded: Long? = null,
     isPinned: Boolean = false,
     isVisibleInMySounds: Boolean = true,
+    source: SoundSource = if (file != null) SoundSource.IMPORTED else SoundSource.BUNDLED,
 ): Sound =
     Sound(
         id = if (file != null) "custom:$name" else "bundled:$rawRes",
@@ -31,4 +32,5 @@ internal fun testSound(
         dateAdded = dateAdded,
         isPinned = isPinned,
         isVisibleInMySounds = isVisibleInMySounds,
+        source = source,
     )

--- a/model/src/test/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepositoryTest.kt
+++ b/model/src/test/java/com/github/barriosnahuel/vossosunboton/model/data/manager/SoundsRepositoryTest.kt
@@ -10,6 +10,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.commons.file.getFile
 import com.github.barriosnahuel.vossosunboton.model.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.github.barriosnahuel.vossosunboton.model.SoundSource
 import com.github.barriosnahuel.vossosunboton.model.testSound
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.async
@@ -490,5 +491,48 @@ internal class SoundsRepositoryTest : AbstractRobolectricTest() {
                     .first { it.id == "custom:priv" }
                     .isVisibleInMySounds,
             ).isTrue()
+        }
+
+    @Test
+    fun `save persists and exposes a RECORDED source`() =
+        runTest {
+            repo.save(testSound("rec", "rec.mp3", source = SoundSource.RECORDED))
+
+            assertThat(
+                repo.sounds
+                    .first()
+                    .first { it.id == "custom:rec" }
+                    .source,
+            ).isEqualTo(SoundSource.RECORDED)
+        }
+
+    @Test
+    fun `a generic save preserves a previously RECORDED source`() =
+        runTest {
+            repo.save(testSound("rec", "rec.mp3", source = SoundSource.RECORDED))
+            // A later generic save (e.g. carrying the default IMPORTED) must not downgrade the origin.
+            repo.save(testSound("rec", "rec.mp3", source = SoundSource.IMPORTED))
+
+            assertThat(
+                repo.sounds
+                    .first()
+                    .first { it.id == "custom:rec" }
+                    .source,
+            ).isEqualTo(SoundSource.RECORDED)
+        }
+
+    @Test
+    fun `decoding coerces an unknown source value to IMPORTED`() =
+        runTest {
+            // A forward-incompatible payload (a future source this build doesn't know) must not break
+            // decoding — `coerceInputValues = true` falls it back to the IMPORTED default (ADR 0019).
+            repo.setRawJsonForTest("""[{"id":"custom:strm","name":"strm","file":"strm.mp3","source":"STREAMED"}]""")
+
+            assertThat(
+                repo.sounds
+                    .first()
+                    .first { it.id == "custom:strm" }
+                    .source,
+            ).isEqualTo(SoundSource.IMPORTED)
         }
 }

--- a/scripts/check-security-test-count.sh
+++ b/scripts/check-security-test-count.sh
@@ -20,7 +20,7 @@
 
 set -euo pipefail
 
-EXPECTED_COUNT=31
+EXPECTED_COUNT=32
 
 SCAN_ROOTS=(
   app/src/test


### PR DESCRIPTION
### Summary

**Record a Bomp in the app**
1. On **My Bomps**, tap the **+**
2. In the sheet, tap **Record a Bomp** (was a disabled "Soon" row)
3. Allow the mic → tap to record → tap to stop → listen back on the clip's **real waveform**
4. Tap **Use this** → name it → **Save**

**before:** the only way to create a Bomp was importing an existing file; recording was a dead "Soon" badge.
**after:** you can record a new Bomp end-to-end inside the app, and it lands in My Bomps like any other.

**Pick up an unsaved recording**
1. Record a clip, then leave the app (Home) without saving
2. Re-open Push Me from the launcher

**before:** the in-progress recording was silently lost (the launcher destroys the recorder screen).
**after:** a banner on My Bomps offers **Continue** (back into review) or **Discard** — surviving backgrounding, launcher re-entry, and process death.

### Technical detail

Carries the `SoundSource` groundwork + ADR 0019 (amended: § Draft recovery); the recorder is the feature on top.

- **`RecordingActivity`** — full-screen `FragmentActivity` (`exported=false`, `configChanges` so rotation is in-place). `RecorderViewModel` (`StateFlow` ready→recording→review, `Channel` events) + `RecorderEngine` (`MediaRecorder` AAC/M4A, audio focus, idempotent release) + `RecorderTempFiles`.
- **Real review waveform, rendered instantly** — built from the amplitude samples captured live during recording (`buildRecorderEnvelope`), so review shows the real envelope with no post-stop decode flash. A restored draft (no live samples) still decodes the file via `WaveformExtractor`'s `content://` overload; the decoded result is cached back so a config recreate reuses it. An all-silent capture (incl. the `getMaxAmplitude()`-always-0 device quirk) decodes the file instead of showing a fake flat line.
- **Draft recovery** — `RecorderDraftStore` (interface + DataStore impl, process-singleton via `RecorderDraftStoreProvider`, file-existence self-heal). Persisted on entering review; cleared by the **save pipeline once the Sound is actually persisted** (not at handoff, so backing out of the name screen stays recoverable); a fresh recorder entry always spares the draft's file.
- **`saveNewButtonAsync`** derives the destination extension from the validated MIME and threads `SoundSource` (recorder = `RECORDED`).
- **Funnel analytics** — `recording_completed` (review reached, not on a draft restore), `record_permission_result` (mic grant/deny), and the draft-recovery trio `recording_draft_banner_shown` / `_resumed` / `_discarded`; closes intent→completion→conversion + measures recovery adoption.
- **Tap-to-toggle, no manual pause**; 60s/1s bounds; focus-loss + background auto-stop & preserve.
- New `RECORD_AUDIO` permission + `import_hub_record_selected` event + `record_sound` screen.

### Code review tips

- **Concurrency:** a single `transitioning` flag serializes the start↔stop transition across its suspension points — guards against double-tap on Record (second `MediaRecorder`/mic leak) and on Stop (deleting a valid clip down the discard branch).
- **Draft ownership:** `onCleared` no longer deletes the temp (a review clip is now a recoverable draft); explicit discard/re-record/back delete it durably; the save pipeline clears it on success. Two surfaces (recorder VM + banner VM) share **one** store instance/scope so a save↔clear can't race.
- **`onRecordTapped` free-space check moved off-main** (was a main-thread `usableSpace` syscall → StrictMode crash gate).
- **`permanentlyDenied`/`showDiscard` are `rememberSaveable`** — survive a locale/theme recreate.
- **Known best-effort limit (ADR 0019 § Draft recovery):** backgrounding *mid-recording* then an immediate OS kill (before `engine.stop()` finalizes the `.m4a`) is unrecoverable — a foreground service is out of scope.
- **Baseline Profile not yet regenerated** — the banner adds a flow collection to the My Bomps first frame; regenerate on the reconnected Pixel before merge (perf-only, never broken).

### Already tested

- Unit + Robolectric: `./gradlew check` green — incl. `RecorderViewModelTest` (persist/restore/clear, double-tap-record-once, double-tap-stop-once, fresh-entry-keeps-draft), `DataStoreRecorderDraftStoreTest`, `RecorderDraftBannerTest`, `AddButtonScreenAnalyticsTest` (recorded save clears draft / import doesn't). `RecorderDraftBannerFlowTest` (draft → banner on My Bomps → Discard tears it down) and `SoundsViewModelDraftTest` (`discardDraft` deletes the clip + clears the store) close the banner-integration coverage gap.
- **Instrumented (cold-boot wrapper, CI doesn't run it): recorder suite green** — `RecorderFlowTest` (stop→review, config-recreate keeps recording, destroy-while-recording), `RecorderResumeDraftTest` (seed draft → relaunch resume → Review), `WaveformExtractorContentUriTest` (real envelope from a `content://`).
- Waveform: `RecorderEnvelopeTest` (bucket/interpolate/silence→null) + `RecorderViewModelTest` (envelope built on stop, null on restore/silence, decoded-envelope cache). Multi-agent code review run on the Option-1 diff; all confirmed findings fixed. Analytics: `RecorderViewModelTest` asserts `recording_completed` fires on review (and NOT on restore); `RecorderDraftBannerFlowTest` asserts the banner trio. `record_permission_result` is DebugView-verified (the system permission callback isn't deterministically drivable in either harness).
- **Multi-agent code review** run on the diff; all confirmed findings fixed.
- Manual on a Pixel (user-verified): real waveform + preview progress, bugs #2 (rotation) & #4 (preview), and the full draft-recovery flow (record → Home → re-open from launcher → banner → Continue/Discard). Pending only the Baseline Profile regen on-device.




