### PR TITLE
feat(recorder): seekable review waveform + listen-seek stale-closure fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 ### Added
 - Record a Bomp without leaving the app — the add sheet's "Record" option opens a full-screen recorder: tap to record, listen back on a real waveform, and save it like any other Bomp; if you leave mid-recording, a banner offers to pick it back up
-- Drag the recorder's review waveform to scrub through your recording while previewing it, the same way you can on the listen screen
+- Drag the recorder's review waveform to scrub through your recording and jump to any spot — before, during, or after playback — the same way you can on the listen screen
 
 ### Fixed
 - Bomps saved before an earlier update no longer disappear when you open the app — audios stored under the old format are recovered instead of the whole list silently emptying

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 ### Added
 - Record a Bomp without leaving the app — the add sheet's "Record" option opens a full-screen recorder: tap to record, listen back on a real waveform, and save it like any other Bomp; if you leave mid-recording, a banner offers to pick it back up
+- Drag the recorder's review waveform to scrub through your recording while previewing it, the same way you can on the listen screen
 
 ### Fixed
 - Bomps saved before an earlier update no longer disappear when you open the app — audios stored under the old format are recovered instead of the whole list silently emptying
+- Dragging the listen-screen waveform to seek now works even right after opening an audio, before its length has finished loading
 
 ### For nerds 🤓
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerController.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerController.kt
@@ -56,10 +56,15 @@ internal interface PlayerController {
      * registered [PlayerControllerListener] sees `onPlayerPause(currentSound, ...)` for the Sound
      * case (preemption preserves position — it is a pause, not a stop). Progress for the new
      * preview is reported via [playbackState] only — listener events are not fired (no Sound to pass).
+     *
+     * [startPositionMs] resumes a fresh start from that offset (e.g. the recorder review resuming a
+     * scrubbed position); 0 starts from the beginning. A resume of the already-loaded paused uri
+     * continues from its own head and ignores this.
      */
     fun startPlayingUri(
         context: Context,
         uri: Uri,
+        startPositionMs: Int = 0,
     )
 
     /**

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerImpl.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerImpl.kt
@@ -390,6 +390,9 @@ internal class PlayerControllerImpl(
 
     override fun seekTo(positionMs: Int) {
         mediaPlayer.seekTo(positionMs)
+        // Publish the new head right away so a seek while paused reflects in the UI — the progress
+        // runnable only advances positionMs while playing, so otherwise a paused scrub would snap back.
+        _playbackState.update { it?.copy(positionMs = positionMs) }
     }
 
     override fun forgetSound(sound: Sound) {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerImpl.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerImpl.kt
@@ -166,6 +166,7 @@ internal class PlayerControllerImpl(
     override fun startPlayingUri(
         context: Context,
         uri: Uri,
+        startPositionMs: Int,
     ) {
         val currentTarget = target
         if (currentTarget is PlaybackTarget.UriTarget && currentTarget.uri == uri && !mediaPlayer.isPlaying) {
@@ -192,7 +193,7 @@ internal class PlayerControllerImpl(
                 if (!isActive) return@launch
 
                 prepared
-                    .onSuccess { durationMs -> completeUriStart(uri, durationMs) }
+                    .onSuccess { durationMs -> completeUriStart(uri, durationMs, startPositionMs) }
                     .onFailure { e -> trackUriPrepareFailure(uri, e) }
             }
     }
@@ -200,18 +201,21 @@ internal class PlayerControllerImpl(
     private fun completeUriStart(
         uri: Uri,
         durationMs: Int,
+        startPositionMs: Int,
     ) {
         mediaPlayer.setOnCompletionListener {
             handler.removeCallbacks(progressRunnable)
             target = null
             _playbackState.value = null
         }
+        // seekTo is valid in PREPARED state; the next start() picks up from there (the scrubbed offset).
+        if (startPositionMs > 0) runCatching { mediaPlayer.seekTo(startPositionMs) }
         val started = runCatching { mediaPlayer.start() }
         started
             .onSuccess {
                 target = PlaybackTarget.UriTarget(uri)
                 _playbackState.value =
-                    PlaybackState(uri = uri, positionMs = 0, durationMs = durationMs, isPlaying = true)
+                    PlaybackState(uri = uri, positionMs = startPositionMs, durationMs = durationMs, isPlaying = true)
                 handler.post(progressRunnable)
             }.onFailure { e ->
                 if (e is IllegalStateException) {
@@ -389,9 +393,18 @@ internal class PlayerControllerImpl(
     }
 
     override fun seekTo(positionMs: Int) {
-        mediaPlayer.seekTo(positionMs)
+        // Wrapped like every other MediaPlayer call here: a seek racing a stop/complete can land in an
+        // invalid state and throw IllegalStateException — swallow + report rather than crash.
+        runCatching { mediaPlayer.seekTo(positionMs) }
+            .onFailure { e ->
+                Tracker.log("playback.seek_position=$positionMs")
+                Tracker.track(RuntimeException("MediaPlayer can't seek", e))
+                return
+            }
         // Publish the new head right away so a seek while paused reflects in the UI — the progress
         // runnable only advances positionMs while playing, so otherwise a paused scrub would snap back.
+        // seekTo acts on the currently-loaded target, so _playbackState (that same target) is the right
+        // place to publish; callers own matching the fraction to the loaded clip before seeking.
         _playbackState.update { it?.copy(positionMs = positionMs) }
     }
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/SeekTarget.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/SeekTarget.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.playback
+
+/**
+ * Maps a scrub [fraction] (0..1) to a millisecond seek target within a clip of [durationMs]. Returns
+ * `null` for a non-positive duration (nothing to seek). Clamps just shy of the end so a full-right
+ * scrub stays a valid in-range position instead of landing exactly on EOS. Pure — the single source
+ * for the fraction→ms mapping shared by the listen and recorder-review waveform scrubs (was inlined
+ * per surface).
+ */
+internal fun seekTargetMs(
+    durationMs: Long,
+    fraction: Float,
+): Int? {
+    if (durationMs <= 0L) return null
+    val target = (fraction.coerceIn(0f, 1f) * durationMs).toLong()
+    return target.coerceIn(0L, durationMs - 1L).toInt()
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderEnvelope.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderEnvelope.kt
@@ -47,3 +47,15 @@ internal fun buildRecorderEnvelope(
     // caller decodes the real file instead of showing a fake flat line for a clip that has audio.
     return if (loudest <= 0f) null else normalizeEnvelope(raw, loudest)
 }
+
+/**
+ * The position (ms) the review wave should show: the live [playerPositionMs] while the clip is the
+ * loaded playback; otherwise a [pendingScrubMs] the user scrubbed to before playing; otherwise the
+ * start. The pending scrub is consumed when play begins, so after a natural completion (no player, no
+ * pending) the wave rests at the start — matching the listen screen instead of sticking at the last
+ * scrub. Pure so the rule is unit-tested without the Activity/playback host.
+ */
+internal fun reviewWavePositionMs(
+    playerPositionMs: Long?,
+    pendingScrubMs: Long?,
+): Long = playerPositionMs ?: pendingScrubMs ?: 0L

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderEnvelope.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderEnvelope.kt
@@ -47,14 +47,3 @@ internal fun buildRecorderEnvelope(
     // caller decodes the real file instead of showing a fake flat line for a clip that has audio.
     return if (loudest <= 0f) null else normalizeEnvelope(raw, loudest)
 }
-
-/**
- * Maps a waveform-scrub [fraction] (0..1) to a millisecond seek target within a clip of [durationMs].
- * Returns `null` for a non-positive duration (nothing to seek). Pure so the recorder review's seek
- * gate/mapping is unit-tested without an Activity; the host still gates on the clip being the active
- * preview playback before calling `seekTo`.
- */
-internal fun recorderSeekTargetMs(
-    durationMs: Long,
-    fraction: Float,
-): Int? = if (durationMs > 0L) (fraction.coerceIn(0f, 1f) * durationMs).toInt() else null

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderEnvelope.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderEnvelope.kt
@@ -47,3 +47,14 @@ internal fun buildRecorderEnvelope(
     // caller decodes the real file instead of showing a fake flat line for a clip that has audio.
     return if (loudest <= 0f) null else normalizeEnvelope(raw, loudest)
 }
+
+/**
+ * Maps a waveform-scrub [fraction] (0..1) to a millisecond seek target within a clip of [durationMs].
+ * Returns `null` for a non-positive duration (nothing to seek). Pure so the recorder review's seek
+ * gate/mapping is unit-tested without an Activity; the host still gates on the clip being the active
+ * preview playback before calling `seekTo`.
+ */
+internal fun recorderSeekTargetMs(
+    durationMs: Long,
+    fraction: Float,
+): Int? = if (durationMs > 0L) (fraction.coerceIn(0f, 1f) * durationMs).toInt() else null

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreen.kt
@@ -76,6 +76,7 @@ internal fun RecorderScreen(
     onUseClip: () -> Unit,
     onReRecord: () -> Unit,
     onClose: () -> Unit,
+    onSeek: (Float) -> Unit,
 ) {
     RecorderBackdrop {
         Column(
@@ -88,7 +89,7 @@ internal fun RecorderScreen(
                 verticalArrangement = Arrangement.SpaceBetween,
             ) {
                 RecorderHeadline(state, isPreviewPlaying, previewPositionMs)
-                RecorderVisual(state, previewPositionMs, peaks)
+                RecorderVisual(state, previewPositionMs, peaks, onSeek)
                 RecorderTransport(
                     state = state,
                     isPreviewPlaying = isPreviewPlaying,
@@ -167,6 +168,7 @@ private fun RecorderVisual(
     state: RecorderState,
     previewPositionMs: Long,
     peaks: FloatArray?,
+    onSeek: (Float) -> Unit,
 ) {
     Box(modifier = Modifier.fillMaxWidth().height(WAVEFORM_HEIGHT), contentAlignment = Alignment.Center) {
         when (state) {
@@ -179,6 +181,7 @@ private fun RecorderVisual(
                     barCount = RECORDER_WAVEFORM_BARS,
                     barFill = WAVEFORM_BAR_FILL,
                     modifier = Modifier.fillMaxWidth().height(WAVEFORM_HEIGHT),
+                    onSeek = onSeek,
                 )
             RecorderState.Ready -> LiveWaveform(amplitude = 0f, tick = 0L)
         }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
@@ -150,6 +150,17 @@ class RecordingActivity : FragmentActivity() {
                                 viewModel.onReRecord()
                             },
                             onClose = { if (viewModel.hasUnsavedClip()) showDiscard = true else finish() },
+                            // Scrub the preview like the Vault listen wave. Only seeks when this clip is
+                            // the loaded playback (preview started); before first play there is no player
+                            // to seek, so the drag scrubs the wave visually only.
+                            onSeek = { fraction ->
+                                val review = state as? RecorderState.Review
+                                if (review != null && preview != null) {
+                                    recorderSeekTargetMs(review.durationMs, fraction)?.let {
+                                        PlayerControllerFactory.instance.seekTo(it)
+                                    }
+                                }
+                            },
                         )
                     permanentlyDenied ->
                         MicPermissionDenied(

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
@@ -43,6 +43,7 @@ import com.github.barriosnahuel.vossosunboton.commons.android.analytics.Analytic
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
 import com.github.barriosnahuel.vossosunboton.feature.addbutton.AddButtonActivity
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
+import com.github.barriosnahuel.vossosunboton.feature.playback.seekTargetMs
 import com.github.barriosnahuel.vossosunboton.feature.vault.WaveformExtractor
 import com.github.barriosnahuel.vossosunboton.ui.theme.ImmersiveListenTheme
 
@@ -103,7 +104,14 @@ class RecordingActivity : FragmentActivity() {
         val reviewUri = (state as? RecorderState.Review)?.uri
         val preview = playback?.takeIf { it.uri == reviewUri }
         val isPreviewPlaying = preview?.isPlaying == true
-        val previewPositionMs = preview?.positionMs?.toLong() ?: 0L
+        // Persisted scrub position for the current clip. The Vault keeps this in its ViewModel
+        // (_pausedProgress) because the VM owns playback; the recorder owns playback in this host, so it
+        // lives here. It lets the wave hold the scrubbed spot when no player is loaded (before first
+        // play / after the clip completes) and gives `play` a resume offset. Reset per clip.
+        var scrubPositionMs by rememberSaveable(reviewUri) { mutableStateOf(0L) }
+        // While the clip is the loaded playback, follow the player head (seekTo publishes it even when
+        // paused); otherwise show the persisted scrub position so the wave never snaps back to 0.
+        val displayPositionMs = if (preview != null) preview.positionMs.toLong() else scrubPositionMs
 
         // Real amplitude envelope of the recorded clip. A fresh recording carries the live-captured
         // envelope (instant — no placeholder gap); only a restored draft (no live samples) falls back to
@@ -139,25 +147,26 @@ class RecordingActivity : FragmentActivity() {
                         RecorderScreen(
                             state = state,
                             isPreviewPlaying = isPreviewPlaying,
-                            previewPositionMs = previewPositionMs,
+                            previewPositionMs = displayPositionMs,
                             peaks = peaks,
                             onRecordTap = viewModel::onRecordTapped,
                             onStopTap = viewModel::onStopTapped,
-                            onPreviewToggle = { togglePreview(reviewUri) },
+                            onPreviewToggle = { togglePreview(reviewUri, scrubPositionMs.toInt()) },
                             onUseClip = viewModel::onUseClip,
                             onReRecord = {
                                 PlayerControllerFactory.instance.stopPlayingSound()
                                 viewModel.onReRecord()
                             },
                             onClose = { if (viewModel.hasUnsavedClip()) showDiscard = true else finish() },
-                            // Scrub the preview like the Vault listen wave. Only seeks when this clip is
-                            // the loaded playback (preview started); before first play there is no player
-                            // to seek, so the drag scrubs the wave visually only.
+                            // Scrub like the Vault listen wave: remember the target so the wave holds it,
+                            // and seek the player when this clip is loaded. Tapping play from idle resumes
+                            // from the remembered offset (passed into togglePreview).
                             onSeek = { fraction ->
                                 val review = state as? RecorderState.Review
-                                if (review != null && preview != null) {
-                                    recorderSeekTargetMs(review.durationMs, fraction)?.let {
-                                        PlayerControllerFactory.instance.seekTo(it)
+                                if (review != null) {
+                                    seekTargetMs(review.durationMs, fraction)?.let { target ->
+                                        scrubPositionMs = target.toLong()
+                                        if (preview != null) PlayerControllerFactory.instance.seekTo(target)
                                     }
                                 }
                             },
@@ -195,14 +204,19 @@ class RecordingActivity : FragmentActivity() {
         }
     }
 
-    private fun togglePreview(reviewUri: Uri?) {
+    private fun togglePreview(
+        reviewUri: Uri?,
+        startPositionMs: Int,
+    ) {
         val uri = reviewUri ?: return
         val controller = PlayerControllerFactory.instance
         val current = controller.playbackState.value
         when {
             current?.isPlaying == true -> controller.pause()
+            // Paused on this clip: the player head already holds the scrubbed position — resume from it.
             current != null && current.uri == uri -> controller.resume()
-            else -> controller.startPlayingUri(this, uri)
+            // Fresh start (before first play / after completion): resume from the remembered scrub offset.
+            else -> controller.startPlayingUri(this, uri, startPositionMs)
         }
     }
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
@@ -104,14 +104,13 @@ class RecordingActivity : FragmentActivity() {
         val reviewUri = (state as? RecorderState.Review)?.uri
         val preview = playback?.takeIf { it.uri == reviewUri }
         val isPreviewPlaying = preview?.isPlaying == true
-        // Persisted scrub position for the current clip. The Vault keeps this in its ViewModel
-        // (_pausedProgress) because the VM owns playback; the recorder owns playback in this host, so it
-        // lives here. It lets the wave hold the scrubbed spot when no player is loaded (before first
-        // play / after the clip completes) and gives `play` a resume offset. Reset per clip.
-        var scrubPositionMs by rememberSaveable(reviewUri) { mutableStateOf(0L) }
-        // While the clip is the loaded playback, follow the player head (seekTo publishes it even when
-        // paused); otherwise show the persisted scrub position so the wave never snaps back to 0.
-        val displayPositionMs = if (preview != null) preview.positionMs.toLong() else scrubPositionMs
+        // A scrub the user made BEFORE playing this clip (no player loaded yet). Held so the wave shows
+        // it, and consumed as the resume offset when play begins (so a later completion rewinds to 0 like
+        // the listen screen). The Vault keeps the equivalent in its VM; the recorder owns playback in
+        // this host, so it lives here. Reset per clip. While the clip is loaded the live player head wins
+        // (seekTo publishes it even when paused), so a pending scrub only matters before first play.
+        var pendingScrubMs by rememberSaveable(reviewUri) { mutableStateOf<Long?>(null) }
+        val displayPositionMs = reviewWavePositionMs(preview?.positionMs?.toLong(), pendingScrubMs)
 
         // Real amplitude envelope of the recorded clip. A fresh recording carries the live-captured
         // envelope (instant — no placeholder gap); only a restored draft (no live samples) falls back to
@@ -151,22 +150,30 @@ class RecordingActivity : FragmentActivity() {
                             peaks = peaks,
                             onRecordTap = viewModel::onRecordTapped,
                             onStopTap = viewModel::onStopTapped,
-                            onPreviewToggle = { togglePreview(reviewUri, scrubPositionMs.toInt()) },
+                            onPreviewToggle = {
+                                togglePreview(reviewUri, (pendingScrubMs ?: 0L).toInt())
+                                // The pending pre-play scrub is now the resume offset — consume it so a
+                                // later completion rewinds the wave to the start (like the listen screen).
+                                pendingScrubMs = null
+                            },
                             onUseClip = viewModel::onUseClip,
                             onReRecord = {
                                 PlayerControllerFactory.instance.stopPlayingSound()
                                 viewModel.onReRecord()
                             },
                             onClose = { if (viewModel.hasUnsavedClip()) showDiscard = true else finish() },
-                            // Scrub like the Vault listen wave: remember the target so the wave holds it,
-                            // and seek the player when this clip is loaded. Tapping play from idle resumes
-                            // from the remembered offset (passed into togglePreview).
+                            // Scrub like the Vault listen wave. While the clip is loaded, seek the player
+                            // live; before first play there is no player, so hold the target as a pending
+                            // scrub that the wave shows and that `play` resumes from.
                             onSeek = { fraction ->
                                 val review = state as? RecorderState.Review
                                 if (review != null) {
                                     seekTargetMs(review.durationMs, fraction)?.let { target ->
-                                        scrubPositionMs = target.toLong()
-                                        if (preview != null) PlayerControllerFactory.instance.seekTo(target)
+                                        if (preview != null) {
+                                            PlayerControllerFactory.instance.seekTo(target)
+                                        } else {
+                                            pendingScrubMs = target.toLong()
+                                        }
                                     }
                                 }
                             },

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreen.kt
@@ -46,6 +46,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
+import com.github.barriosnahuel.vossosunboton.feature.playback.seekTargetMs
 import com.github.barriosnahuel.vossosunboton.feature.waveform.EnvelopeWaveform
 import com.github.barriosnahuel.vossosunboton.model.Collection
 import com.github.barriosnahuel.vossosunboton.ui.AppIcons
@@ -132,7 +133,7 @@ internal fun ImmersiveListenHost(
         peaks = peaks,
         onPlayPause = { viewModel.playOrStop(sound.copy(isPlaying = isThisPlaying)) },
         onRestart = { viewModel.seekTo(0, soundId) },
-        onSeek = { f -> durationMs?.let { d -> viewModel.seekTo((f * d).toInt(), soundId) } },
+        onSeek = { f -> durationMs?.let { d -> seekTargetMs(d.toLong(), f)?.let { viewModel.seekTo(it, soundId) } } },
         onBack = onBack,
     )
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/waveform/EnvelopeWaveform.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/waveform/EnvelopeWaveform.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.CornerRadius
@@ -52,6 +53,10 @@ internal fun EnvelopeWaveform(
     val unplayedColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = WAVEFORM_UNPLAYED_ALPHA)
     val label = contentDescription
     val effectiveBars = peaks?.size ?: barCount
+    // The drag gesture lives in a pointerInput(Unit) that never restarts, so it would otherwise
+    // capture the onSeek from first composition — stale once the host's seek closure rebinds to a
+    // late-arriving duration (developer.android.com/jetpack/compose/side-effects#rememberupdatedstate).
+    val currentOnSeek by rememberUpdatedState(onSeek)
     var scrub by remember { mutableStateOf<Float?>(null) }
     val displayFraction = (scrub ?: progress).coerceIn(0f, 1f)
 
@@ -76,7 +81,7 @@ internal fun EnvelopeWaveform(
                         scrub = (change.position.x / size.width.toFloat()).coerceIn(0f, 1f)
                     },
                     onDragEnd = {
-                        scrub?.let(onSeek)
+                        scrub?.let { fraction -> currentOnSeek?.invoke(fraction) }
                         scrub = null
                     },
                     onDragCancel = { scrub = null },

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerTest.kt
@@ -425,6 +425,25 @@ internal class PlayerControllerTest : AbstractRobolectricTest() {
     }
 
     @Test
+    fun `startPlayingUri with a start position seeks there before starting and publishes it`() {
+        // The recorder review resumes a scrubbed offset: a fresh start must seek before start() and
+        // report the offset as the initial position (not 0) so the wave doesn't jump to the beginning.
+        val context = mockk<Context>(relaxed = true)
+        val mp = givenAnIdleMediaPlayer()
+        every { mp.duration } returns 5_000
+        val uri = Uri.parse("content://test/clip.mp3")
+
+        val controller = controllerForTest(mp)
+        controller.startPlayingUri(context, uri, startPositionMs = 2_000)
+
+        verifyOrder {
+            mp.seekTo(2_000)
+            mp.start()
+        }
+        assertThat(controller.playbackState.value?.positionMs).isEqualTo(2_000)
+    }
+
+    @Test
     fun `startPlayingUri while a Sound is playing preempts the sound via onPlayerPause`() {
         // Concurrency invariant: starting a Stream while a Sound plays must surface the event to
         // the Sound listener so the Home UI updates. Because the Sound's position is captured for

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerTest.kt
@@ -515,6 +515,25 @@ internal class PlayerControllerTest : AbstractRobolectricTest() {
         verify { mp.seekTo(1500) }
     }
 
+    @Test
+    fun `seekTo publishes the new position so a paused scrub reflects in the UI`() {
+        // The progress runnable only advances positionMs while playing, so without publishing here a
+        // seek on a paused preview would leave the StateFlow (and the waveform) at the old position.
+        val context = mockk<Context>(relaxed = true)
+        val mp = givenAnIdleMediaPlayer()
+        every { mp.duration } returns 5_000
+        val controller = controllerForTest(mp)
+        controller.startPlayingUri(context, Uri.parse("content://test/clip.mp3"))
+        every { mp.isPlaying } returns true
+        controller.pause()
+        every { mp.isPlaying } returns false
+
+        controller.seekTo(3_200)
+
+        verify { mp.seekTo(3_200) }
+        assertThat(controller.playbackState.value?.positionMs).isEqualTo(3_200)
+    }
+
     private fun givenAMediaPlayerCurrentlyPlayingASound(): MediaPlayer {
         val mockedMediaPlayer = mockk<MediaPlayer>()
         every { mockedMediaPlayer.isPlaying } returns true

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/SeekTargetTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/SeekTargetTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.playback
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+internal class SeekTargetTest {
+    @Test
+    fun `maps a scrub fraction to millis within the clip`() {
+        assertThat(seekTargetMs(durationMs = 10_000, fraction = 0.5f)).isEqualTo(5_000)
+    }
+
+    @Test
+    fun `coerces an out-of-range fraction into the clip bounds`() {
+        assertThat(seekTargetMs(durationMs = 10_000, fraction = -0.3f)).isEqualTo(0)
+    }
+
+    @Test
+    fun `clamps a full-right scrub just shy of the end so it never lands on EOS`() {
+        // A seek to exactly durationMs can fire onCompletion and stop/reset the preview.
+        assertThat(seekTargetMs(durationMs = 10_000, fraction = 1f)).isEqualTo(9_999)
+        assertThat(seekTargetMs(durationMs = 10_000, fraction = 1.5f)).isEqualTo(9_999)
+    }
+
+    @Test
+    fun `returns null for a non-positive duration so nothing seeks`() {
+        assertThat(seekTargetMs(durationMs = 0, fraction = 0.5f)).isNull()
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderEnvelopeTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderEnvelopeTest.kt
@@ -44,6 +44,22 @@ internal class RecorderEnvelopeTest {
         assertThat(buildRecorderEnvelope(List(100) { 0f }, BARS)).isNull()
     }
 
+    @Test
+    fun `recorderSeekTargetMs maps a scrub fraction to millis within the clip`() {
+        assertThat(recorderSeekTargetMs(durationMs = 10_000, fraction = 0.5f)).isEqualTo(5_000)
+    }
+
+    @Test
+    fun `recorderSeekTargetMs coerces out-of-range fractions into the clip bounds`() {
+        assertThat(recorderSeekTargetMs(durationMs = 10_000, fraction = 1.5f)).isEqualTo(10_000)
+        assertThat(recorderSeekTargetMs(durationMs = 10_000, fraction = -0.3f)).isEqualTo(0)
+    }
+
+    @Test
+    fun `recorderSeekTargetMs returns null for a non-positive duration so nothing seeks`() {
+        assertThat(recorderSeekTargetMs(durationMs = 0, fraction = 0.5f)).isNull()
+    }
+
     private companion object {
         const val BARS = 48
         const val FLOOR = 0.06f

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderEnvelopeTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderEnvelopeTest.kt
@@ -44,22 +44,6 @@ internal class RecorderEnvelopeTest {
         assertThat(buildRecorderEnvelope(List(100) { 0f }, BARS)).isNull()
     }
 
-    @Test
-    fun `recorderSeekTargetMs maps a scrub fraction to millis within the clip`() {
-        assertThat(recorderSeekTargetMs(durationMs = 10_000, fraction = 0.5f)).isEqualTo(5_000)
-    }
-
-    @Test
-    fun `recorderSeekTargetMs coerces out-of-range fractions into the clip bounds`() {
-        assertThat(recorderSeekTargetMs(durationMs = 10_000, fraction = 1.5f)).isEqualTo(10_000)
-        assertThat(recorderSeekTargetMs(durationMs = 10_000, fraction = -0.3f)).isEqualTo(0)
-    }
-
-    @Test
-    fun `recorderSeekTargetMs returns null for a non-positive duration so nothing seeks`() {
-        assertThat(recorderSeekTargetMs(durationMs = 0, fraction = 0.5f)).isNull()
-    }
-
     private companion object {
         const val BARS = 48
         const val FLOOR = 0.06f

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderEnvelopeTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderEnvelopeTest.kt
@@ -44,6 +44,23 @@ internal class RecorderEnvelopeTest {
         assertThat(buildRecorderEnvelope(List(100) { 0f }, BARS)).isNull()
     }
 
+    @Test
+    fun `review wave follows the live player position while the clip is loaded`() {
+        assertThat(reviewWavePositionMs(playerPositionMs = 2_000, pendingScrubMs = 5_000)).isEqualTo(2_000)
+    }
+
+    @Test
+    fun `review wave holds a pre-play scrub when no player is loaded`() {
+        assertThat(reviewWavePositionMs(playerPositionMs = null, pendingScrubMs = 3_000)).isEqualTo(3_000)
+    }
+
+    @Test
+    fun `review wave rests at the start with no player and no pending scrub (e g after completion)`() {
+        // Regression: parity once let the last scrub stick after completion; the listen screen rewinds
+        // to 0, so the review must too once the pending scrub has been consumed by play.
+        assertThat(reviewWavePositionMs(playerPositionMs = null, pendingScrubMs = null)).isEqualTo(0)
+    }
+
     private companion object {
         const val BARS = 48
         const val FLOOR = 0.06f

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecorderScreenTest.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeRight
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
 import com.google.common.truth.Truth.assertThat
@@ -105,17 +107,35 @@ internal class RecorderScreenTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `review waveform exposes no seek action`() {
-        // The recorder review is read-only (shared EnvelopeWaveform called with onSeek = null), so it
-        // must not advertise a SetProgress action — otherwise TalkBack would offer a phantom scrub the
-        // recorder never wired. The Vault listen wave is the only seekable envelope (covered there).
+    fun `review waveform exposes a seek action`() {
+        // The recorder review is scrubbable (shared EnvelopeWaveform wired with onSeek), so it must
+        // advertise a SetProgress action for TalkBack — matching the Vault listen wave.
         val review = RecorderState.Review(Uri.parse("content://clip"), durationMs = 5_000)
         composeTestRule.setContent {
             AppTheme { recorder(review, isPreviewPlaying = true, previewPositionMs = 2_000) }
         }
 
         val node = composeTestRule.onNodeWithContentDescription("Playback progress").fetchSemanticsNode()
-        assertThat(node.config.contains(SemanticsActions.SetProgress)).isFalse()
+        assertThat(node.config.contains(SemanticsActions.SetProgress)).isTrue()
+    }
+
+    @Test
+    fun `dragging the review waveform seeks on release`() {
+        var seeked: Float? = null
+        val review = RecorderState.Review(Uri.parse("content://clip"), durationMs = 5_000)
+        composeTestRule.setContent {
+            AppTheme { recorder(review, isPreviewPlaying = true, previewPositionMs = 2_000, onSeek = { seeked = it }) }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("Playback progress")
+            .performTouchInput { swipeRight() }
+        composeTestRule.waitForIdle()
+
+        // Released near the right edge → a fraction well into the second half of the clip.
+        assertThat(seeked).isNotNull()
+        assertThat(seeked!!).isAtLeast(0.5f)
+        assertThat(seeked).isAtMost(1f)
     }
 
     @Composable
@@ -125,6 +145,7 @@ internal class RecorderScreenTest : AbstractRobolectricTest() {
         previewPositionMs: Long = 0L,
         peaks: FloatArray? = null,
         onRecordTap: () -> Unit = {},
+        onSeek: (Float) -> Unit = {},
     ) {
         RecorderScreen(
             state = state,
@@ -137,6 +158,7 @@ internal class RecorderScreenTest : AbstractRobolectricTest() {
             onUseClip = {},
             onReRecord = {},
             onClose = {},
+            onSeek = onSeek,
         )
     }
 }


### PR DESCRIPTION
### Summary

Two waveform-scrub changes — one new capability, one fix.

**Recorder review is now scrubbable (new).**
1. Record a Bomp and reach the review screen.
2. Drag the waveform to any spot — before, during, or after playback.
3. Tap play.

**before:** the review waveform was display-only — no way to jump around the clip.
**after:** dragging scrubs to any spot and playback resumes from there, exactly like the listen screen.

**Listen-screen seek right after opening (fix).**
1. Open an audio in listen mode.
2. Immediately drag the waveform to seek.

**before:** dragging before the audio's length finished loading silently did nothing.
**after:** the seek lands even in that early window.

### Technical detail

Make the shared `EnvelopeWaveform` seek robust and bring the recorder to full listen-screen parity.

- **`EnvelopeWaveform`** (fix) — the drag `pointerInput(Unit)` captured a stale `onSeek`; `rememberUpdatedState(onSeek)` makes the release invoke the current closure.
- **Recorder scrub parity** — `RecordingActivity` persists the scrub position (`rememberSaveable`, mirroring the Vault's VM `_pausedProgress`), so the wave holds the scrubbed spot with no player loaded (before first play / after completion). `PlayerController.startPlayingUri` gains an optional `startPositionMs` so play resumes from the scrubbed offset (seek between prepare and start, like the Sound resume path).
- **`PlayerControllerImpl.seekTo`** — publishes the new `positionMs` into `_playbackState` (so a paused scrub reflects), and now wraps the `MediaPlayer` call in `runCatching` + `Tracker.track` like its siblings.
- **Completion consistency** — the held scrub is a *pending pre-play* offset (`reviewWavePositionMs`) that `play` consumes, so when the clip finishes the wave rewinds to the start like the listen screen instead of sticking at the last scrub.
- **`seekTargetMs`** (`feature/playback`) — one shared fraction→ms mapping routed by both the Vault listen and recorder scrubs (was cloned per surface); clamps just shy of the end so a full-right scrub can't land on EOS and stop the preview.

### Code review tips

- **Part A (the Vault rememberUpdatedState fix) has no unit test, deliberately** — the stale `pointerInput(Unit)` capture isn't reproducible in Robolectric (a focused test passed pre-fix); it's the documented Compose remedy. *Manual verification suggested:* open an audio cold and drag-seek before its length loads.
- **`PlayerControllerImpl` (shared playback) changes:** `startPositionMs` defaults to 0 so existing `startPlayingUri` callers are unaffected; `seekTo`'s state publish is a no-op when nothing is loaded. All existing PlayerController tests stay green.
- **Recorder scrub-position lives in the host** (`RecordingActivity`), not the VM — unlike the Vault, the recorder owns playback in the host. Resets per clip.
- **Addresses a full `/code-review`:** the earlier "seek only while the preview is active" gap is gone (full parity now). The `AudioPreview` / `SoundItem` slider seeks still inline the same fraction→ms math and could also route through `seekTargetMs` — left out here because their EOS semantics differ (a slider may intend to reach the end).

### Already tested

- instrumented: corrido local vía wrapper (cold-boot), 128 tests, 0 failed, 2 skipped — verde tras re-runs; los fallos previos fueron flakes ambientales del AVD degradado (StrictMode InstanceCountViolation, Process crashed, stalls), todos en tests ajenos al cambio

