### PR TITLE
refactor(waveform): share EnvelopeWaveform + normalize helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Shortened seven collection/Vault user property names that exceeded Firebase's 24-character limit and were being dropped before reaching BigQuery, and added a build-time guard so over-length names can't ship again
 
 #### Changed
+- De-duplicated the Vault listen and recorder-review waveforms into one shared `EnvelopeWaveform` component, and the `0.06f` floor + normalize loop into a single `WaveformNormalization` helper (ADR 0020)
 - Kotlin compiler warnings now fail the build (`allWarningsAsErrors`, binary/unconditional) so they can't accumulate
 - `sounds_json` decoding is now element-by-element with id de-dup and a fast path, so one corrupt record can't wipe the list and clean payloads pay no recovery cost (ADR 0018)
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderEnvelope.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderEnvelope.kt
@@ -5,13 +5,14 @@
  */
 package com.github.barriosnahuel.vossosunboton.feature.recorder
 
-import kotlin.math.max
+import com.github.barriosnahuel.vossosunboton.feature.waveform.normalizeEnvelope
 
 /**
  * Builds the recorder review envelope from the amplitude samples captured live during recording (one
  * per poll tick), so the review wave renders **instantly** without re-decoding the file — killing the
- * post-stop placeholder gap (ADR 0019). [barCount] bars normalized to loudest = 1.0 with a [MIN_BAR]
- * floor (same floor as the decoded `PeakAccumulator`, so a live-fed envelope looks like a decoded one).
+ * post-stop placeholder gap (ADR 0019). [barCount] bars normalized to loudest = 1.0 with the shared
+ * `WAVEFORM_MIN_BAR` floor (same floor as the decoded `PeakAccumulator`, so a live-fed envelope looks
+ * like a decoded one).
  *
  * Returns `null` — caller decodes the real file instead — when there is **no usable live signal**:
  * empty input, or every sample silent. The all-silent case matters because some devices' MediaRecorder
@@ -44,8 +45,5 @@ internal fun buildRecorderEnvelope(
     val loudest = raw.maxOrNull() ?: 0f
     // No usable signal (true silence, or the getMaxAmplitude()-always-0 device quirk) → null so the
     // caller decodes the real file instead of showing a fake flat line for a clip that has audio.
-    return if (loudest <= 0f) null else FloatArray(barCount) { max(MIN_BAR, raw[it] / loudest) }
+    return if (loudest <= 0f) null else normalizeEnvelope(raw, loudest)
 }
-
-/** Baseline floor for a normalized bar — matches the decoded envelope's floor (`PeakAccumulator`). */
-private const val MIN_BAR = 0.06f

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreen.kt
@@ -46,14 +46,12 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.progressBarRangeInfo
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.github.barriosnahuel.vossosunboton.R
-import com.github.barriosnahuel.vossosunboton.feature.vault.WaveformExtractor
+import com.github.barriosnahuel.vossosunboton.feature.waveform.EnvelopeWaveform
 import com.github.barriosnahuel.vossosunboton.ui.AppIcons
 import com.github.barriosnahuel.vossosunboton.ui.home.formatDuration
 import com.github.barriosnahuel.vossosunboton.ui.theme.ImmersiveListenTheme
@@ -173,56 +171,15 @@ private fun RecorderVisual(
         when (state) {
             is RecorderState.Recording -> LiveWaveform(amplitude = state.amplitude, tick = state.elapsedMs)
             is RecorderState.Review ->
-                ReviewWaveform(
+                EnvelopeWaveform(
                     progress = if (state.durationMs > 0L) previewPositionMs.toFloat() / state.durationMs else 0f,
                     peaks = peaks,
+                    contentDescription = stringResource(R.string.app_recorder_cd_waveform),
+                    barCount = RECORDER_WAVEFORM_BARS,
+                    barFill = WAVEFORM_BAR_FILL,
+                    modifier = Modifier.fillMaxWidth().height(WAVEFORM_HEIGHT),
                 )
             RecorderState.Ready -> LiveWaveform(amplitude = 0f, tick = 0L)
-        }
-    }
-}
-
-/**
- * Playback-progress waveform for the review state: the clip's real amplitude envelope (decoded by
- * [WaveformExtractor], same as the listen screen), whose left portion fills with `primary` as the
- * preview plays (the rest dimmed) and exposes [progress] via semantics. A neutral placeholder
- * baseline shows while [peaks] is still decoding. Distinct from [LiveWaveform] (the live input meter).
- */
-@Composable
-private fun ReviewWaveform(
-    progress: Float,
-    peaks: FloatArray?,
-    modifier: Modifier = Modifier,
-) {
-    val fraction = progress.coerceIn(0f, 1f)
-    val playedColor = MaterialTheme.colorScheme.primary
-    val unplayedColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = WAVEFORM_UNPLAYED_ALPHA)
-    val label = stringResource(R.string.app_recorder_cd_waveform)
-    Canvas(
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .height(WAVEFORM_HEIGHT)
-                .semantics {
-                    contentDescription = label
-                    progressBarRangeInfo = ProgressBarRangeInfo(fraction, 0f..1f)
-                },
-    ) {
-        val slot = size.width / RECORDER_WAVEFORM_BARS
-        val barWidth = slot * WAVEFORM_BAR_FILL
-        val centerY = size.height / 2f
-        val corner = CornerRadius(barWidth / 2f, barWidth / 2f)
-        for (i in 0 until RECORDER_WAVEFORM_BARS) {
-            val amplitude = peaks?.getOrNull(i) ?: WAVEFORM_PLACEHOLDER_FRACTION
-            val barHeight = amplitude.coerceIn(WAVEFORM_MIN_FRACTION, 1f) * size.height
-            val played = (i + WAVEFORM_BAR_CENTER) / RECORDER_WAVEFORM_BARS <= fraction
-            val x = i * slot + (slot - barWidth) / 2f
-            drawRoundRect(
-                color = if (played) playedColor else unplayedColor,
-                topLeft = Offset(x, centerY - barHeight / 2f),
-                size = Size(barWidth, barHeight),
-                cornerRadius = corner,
-            )
         }
     }
 }
@@ -506,11 +463,6 @@ private val WAVEFORM_HEIGHT = 120.dp
 internal const val RECORDER_WAVEFORM_BARS = 48
 private const val WAVEFORM_BAR_FILL = 0.5f
 private const val WAVEFORM_MIN_FRACTION = 0.06f
-private const val WAVEFORM_UNPLAYED_ALPHA = 0.30f
-private const val WAVEFORM_BAR_CENTER = 0.5f
-
-// Neutral baseline shown while the real envelope is still decoding (matches the listen screen).
-private const val WAVEFORM_PLACEHOLDER_FRACTION = 0.12f
 private const val GLOW_CENTER_ALPHA = 0.16f
 private const val GLOW_MID_ALPHA = 0.04f
 private const val GLOW_STOP_CENTER = 0.0f

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.feature.waveform.EnvelopeWaveform
+import com.github.barriosnahuel.vossosunboton.feature.waveform.WAVEFORM_MIN_BAR
 import com.github.barriosnahuel.vossosunboton.ui.AppIcons
 import com.github.barriosnahuel.vossosunboton.ui.home.formatDuration
 import com.github.barriosnahuel.vossosunboton.ui.theme.ImmersiveListenTheme
@@ -207,7 +208,7 @@ private fun LiveWaveform(
         val centerY = size.height / 2f
         val corner = CornerRadius(barWidth / 2f, barWidth / 2f)
         bars.forEachIndexed { i, raw ->
-            val barHeight = raw.coerceIn(WAVEFORM_MIN_FRACTION, 1f) * size.height
+            val barHeight = raw.coerceIn(WAVEFORM_MIN_BAR, 1f) * size.height
             val x = i * slot + (slot - barWidth) / 2f
             drawRoundRect(
                 color = activeColor,
@@ -462,7 +463,6 @@ private val PRIMING_ICON_SIZE = 64.dp
 private val WAVEFORM_HEIGHT = 120.dp
 internal const val RECORDER_WAVEFORM_BARS = 48
 private const val WAVEFORM_BAR_FILL = 0.5f
-private const val WAVEFORM_MIN_FRACTION = 0.06f
 private const val GLOW_CENTER_ALPHA = 0.16f
 private const val GLOW_MID_ALPHA = 0.04f
 private const val GLOW_STOP_CENTER = 0.0f

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreen.kt
@@ -5,9 +5,7 @@
  */
 package com.github.barriosnahuel.vossosunboton.feature.vault
 
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -34,20 +32,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.CornerRadius
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.progressBarRangeInfo
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.setProgress
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -56,6 +46,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
+import com.github.barriosnahuel.vossosunboton.feature.waveform.EnvelopeWaveform
 import com.github.barriosnahuel.vossosunboton.model.Collection
 import com.github.barriosnahuel.vossosunboton.ui.AppIcons
 import com.github.barriosnahuel.vossosunboton.ui.home.SoundsViewModel
@@ -203,9 +194,12 @@ internal fun ImmersiveListenScreen(
                 // Bottom half: the real waveform (scrubbable) + the position / duration readout.
                 Box(modifier = Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        ImmersiveWaveform(
-                            progressFraction = progressFraction,
+                        EnvelopeWaveform(
+                            progress = progressFraction,
                             peaks = peaks,
+                            contentDescription = stringResource(R.string.app_vault_immersive_waveform),
+                            barCount = WAVEFORM_BARS,
+                            barFill = WAVEFORM_BAR_FILL,
                             onSeek = onSeek,
                             modifier = Modifier.fillMaxWidth().height(WAVEFORM_HEIGHT),
                         )
@@ -388,72 +382,10 @@ private fun ImmersiveControls(
     }
 }
 
-@Composable
-private fun ImmersiveWaveform(
-    progressFraction: Float,
-    peaks: FloatArray?,
-    onSeek: (Float) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    // Real amplitude envelope from [WaveformExtractor]. Until it arrives (or if decoding failed)
-    // `peaks` is null and we draw a neutral flat baseline — never a fake-looking wave. Dragging
-    // horizontally scrubs: the fill follows the finger and `onSeek` fires the fraction on release.
-    val playedColor = MaterialTheme.colorScheme.primary
-    val unplayedColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = WAVEFORM_UNPLAYED_ALPHA)
-    val barCount = peaks?.size ?: WAVEFORM_BARS
-    val scrubberLabel = stringResource(R.string.app_vault_immersive_waveform)
-    var scrub by remember { mutableStateOf<Float?>(null) }
-    val displayFraction = (scrub ?: progressFraction).coerceIn(0f, 1f)
-    Canvas(
-        modifier =
-            modifier
-                .semantics {
-                    contentDescription = scrubberLabel
-                    progressBarRangeInfo = ProgressBarRangeInfo(displayFraction, 0f..1f)
-                    setProgress { target ->
-                        onSeek(target.coerceIn(0f, 1f))
-                        true
-                    }
-                }.pointerInput(Unit) {
-                    detectHorizontalDragGestures(
-                        onDragStart = { offset -> scrub = (offset.x / size.width.toFloat()).coerceIn(0f, 1f) },
-                        onHorizontalDrag = { change, _ ->
-                            change.consume()
-                            scrub = (change.position.x / size.width.toFloat()).coerceIn(0f, 1f)
-                        },
-                        onDragEnd = {
-                            scrub?.let(onSeek)
-                            scrub = null
-                        },
-                        onDragCancel = { scrub = null },
-                    )
-                },
-    ) {
-        val slot = size.width / barCount
-        val barWidth = slot * WAVEFORM_BAR_FILL
-        val centerY = size.height / 2f
-        val corner = CornerRadius(barWidth / 2f, barWidth / 2f)
-        for (i in 0 until barCount) {
-            val amplitude = peaks?.getOrNull(i) ?: WAVEFORM_PLACEHOLDER_FRACTION
-            val barHeight = amplitude.coerceIn(WAVEFORM_MIN_FRACTION, 1f) * size.height
-            val played = i.toFloat() / barCount < displayFraction
-            val x = i * slot + (slot - barWidth) / 2f
-            drawRoundRect(
-                color = if (played) playedColor else unplayedColor,
-                topLeft = Offset(x, centerY - barHeight / 2f),
-                size = Size(barWidth, barHeight),
-                cornerRadius = corner,
-            )
-        }
-    }
-}
-
-// Bar count used for the placeholder + as the extractor's target resolution.
+// Bar count used for the placeholder + as the extractor's target resolution; bar width as a
+// fraction of each slot. The waveform itself is the shared [EnvelopeWaveform].
 private const val WAVEFORM_BARS = 56
 private const val WAVEFORM_BAR_FILL = 0.45f
-private const val WAVEFORM_MIN_FRACTION = 0.06f
-private const val WAVEFORM_PLACEHOLDER_FRACTION = 0.12f
-private const val WAVEFORM_UNPLAYED_ALPHA = 0.30f
 private val WAVEFORM_HEIGHT = 120.dp
 private val TOP_BAR_HEIGHT = 64.dp
 private val TOP_BAR_ICON_SLOT = 48.dp

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/WaveformExtractor.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/WaveformExtractor.kt
@@ -12,6 +12,8 @@ import android.media.MediaFormat
 import android.net.Uri
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.commons.file.getFile
+import com.github.barriosnahuel.vossosunboton.feature.waveform.WAVEFORM_MIN_BAR
+import com.github.barriosnahuel.vossosunboton.feature.waveform.normalizeEnvelope
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
@@ -225,15 +227,14 @@ internal class PeakAccumulator(
         index++
     }
 
-    /** Normalized peaks in [MIN_BAR, 1]. Silent / empty input yields a flat [MIN_BAR] baseline. */
+    /** Normalized peaks in [WAVEFORM_MIN_BAR, 1]. Silent / empty input yields a flat baseline. */
     fun result(): FloatArray {
         val loudest = peaks.maxOrNull() ?: 0f
-        if (loudest <= 0f) return FloatArray(barCount) { MIN_BAR }
-        return FloatArray(barCount) { i -> max(MIN_BAR, peaks[i] / loudest) }
+        if (loudest <= 0f) return FloatArray(barCount) { WAVEFORM_MIN_BAR }
+        return normalizeEnvelope(peaks, loudest)
     }
 
     private companion object {
         const val SHORT_FULL_SCALE = 32_768f
-        const val MIN_BAR = 0.06f
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/waveform/EnvelopeWaveform.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/waveform/EnvelopeWaveform.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.waveform
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.progressBarRangeInfo
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.setProgress
+
+/**
+ * Shared amplitude-envelope waveform: [barCount] vertical bars drawn from a real `peaks` envelope
+ * (0..1, normalized by `WaveformExtractor` / `buildRecorderEnvelope`), whose left portion fills with
+ * `primary` as playback advances and the rest dims. While `peaks` is still decoding (or decoding
+ * failed) it is `null` and a neutral placeholder baseline shows — never a fake-looking wave.
+ *
+ * One component for both the Vault listen screen and the recorder review (was `ImmersiveWaveform` +
+ * `ReviewWaveform`). Per-surface differences are parameters: bar count and bar width ([barCount],
+ * [barFill]) and, when non-null, [onSeek] enables drag-to-scrub plus the `SetProgress` semantics
+ * action; a `null` [onSeek] renders a read-only wave. The played boundary is the bar's left edge
+ * (`i / barCount < progress`), matching the shipped Vault behavior.
+ */
+@Composable
+internal fun EnvelopeWaveform(
+    progress: Float,
+    peaks: FloatArray?,
+    contentDescription: String,
+    barCount: Int,
+    barFill: Float,
+    modifier: Modifier = Modifier,
+    onSeek: ((Float) -> Unit)? = null,
+) {
+    val playedColor = MaterialTheme.colorScheme.primary
+    val unplayedColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = WAVEFORM_UNPLAYED_ALPHA)
+    val label = contentDescription
+    val effectiveBars = peaks?.size ?: barCount
+    var scrub by remember { mutableStateOf<Float?>(null) }
+    val displayFraction = (scrub ?: progress).coerceIn(0f, 1f)
+
+    val semanticsModifier =
+        modifier.semantics {
+            this.contentDescription = label
+            progressBarRangeInfo = ProgressBarRangeInfo(displayFraction, 0f..1f)
+            if (onSeek != null) {
+                setProgress { target ->
+                    onSeek(target.coerceIn(0f, 1f))
+                    true
+                }
+            }
+        }
+    val canvasModifier =
+        if (onSeek != null) {
+            semanticsModifier.pointerInput(Unit) {
+                detectHorizontalDragGestures(
+                    onDragStart = { offset -> scrub = (offset.x / size.width.toFloat()).coerceIn(0f, 1f) },
+                    onHorizontalDrag = { change, _ ->
+                        change.consume()
+                        scrub = (change.position.x / size.width.toFloat()).coerceIn(0f, 1f)
+                    },
+                    onDragEnd = {
+                        scrub?.let(onSeek)
+                        scrub = null
+                    },
+                    onDragCancel = { scrub = null },
+                )
+            }
+        } else {
+            semanticsModifier
+        }
+
+    Canvas(modifier = canvasModifier) {
+        val slot = size.width / effectiveBars
+        val barWidth = slot * barFill
+        val centerY = size.height / 2f
+        val corner = CornerRadius(barWidth / 2f, barWidth / 2f)
+        for (i in 0 until effectiveBars) {
+            val amplitude = peaks?.getOrNull(i) ?: WAVEFORM_PLACEHOLDER_FRACTION
+            val barHeight = amplitude.coerceIn(WAVEFORM_MIN_BAR, 1f) * size.height
+            val played = i.toFloat() / effectiveBars < displayFraction
+            val x = i * slot + (slot - barWidth) / 2f
+            drawRoundRect(
+                color = if (played) playedColor else unplayedColor,
+                topLeft = Offset(x, centerY - barHeight / 2f),
+                size = Size(barWidth, barHeight),
+                cornerRadius = corner,
+            )
+        }
+    }
+}
+
+// Neutral baseline drawn for every bar while the real envelope is still decoding (peaks == null).
+private const val WAVEFORM_PLACEHOLDER_FRACTION = 0.12f
+private const val WAVEFORM_UNPLAYED_ALPHA = 0.30f

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/waveform/EnvelopeWaveform.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/waveform/EnvelopeWaveform.kt
@@ -30,11 +30,13 @@ import androidx.compose.ui.semantics.setProgress
  * `primary` as playback advances and the rest dims. While `peaks` is still decoding (or decoding
  * failed) it is `null` and a neutral placeholder baseline shows — never a fake-looking wave.
  *
- * One component for both the Vault listen screen and the recorder review (was `ImmersiveWaveform` +
- * `ReviewWaveform`). Per-surface differences are parameters: bar count and bar width ([barCount],
- * [barFill]) and, when non-null, [onSeek] enables drag-to-scrub plus the `SetProgress` semantics
- * action; a `null` [onSeek] renders a read-only wave. The played boundary is the bar's left edge
- * (`i / barCount < progress`), matching the shipped Vault behavior.
+ * Per-surface differences are parameters: bar width ([barFill]); [onSeek], which when non-null wires
+ * drag-to-scrub plus the `SetProgress` semantics action (a `null` renders a read-only wave); and
+ * [barCount], which sizes the placeholder grid only — once `peaks` arrives the bar count follows
+ * `peaks.size`, so a caller must decode at the same resolution it passes here.
+ *
+ * The one shared component, the unified left-edge played boundary, and the per-surface params:
+ * docs/adr/0020-shared-envelope-waveform.md.
  */
 @Composable
 internal fun EnvelopeWaveform(

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/waveform/WaveformNormalization.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/waveform/WaveformNormalization.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.waveform
+
+import kotlin.math.max
+
+/**
+ * Shared baseline floor for a normalized waveform bar (0..1). A silent bar never collapses to zero —
+ * it shows this minimum so the wave still reads as a wave, not a gap. Single source for the floor
+ * used by the decoded `PeakAccumulator`, the live `buildRecorderEnvelope`, and the [EnvelopeWaveform]
+ * renderer (was duplicated as `MIN_BAR` / `WAVEFORM_MIN_FRACTION` across all three).
+ */
+internal const val WAVEFORM_MIN_BAR = 0.06f
+
+/**
+ * Normalizes [raw] amplitude buckets so the [loudest] becomes 1.0, with every bar floored at
+ * [WAVEFORM_MIN_BAR]. Pure (no Android types) so the bucketing callers stay unit-testable.
+ * Precondition: [loudest] > 0 — callers own the all-silent case (a flat baseline, or `null` to
+ * decode the real file instead), which is why that branch is not folded in here.
+ */
+internal fun normalizeEnvelope(
+    raw: FloatArray,
+    loudest: Float,
+): FloatArray = FloatArray(raw.size) { max(WAVEFORM_MIN_BAR, raw[it] / loudest) }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/waveform/WaveformNormalization.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/waveform/WaveformNormalization.kt
@@ -18,8 +18,8 @@ internal const val WAVEFORM_MIN_BAR = 0.06f
 /**
  * Normalizes [raw] amplitude buckets so the [loudest] becomes 1.0, with every bar floored at
  * [WAVEFORM_MIN_BAR]. Pure (no Android types) so the bucketing callers stay unit-testable.
- * Precondition: [loudest] > 0 — callers own the all-silent case (a flat baseline, or `null` to
- * decode the real file instead), which is why that branch is not folded in here.
+ * Precondition: [loudest] > 0 — callers own the all-silent case, which is deliberately not folded
+ * in here: docs/adr/0020-shared-envelope-waveform.md.
  */
 internal fun normalizeEnvelope(
     raw: FloatArray,

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreenTest.kt
@@ -8,6 +8,7 @@ package com.github.barriosnahuel.vossosunboton.feature.recorder
 import android.net.Uri
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertRangeInfoEquals
 import androidx.compose.ui.test.junit4.v2.createComposeRule
@@ -101,6 +102,20 @@ internal class RecorderScreenTest : AbstractRobolectricTest() {
         composeTestRule
             .onNodeWithContentDescription("Playback progress")
             .assertRangeInfoEquals(ProgressBarRangeInfo(0.4f, 0f..1f))
+    }
+
+    @Test
+    fun `review waveform exposes no seek action`() {
+        // The recorder review is read-only (shared EnvelopeWaveform called with onSeek = null), so it
+        // must not advertise a SetProgress action — otherwise TalkBack would offer a phantom scrub the
+        // recorder never wired. The Vault listen wave is the only seekable envelope (covered there).
+        val review = RecorderState.Review(Uri.parse("content://clip"), durationMs = 5_000)
+        composeTestRule.setContent {
+            AppTheme { recorder(review, isPreviewPlaying = true, previewPositionMs = 2_000) }
+        }
+
+        val node = composeTestRule.onNodeWithContentDescription("Playback progress").fetchSemanticsNode()
+        assertThat(node.config.contains(SemanticsActions.SetProgress)).isFalse()
     }
 
     @Composable

--- a/docs/adr/0020-shared-envelope-waveform.md
+++ b/docs/adr/0020-shared-envelope-waveform.md
@@ -1,0 +1,52 @@
+# ADR 0020 — Shared `EnvelopeWaveform` for listen + recorder-review
+
+- **Status:** Accepted
+- **Date:** 2026-06-26
+- **Supersedes:** —
+
+## Context
+
+Two near-identical envelope-with-progress waveforms had grown in parallel: the Vault listen
+screen's `ImmersiveWaveform` (drag-to-seek, 56 bars) and the recorder review's `ReviewWaveform`
+(read-only, 48 bars), shipped one release apart (ADR 0019). Both draw the same thing — a real
+amplitude envelope (0..1) normalized to the loudest bar with a `0.06f` floor, left portion filled
+with `primary`, the rest dimmed, exposed via `ProgressBarRangeInfo` semantics. The clones diverged
+only in bar count, bar width, the played-boundary test, and whether a drag gesture was wired.
+
+The `0.06f` floor was duplicated four times (`PeakAccumulator.MIN_BAR`, `RecorderEnvelope.MIN_BAR`,
+each waveform's `WAVEFORM_MIN_FRACTION`), and the "normalize to loudest, floor each bar" loop twice.
+The code review on #1248 flagged the `PeakAccumulator` ↔ `buildRecorderEnvelope` normalize
+duplication and deferred the dedup to here.
+
+## Decision drivers
+
+1. **One renderer, not two clones** — a fix or a11y tweak should land once, on both surfaces.
+2. **Protect the shipped, tested Vault** — the listen screen is the regression-sensitive surface;
+   the reconciliation must not change its behavior.
+3. **Per-surface tuning stays visible** — bar count / width are genuine design choices per screen,
+   not accidents to flatten.
+
+## Decision
+
+- A single `feature/waveform/EnvelopeWaveform.kt` Composable replaces both clones. Per-surface
+  differences are parameters: `barCount`, `barFill`, a `contentDescription`, and `onSeek`.
+- `onSeek: ((Float) -> Unit)? = null` carries the seek capability: non-null wires drag-to-scrub +
+  the `SetProgress` semantics action (Vault); null renders a read-only wave (recorder).
+- The played boundary is unified to the Vault's left-edge test (`i / barCount < progress`) so the
+  regression-sensitive surface is pixel-identical; the recorder's fill boundary shifts by a sub-bar
+  fraction (was bar-center `(i + 0.5) / barCount <= progress`) — visually imperceptible during
+  playback, and the recorder progress test asserts semantics, not pixels.
+- The `0.06f` floor + normalize loop collapse into `feature/waveform/WaveformNormalization.kt`
+  (`WAVEFORM_MIN_BAR`, `normalizeEnvelope`), reused by `PeakAccumulator`, `buildRecorderEnvelope`,
+  and the renderer. The all-silent branch is NOT folded in — its callers disagree on purpose
+  (`PeakAccumulator` returns a flat baseline; `buildRecorderEnvelope` returns `null` to decode).
+
+## Out of scope
+
+`LiveWaveform` (the recorder's scrolling live input meter) and onboarding's decorative `Waveform`
+are different concepts — not envelope-with-progress waves — and stay independent.
+
+## Revisit criteria
+
+If a third surface needs a materially different envelope (log scale, stereo split, mirrored bars),
+re-evaluate whether parameters still beat separate components before piling on flags.

--- a/docs/adr/0020-shared-envelope-waveform.md
+++ b/docs/adr/0020-shared-envelope-waveform.md
@@ -41,6 +41,13 @@ duplication and deferred the dedup to here.
   and the renderer. The all-silent branch is NOT folded in — its callers disagree on purpose
   (`PeakAccumulator` returns a flat baseline; `buildRecorderEnvelope` returns `null` to decode).
 
+## Enforcement
+
+The single-sourced floor is grep-guarded: `scripts/check-adr-invariants.sh` (CI job
+`adr-invariants`) fails on a bare `0.06f` bar-floor literal in any waveform surface outside
+`WaveformNormalization.kt`. The "one shared component" half is not cleanly greppable and relies on
+review.
+
 ## Out of scope
 
 `LiveWaveform` (the recorder's scrolling live input meter) and onboarding's decorative `Waveform`

--- a/scripts/check-adr-invariants.sh
+++ b/scripts/check-adr-invariants.sh
@@ -289,6 +289,25 @@ A test's runBlocking { … .first/.collect/.await/.single … } must be bounded 
 fi
 
 # ============================================================================
+# ADR 0020 — docs/adr/0020-shared-envelope-waveform.md
+# Invariant: the normalized waveform-bar floor is single-sourced as
+# WAVEFORM_MIN_BAR (feature/waveform/WaveformNormalization.kt). The dedup
+# collapsed a 0.06f floor that used to live in 4 places; a bare 0.06f literal in
+# any waveform surface re-forks it. Reuse the shared constant — kin to the
+# design-system alpha/color greps above.
+# ============================================================================
+WAVEFORM_DIRS="app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/waveform app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder"
+stray_floor=$(
+    grep -rnE --include="*.kt" '\b0\.06f\b' $WAVEFORM_DIRS 2>/dev/null \
+        | grep -vF 'WaveformNormalization.kt' || true
+)
+if [ -n "$stray_floor" ]; then
+    fail "ADR 0020 broken: bar-floor literal 0.06f outside WaveformNormalization.kt:
+$stray_floor
+The normalized bar floor is single-sourced as WAVEFORM_MIN_BAR. Reuse it instead of a bare 0.06f literal, or supersede ADR 0020. See docs/adr/0020-shared-envelope-waveform.md."
+fi
+
+# ============================================================================
 if [ "$errors" -gt 0 ]; then
     echo
     echo "$errors ADR invariant(s) violated. See messages above for which ADR(s) to revisit." >&2


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change. The Vault listen wave and the recorder review wave looked and behaved the same but were two separate clones; this folds them into one, so a future fix or accessibility tweak to the waveform lands once instead of drifting between copies. ADR 0020 records the decision.

### Technical detail

Extract a shared `EnvelopeWaveform` + a shared normalize helper from the two waveform clones.

- **`feature/waveform/EnvelopeWaveform.kt`** (new) — one Composable replacing `ImmersiveWaveform` (Vault) and `ReviewWaveform` (recorder). Per-surface differences are params: `barCount`, `barFill`, `contentDescription`, and `onSeek: ((Float)->Unit)? = null` — non-null wires drag-to-scrub + the `SetProgress` semantics action; null renders read-only.
- **`feature/waveform/WaveformNormalization.kt`** (new) — `WAVEFORM_MIN_BAR` (the `0.06f` floor) + `normalizeEnvelope(raw, loudest)`, collapsing a floor duplicated 4× and a normalize loop duplicated 2×.
- **ADR 0020 grep guard** — `check-adr-invariants.sh` now fails on a bare `0.06f` bar-floor literal in any waveform surface outside `WaveformNormalization.kt`, locking in the single-source.
- **`PeakAccumulator` / `buildRecorderEnvelope`** — both reuse `normalizeEnvelope`; each keeps its own all-silent branch (flat baseline vs `null`).
- **`ImmersiveListenScreen` / `RecorderScreen`** — call the shared component; their private clones + orphaned constants deleted. `LiveWaveform` (live input meter) left untouched — out of scope.

### Code review tips

- **Played boundary unified to the Vault's left-edge** (`i/N < progress`). The recorder review (was bar-center) shifts its fill by a sub-bar fraction — imperceptible, documented in ADR 0020. Vault stays pixel-identical (the regression-sensitive surface).
- **`effectiveBars = peaks?.size ?: barCount`** — the recorder previously hardcoded 48 regardless of `peaks.size`; now derives from it. Inert, since both callers build/decode at exactly their `barCount`.
- **`normalizeEnvelope` precondition `loudest > 0`** — both callers guard before calling; the all-silent case is deliberately NOT folded in (callers disagree on purpose).
- **Floor fully single-sourced:** every `0.06f` bar floor (incl. `LiveWaveform`) now reads the shared `WAVEFORM_MIN_BAR`.
- **Manual verification suggested (device-only, not headless-verifiable):** confirm on a real device that the Vault listen wave (drag-to-seek) and the recorder review wave (fill while previewing) render identically to before.
- **Instrumented flakes:** two prior cold-boot runs failed environmentally — a stall at 54/126, then a `Process crashed` on the unrelated `AboutScreenFlowTest` — before a clean pass. The ADR 0001 degraded-AVD scenario, not this change.

- A follow-up commit folds the `/code-review` cleanups (floor single-source + ADR 0020 KDoc pointers + barCount/peaks coupling doc); no behavior change.

### Already tested

- instrumented: corrido local vía wrapper (cold-boot), 128 tests, 0 failed, 2 skipped — verde tras re-run; los 2 fallos previos fueron flakes ambientales del AVD en tests ajenos al cambio


