### PR TITLE
refactor(playback): route preview/list sliders through seekTargetMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 #### Changed
 - De-duplicated the Vault listen and recorder-review waveforms into one shared `EnvelopeWaveform` component, and the `0.06f` floor + normalize loop into a single `WaveformNormalization` helper (ADR 0020)
+- Routed the `AudioPreview` and `SoundItem` progress sliders through the shared `seekTargetMs` mapping (a new `reserveEndMargin` flag keeps their reach-the-end semantics, distinct from the waveform scrub), finishing the fraction→ms dedup left over from the waveform scrub work
 - Kotlin compiler warnings now fail the build (`allWarningsAsErrors`, binary/unconditional) so they can't accumulate
 - `sounds_json` decoding is now element-by-element with id de-dup and a fast path, so one corrupt record can't wipe the list and clean payloads pay no recovery cost (ADR 0018)
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AudioPreview.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AudioPreview.kt
@@ -45,6 +45,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
+import com.github.barriosnahuel.vossosunboton.feature.playback.seekTargetMs
 import com.github.barriosnahuel.vossosunboton.ui.AppIcons
 import com.github.barriosnahuel.vossosunboton.ui.home.formatDuration
 import com.github.barriosnahuel.vossosunboton.ui.home.formatRelativeDate
@@ -188,7 +189,9 @@ internal fun AudioPreview(
                         Slider(
                             value = sliderPosition,
                             onValueChange = { value ->
-                                if (durationMs > 0) controller.seekTo((value * durationMs).toInt())
+                                // reserveEndMargin = false: a full-right drag may intend to reach
+                                // the end and complete, unlike the waveform scrub (see seekTargetMs).
+                                seekTargetMs(durationMs.toLong(), value, reserveEndMargin = false)?.let(controller::seekTo)
                             },
                             enabled = isPlaying,
                             colors =

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/SeekTarget.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/SeekTarget.kt
@@ -7,16 +7,23 @@ package com.github.barriosnahuel.vossosunboton.feature.playback
 
 /**
  * Maps a scrub [fraction] (0..1) to a millisecond seek target within a clip of [durationMs]. Returns
- * `null` for a non-positive duration (nothing to seek). Clamps just shy of the end so a full-right
- * scrub stays a valid in-range position instead of landing exactly on EOS. Pure — the single source
- * for the fraction→ms mapping shared by the listen and recorder-review waveform scrubs (was inlined
- * per surface).
+ * `null` for a non-positive duration (nothing to seek). Pure — the single source for the fraction→ms
+ * mapping shared by the waveform scrubs and the progress sliders (was inlined per surface).
+ *
+ * [reserveEndMargin] controls the end semantics, which differ per surface:
+ * - `true` (default) — clamps just shy of the end so a full-right scrub stays in-range instead of
+ *   landing on EOS. Used by the waveform scrubs (listen + recorder review), where landing on EOS
+ *   fires onCompletion and stops/resets the preview.
+ * - `false` — lets a full-right value reach exactly [durationMs] so a progress slider dragged to the
+ *   end can complete naturally. Used by the `AudioPreview` / `SoundItem` sliders.
  */
 internal fun seekTargetMs(
     durationMs: Long,
     fraction: Float,
+    reserveEndMargin: Boolean = true,
 ): Int? {
     if (durationMs <= 0L) return null
     val target = (fraction.coerceIn(0f, 1f) * durationMs).toLong()
-    return target.coerceIn(0L, durationMs - 1L).toInt()
+    val maxTarget = if (reserveEndMargin) durationMs - 1L else durationMs
+    return target.coerceIn(0L, maxTarget).toInt()
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
+import com.github.barriosnahuel.vossosunboton.feature.playback.seekTargetMs
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.ui.AppIcons
 import com.github.barriosnahuel.vossosunboton.ui.haptics.performConfirmHaptic
@@ -498,7 +499,10 @@ private fun SoundCard(
                         onValueChangeFinished = {
                             isDragging = false
                             if (playbackProgress != null) {
-                                onSeek((sliderPosition * playbackProgress.durationMs).toInt())
+                                // reserveEndMargin = false: a full-right drag may intend to reach
+                                // the end and complete, unlike the waveform scrub (see seekTargetMs).
+                                seekTargetMs(playbackProgress.durationMs.toLong(), sliderPosition, reserveEndMargin = false)
+                                    ?.let(onSeek)
                             }
                         },
                         enabled = sound.isPlaying,

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/SeekTargetTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/SeekTargetTest.kt
@@ -30,4 +30,22 @@ internal class SeekTargetTest {
     fun `returns null for a non-positive duration so nothing seeks`() {
         assertThat(seekTargetMs(durationMs = 0, fraction = 0.5f)).isNull()
     }
+
+    @Test
+    fun `without end margin a full-right scrub reaches the end so a slider can complete`() {
+        // A progress slider dragged to the end should land on EOS and complete naturally, unlike the
+        // waveform scrub which reserves the margin to keep the preview alive.
+        assertThat(seekTargetMs(durationMs = 10_000, fraction = 1f, reserveEndMargin = false)).isEqualTo(10_000)
+        assertThat(seekTargetMs(durationMs = 10_000, fraction = 1.5f, reserveEndMargin = false)).isEqualTo(10_000)
+    }
+
+    @Test
+    fun `without end margin a mid scrub still maps to millis within the clip`() {
+        assertThat(seekTargetMs(durationMs = 10_000, fraction = 0.5f, reserveEndMargin = false)).isEqualTo(5_000)
+    }
+
+    @Test
+    fun `without end margin a non-positive duration still returns null`() {
+        assertThat(seekTargetMs(durationMs = 0, fraction = 1f, reserveEndMargin = false)).isNull()
+    }
 }


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change. The preview slider (add sheet) and the My Sounds list slider keep seeking exactly as before; this finishes the fraction→ms dedup left over from the waveform-scrub work (#1251) so all four seek surfaces share one mapping.

### Technical detail

Route the two progress sliders through the existing shared `seekTargetMs`, replacing their inlined `(fraction * durationMs).toInt()`.

- **`SeekTarget.kt`** — new `reserveEndMargin: Boolean = true` param. `true` (waveform scrubs) clamps to `durationMs-1` so a full-right scrub never lands on EOS and stops the preview; `false` (sliders) lets a full-right drag reach exactly `durationMs` so it can complete naturally — the EOS-semantics split you flagged on #1251.
- **`AudioPreview.kt` / `SoundItem.kt`** — sliders now call `seekTargetMs(durationMs, fraction, reserveEndMargin = false)?.let(...)`; the null-on-zero-duration guard and fraction coercion are centralized.
- **Left unchanged:** the two waveform callers (`ImmersiveListenScreen`, `RecordingActivity`) keep the default `true` — verified identical output.

### Code review tips

- **EOS semantics preserved per surface (Interpretation):** sliders pass `reserveEndMargin = false` to keep their reach-the-end behavior; only the waveform scrubs reserve the end margin. This is the conservative reading of the #1251 note — sliders may intend to complete, not clamp.
- **One deliberate micro-divergence in `SoundItem`:** when `playbackProgress.durationMs == 0` (transient, pre-duration-resolved) the old code called `onSeek(0)`; `seekTargetMs` returns `null` there, so no seek fires. Benign (the slider is `enabled = isPlaying`, and seeking a zero-duration clip is meaningless) and arguably more correct. `AudioPreview` has no divergence — its Card is already gated behind `durationMs > 0`.
- **Self-review:** confirmed the `Float * Long → toLong → coerceIn → toInt` path reproduces the prior `Float * Int → toInt` for all in-range slider values (full-right, mid, null guards).

### Already tested

- instrumented: corridos local vía wrapper (cold-boot), 126 tests, 124 verdes, 2 skipped (los esperados es-AR/deep-link), 0 failed