### PR TITLE
fix(analytics): shorten user property names over Firebase's 24-char limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - `legacy_sounds_recovered` analytics event (one-shot per install) so the pre-stable-id population is countable and the migration's retirement is verifiable (ADR 0018)
 - Documented the GitHub release procedure (tag from develop, notes from the store change file, R8 mapping archived as the sole asset) and the Firebase CLI/MCP path for reading deobfuscated Crashlytics stacks
 
+#### Fixed
+- Shortened seven collection/Vault user property names that exceeded Firebase's 24-character limit and were being dropped before reaching BigQuery, and added a build-time guard so over-length names can't ship again
+
 #### Changed
 - Kotlin compiler warnings now fail the build (`allWarningsAsErrors`, binary/unconditional) so they can't accumulate
 - `sounds_json` decoding is now element-by-element with id de-dup and a fast path, so one corrupt record can't wipe the list and clean payloads pay no recovery cost (ADR 0018)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -737,6 +737,10 @@ manually.
 
 - `snake_case` lowercase. Reserved Firebase event names are forbidden — check
   <https://firebase.google.com/docs/analytics/events> before naming.
+- **Length limits.** User property names ≤ **24** chars; event and param names
+  ≤ 40. Firebase drops an over-length name silently (`E/FA Name is too long…`)
+  so it never reaches BigQuery — invisible until someone reads logcat.
+  `AnalyticsUserPropertyNameTest` enforces the user-property bound at build time.
 - Describe the **product fact**, not the **UI mechanic**: `about_credits_open`,
   not `about_credits_expand`.
 - `screen_view` for full destinations; custom events for discrete actions.

--- a/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsUserProperty.kt
+++ b/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsUserProperty.kt
@@ -6,10 +6,12 @@
 package com.github.barriosnahuel.vossosunboton.commons.android.analytics
 
 /**
- * Canonical Firebase user property names emitted by [AnalyticsTracker.setUserProperty]. The two `lifetime_*`
- * properties also double as keys into the [CounterStore], so the same constant must be used on both sides — that's
- * exactly what this object enforces. The regression net (`AnalyticsCoverageMatrixTest`) enumerates these and fails
- * when a new entry is added without a matching call-site test.
+ * Canonical Firebase user property names emitted by [AnalyticsTracker.setUserProperty]. Every `lifetime_*` property
+ * also doubles as a key into the [CounterStore], so the same constant must be used on both sides — that's exactly
+ * what this object enforces. Names must satisfy Firebase's constraints (≤ 24 chars, allowed charset, no reserved
+ * prefix); `AnalyticsUserPropertyNameTest` fails the build otherwise — an over-length name is dropped silently and
+ * never reaches BigQuery. `AnalyticsCoverageMatrixTest` enumerates these and fails when a new entry is added without
+ * a matching call-site test.
  */
 object AnalyticsUserProperty {
     /** Snapshot of the user-created sound count. Updated on add/delete. */
@@ -19,13 +21,13 @@ object AnalyticsUserProperty {
     const val CURRENT_PINNED = "current_pinned"
 
     /** Snapshot — number of public (My Sounds) user collections. System collections excluded. */
-    const val CURRENT_COLLECTIONS_PUBLIC = "current_collections_public"
+    const val CURRENT_COLLECTIONS_PUBLIC = "current_public_colls"
 
     /** Snapshot — number of Vault (private) user collections. Seeded "Baúl" system collection excluded. */
-    const val CURRENT_COLLECTIONS_PRIVATE = "current_collections_private"
+    const val CURRENT_COLLECTIONS_PRIVATE = "current_private_colls"
 
     /** Snapshot — number of audios that belong to at least one user collection. Engagement signal. */
-    const val CURRENT_AUDIOS_IN_COLLECTIONS = "current_audios_in_collections"
+    const val CURRENT_AUDIOS_IN_COLLECTIONS = "current_audios_in_colls"
 
     // Four mutually-exclusive snapshots that classify every user audio by where it lives. They sum
     // to the total user-created (non-bundled) audio count, so the dashboard reads as a pie of how
@@ -52,16 +54,16 @@ object AnalyticsUserProperty {
     const val LIFETIME_PLAYS = "lifetime_plays"
 
     /** Monotonic counter — total collections the user has created over the lifetime of the install. */
-    const val LIFETIME_COLLECTION_CREATES = "lifetime_collection_creates"
+    const val LIFETIME_COLLECTION_CREATES = "lifetime_coll_creates"
 
     /** Monotonic counter — total collections the user has deleted over the lifetime of the install. */
-    const val LIFETIME_COLLECTION_DELETES = "lifetime_collection_deletes"
+    const val LIFETIME_COLLECTION_DELETES = "lifetime_coll_deletes"
 
     /** Monotonic counter — total collection renames over the lifetime of the install. */
-    const val LIFETIME_COLLECTION_RENAMES = "lifetime_collection_renames"
+    const val LIFETIME_COLLECTION_RENAMES = "lifetime_coll_renames"
 
     /** Monotonic counter — total assign + unassign toggles via the assign-to-collection sheet. */
-    const val LIFETIME_COLLECTION_ASSIGNS = "lifetime_collection_assigns"
+    const val LIFETIME_COLLECTION_ASSIGNS = "lifetime_coll_assigns"
 
     /** Monotonic counter — total successful Vault biometric unlocks. */
     const val LIFETIME_VAULT_UNLOCKS = "lifetime_vault_unlocks"

--- a/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsUserPropertyNameTest.kt
+++ b/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsUserPropertyNameTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.commons.android.analytics
+
+import com.google.common.truth.Truth.assertWithMessage
+import org.junit.Test
+
+/**
+ * Catalogue guard for [AnalyticsUserProperty]. Firebase Analytics silently drops a user property whose name breaks
+ * its constraints (`E/FA Name is too long…`), so an over-length name never reaches the dashboard or BigQuery and the
+ * failure is invisible until someone reads logcat. These tests fail at build time instead.
+ *
+ * Limits per https://firebase.google.com/docs/analytics/user-properties (Android): name ≤ 24 chars, starts with a
+ * letter, alphanumeric + underscore only, no reserved `firebase_` / `google_` / `ga_` prefix.
+ */
+internal class AnalyticsUserPropertyNameTest {
+    @Test
+    fun `every user property name fits the Firebase 24-character limit`() {
+        val tooLong = AnalyticsUserProperty.ALL.filter { it.length > MAX_NAME_LENGTH }
+        assertWithMessage(
+            "User property names exceeding Firebase's $MAX_NAME_LENGTH-char limit are dropped silently. Shorten them" +
+                " in AnalyticsUserProperty.",
+        ).that(tooLong).isEmpty()
+    }
+
+    @Test
+    fun `every user property name uses Firebase's allowed character set`() {
+        val malformed = AnalyticsUserProperty.ALL.filterNot { NAME_PATTERN.matches(it) }
+        assertWithMessage(
+            "User property names must start with a letter and contain only letters, digits and underscores.",
+        ).that(malformed).isEmpty()
+    }
+
+    @Test
+    fun `user property names are unique`() {
+        val duplicates =
+            AnalyticsUserProperty.ALL
+                .groupingBy { it }
+                .eachCount()
+                .filterValues { it > 1 }
+                .keys
+        assertWithMessage(
+            "Two constants resolve to the same user property name; Firebase would silently merge their values.",
+        ).that(duplicates).isEmpty()
+    }
+
+    @Test
+    fun `no user property name uses a reserved Firebase prefix`() {
+        val reserved = AnalyticsUserProperty.ALL.filter { name -> RESERVED_PREFIXES.any { name.startsWith(it) } }
+        assertWithMessage(
+            "User property names cannot start with a reserved prefix ($RESERVED_PREFIXES); Firebase rejects them.",
+        ).that(reserved).isEmpty()
+    }
+
+    private companion object {
+        private const val MAX_NAME_LENGTH = 24
+        private val NAME_PATTERN = Regex("^[A-Za-z][A-Za-z0-9_]*$")
+        private val RESERVED_PREFIXES = listOf("firebase_", "google_", "ga_")
+    }
+}


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change.

Protects collection/Vault telemetry that production was silently losing since **v2.1.0**: seven user property names exceeded Firebase's 24-character limit, so Firebase dropped them client-side (`E/FA Name is too long`) before they ever reached BigQuery.

### Technical detail

Shorten the seven over-length user property values and add a TDD guard so this class of bug can't ship again.

- **`AnalyticsUserProperty.kt`** — shortened the 7 string values; the **Kotlin symbols are unchanged**, so every call-site (`SoundsViewModel`, `VaultScreen`, `ShareFeature`) and the existing analytics tests (which reference symbols, not literals) are untouched. New longest name is 23 chars.
  - `current_collections_public`→`current_public_colls`, `current_collections_private`→`current_private_colls`, `current_audios_in_collections`→`current_audios_in_colls`, `lifetime_collection_{creates,deletes,renames,assigns}`→`lifetime_coll_{…}`.
- **`AnalyticsUserPropertyNameTest`** (new) — guard over `AnalyticsUserProperty.ALL`: length ≤ 24, Firebase charset, no reserved prefix, uniqueness. Red on the 7 names before the fix → green after (true TDD).
- **`CONTRIBUTING.md` / KDoc** — documented the length limits and corrected the stale "two `lifetime_*`" note (all `lifetime_*` are counter keys).
- **Out of scope** — an equivalent guard for event/param names (40-char limit) lives in a separate `AnalyticsEvent` catalogue; left as a follow-up.

### Code review tips

- The 4 `lifetime_coll_*` are also **DataStore counter keys** (`DataStoreCounterStore`): the new value is a new key, so each user's local counter **resets once**. No analytics continuity lost — these never reached Firebase/BQ, so they start reporting clean from 0. The old key lingers as inert cruft in `.preferences_pb`; nothing reads it. The 3 `current_*` are recomputed snapshots (not DataStore-backed) → no reset.
- **BigQuery pre-validation** against `bomp-prod.analytics_536876881`: the 7 over-length names have **zero rows**; the 9 in-bounds properties all have hits. Confirms the silent drop and a continuity-free rename.
- Symbols intentionally kept (e.g. `LIFETIME_COLLECTION_CREATES` = `"lifetime_coll_creates"`) to confine the diff to one file; minor symbol↔value wording drift is acceptable.
- Instrumented suite **N/A** — analytics-catalogue-only; no Composable / navigation / user-facing-persistence surface.

### Already tested

- Local: `./gradlew check -x test` and `./gradlew test` green (CI re-runs the same).
