### PR TITLE
feat(hub): reorder add sheet and add a bring-from-apps guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 ### Changed
 - The add-a-Bomp sheet now leads with recording and adds a "Bring audios from other apps" option that shows how to share a voice note in from WhatsApp or Telegram, with importing a saved file moved last
+- The quick tour is easier to find — it shows up right under the welcome audio for new users and lives in the top "⋮" menu so you can reopen it any time
 
 ### Fixed
 - Bomps saved before an earlier update no longer disappear when you open the app — audios stored under the old format are recovered instead of the whole list silently emptying
@@ -31,7 +32,8 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Shortened seven collection/Vault user property names that exceeded Firebase's 24-character limit and were being dropped before reaching BigQuery, and added a build-time guard so over-length names can't ship again
 
 #### Changed
-- Reordered the import Hub rows by returning-user intent (record → bring-from-apps → import) and replaced the Hub's full-tour entry with a focused single-step guide reusing the onboarding IMPORT step; added the `import_hub_bring_selected` funnel event (the full tour stays reachable from the empty state)
+- Reordered the import Hub rows by returning-user intent (record → bring-from-apps → import) and replaced the Hub's full-tour entry with a focused single-step guide reusing the onboarding IMPORT step; added the `import_hub_bring_selected` funnel event and a `bring_guide` screen_view
+- Surfaced the full onboarding tour from a welcome-audio footer and the top-bar overflow (so a fresh-install user, whose welcome audio hides the empty-state, can still reach it); parameterized `onboarding_opened` by source (`welcome_footer`, `overflow_menu`) and reordered the overflow menu with decorative leading icons
 - De-duplicated the Vault listen and recorder-review waveforms into one shared `EnvelopeWaveform` component, and the `0.06f` floor + normalize loop into a single `WaveformNormalization` helper (ADR 0020)
 - Kotlin compiler warnings now fail the build (`allWarningsAsErrors`, binary/unconditional) so they can't accumulate
 - `sounds_json` decoding is now element-by-element with id de-dup and a fast path, so one corrupt record can't wipe the list and clean payloads pay no recovery cost (ADR 0018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Record a Bomp without leaving the app — the add sheet's "Record" option opens a full-screen recorder: tap to record, listen back on a real waveform, and save it like any other Bomp; if you leave mid-recording, a banner offers to pick it back up
 - Drag the recorder's review waveform to scrub through your recording and jump to any spot — before, during, or after playback — the same way you can on the listen screen
 
+### Changed
+- The add-a-Bomp sheet now leads with recording and adds a "Bring audios from other apps" option that shows how to share a voice note in from WhatsApp or Telegram, with importing a saved file moved last
+
 ### Fixed
 - Bomps saved before an earlier update no longer disappear when you open the app — audios stored under the old format are recovered instead of the whole list silently emptying
 - Dragging the listen-screen waveform to seek now works even right after opening an audio, before its length has finished loading
@@ -28,6 +31,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 - Shortened seven collection/Vault user property names that exceeded Firebase's 24-character limit and were being dropped before reaching BigQuery, and added a build-time guard so over-length names can't ship again
 
 #### Changed
+- Reordered the import Hub rows by returning-user intent (record → bring-from-apps → import) and replaced the Hub's full-tour entry with a focused single-step guide reusing the onboarding IMPORT step; added the `import_hub_bring_selected` funnel event (the full tour stays reachable from the empty state)
 - De-duplicated the Vault listen and recorder-review waveforms into one shared `EnvelopeWaveform` component, and the `0.06f` floor + normalize loop into a single `WaveformNormalization` helper (ADR 0020)
 - Kotlin compiler warnings now fail the build (`allWarningsAsErrors`, binary/unconditional) so they can't accumulate
 - `sounds_json` decoding is now element-by-element with id de-dup and a fast path, so one corrupt record can't wipe the list and clean payloads pay no recovery cost (ADR 0018)

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/HomeTabFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/HomeTabFlowTest.kt
@@ -153,6 +153,20 @@ internal class HomeTabFlowTest : AbstractUiTest() {
         }
     }
 
+    @Test
+    fun overflowSeeHowItWorksOpensTheTour() {
+        // A seeded custom sound hides the welcome footer, so the overflow item is the only "See how it
+        // works"; tapping it opens the full onboarding tour at step 1.
+        TestData.seedCustomSounds(context, count = 1)
+
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            composeRule.awaitNodeWithContentDescription(overflowLabel()).performClick()
+            composeRule.awaitNodeWithText(seeHowItWorksLabel()).performClick()
+
+            composeRule.awaitNodeWithText(tourStep1Title()).assertIsDisplayed()
+        }
+    }
+
     private fun playLabel() = context.getString(R.string.app_play)
 
     private fun pauseLabel() = context.getString(R.string.app_pause)
@@ -168,6 +182,10 @@ internal class HomeTabFlowTest : AbstractUiTest() {
     private fun searchLabel() = context.getString(R.string.app_search)
 
     private fun overflowLabel() = context.getString(R.string.app_overflow_menu)
+
+    private fun seeHowItWorksLabel() = context.getString(R.string.app_my_sounds_empty_secondary)
+
+    private fun tourStep1Title() = context.getString(R.string.app_onboarding_step1_title)
 
     companion object {
         private const val SNACKBAR_LONG_TIMEOUT_MS = 15_000L

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/HubImportFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/ui/home/HubImportFlowTest.kt
@@ -97,13 +97,15 @@ internal class HubImportFlowTest : AbstractUiTest() {
     }
 
     @Test
-    fun hubExposesSeeHowItWorksEntryPoint() {
-        // PR4: the onboarding entry point now has a live destination, so it joins the Hub as an
-        // actionable row. The full open→tour flow (with its looping demo animations) is covered by the
-        // reduce-motion Robolectric suite; here we only assert the new tappable thing is reachable.
+    fun bringFromAppsRowOpensTheGuide() {
+        // The "bring audios from other apps" row opens the focused single-step guide. Assert the
+        // transition end-to-end: tapping the row dismisses the Hub and lands on the guide (its terminal
+        // CTA is shown). The looping demo animation itself is covered by the reduce-motion Robolectric suite.
         ActivityScenario.launch(LandingActivity::class.java).use {
             composeRule.awaitNodeWithContentDescription(fabLabel()).performClick()
-            composeRule.awaitNodeWithText(howLabel()).assertHasClickAction()
+            composeRule.awaitNodeWithText(bringLabel()).performClick()
+
+            composeRule.awaitNodeWithText(bringGuideCta()).assertIsDisplayed()
         }
     }
 
@@ -113,7 +115,9 @@ internal class HubImportFlowTest : AbstractUiTest() {
 
     private fun importLabel() = context.getString(R.string.app_hub_import)
 
-    private fun howLabel() = context.getString(R.string.app_hub_how)
+    private fun bringLabel() = context.getString(R.string.app_hub_bring)
+
+    private fun bringGuideCta() = context.getString(R.string.app_hub_bring_guide_cta)
 
     companion object {
         private val PICKED_AUDIO: Uri = Uri.parse("content://test/picked-audio.mp3")

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/onboarding/BringFromAppsGuide.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/onboarding/BringFromAppsGuide.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.onboarding
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.ui.rememberReduceMotionEnabled
+import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
+
+private val STAGE_RADIUS = 24.dp
+private val CTA_HEIGHT = 56.dp
+
+/**
+ * Focused single-step guide reached from the Hub's "bring audios from other apps" row. Reuses the
+ * onboarding IMPORT step's content (title/body) and its live share-in demo ([OnboardingImportDemo]) so
+ * the lesson stays in sync with the full tour — but without the tour's navigation machinery (no progress
+ * dots, no story tap-halves, no step funnel analytics). The CTA is terminal ("Got it") rather than the
+ * tour's "Go on", since there is nothing after it.
+ *
+ * Stateless: [onClose] is owned by the host (`LandingScreen`), which also emits the ONBOARDING
+ * screen_view and clears its visibility flag. Back closes the guide, returning the user where they were.
+ */
+@Composable
+internal fun BringFromAppsGuide(onClose: () -> Unit) {
+    val reduceMotion = rememberReduceMotionEnabled()
+    BackHandler { onClose() }
+    Scaffold(containerColor = MaterialTheme.colorScheme.surface) { innerPadding ->
+        // The terminal CTA stays pinned at the bottom (always reachable); the demo + copy scroll above it
+        // so they survive short windows, large fonts and split-screen. Mirrors the tour's portrait layout.
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(horizontal = Spacing.XL, vertical = Spacing.XL),
+        ) {
+            // The demo takes the flexible top (shrinks / scrolls within on short windows) so the lesson
+            // copy + terminal CTA below stay visible without a page scroll, mirroring the tour's stage.
+            // Decorative animation: one merged description for TalkBack (the IMPORT step's demo copy).
+            val demoDescription = stringResource(R.string.app_onboarding_step1_demo_description)
+            Column(
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .verticalScroll(rememberScrollState())
+                        .clip(RoundedCornerShape(STAGE_RADIUS))
+                        .background(MaterialTheme.colorScheme.surfaceVariant)
+                        .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(STAGE_RADIUS))
+                        .padding(Spacing.LG)
+                        .clearAndSetSemantics {
+                            contentDescription = demoDescription
+                        },
+            ) {
+                OnboardingImportDemo(reduceMotion = reduceMotion)
+            }
+            Spacer(Modifier.height(Spacing.LG))
+            Text(
+                text = stringResource(R.string.app_onboarding_step1_eyebrow).uppercase(),
+                fontFamily = FontFamily.Monospace,
+                fontSize = 10.sp,
+                letterSpacing = 1.6.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(Spacing.SM))
+            Text(
+                text = stringResource(R.string.app_onboarding_step1_title),
+                style = MaterialTheme.typography.displaySmall,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(Modifier.height(Spacing.MD))
+            Text(
+                text = stringResource(R.string.app_onboarding_step1_body),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(Spacing.XL))
+            // Filled-primary tier (ADR 0010): the single, terminal action of the screen. Tall acid pill.
+            Button(
+                onClick = onClose,
+                modifier = Modifier.fillMaxWidth().height(CTA_HEIGHT),
+                shape = RoundedCornerShape(percent = 50),
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    ),
+            ) {
+                Text(
+                    text = stringResource(R.string.app_hub_bring_guide_cta),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/onboarding/BringFromAppsGuide.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/onboarding/BringFromAppsGuide.kt
@@ -6,119 +6,72 @@
 package com.github.barriosnahuel.vossosunboton.feature.onboarding
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.clearAndSetSemantics
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.ui.rememberReduceMotionEnabled
 import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
 
-private val STAGE_RADIUS = 24.dp
-private val CTA_HEIGHT = 56.dp
-
 /**
  * Focused single-step guide reached from the Hub's "bring audios from other apps" row. Reuses the
- * onboarding IMPORT step's content (title/body) and its live share-in demo ([OnboardingImportDemo]) so
- * the lesson stays in sync with the full tour — but without the tour's navigation machinery (no progress
- * dots, no story tap-halves, no step funnel analytics). The CTA is terminal ("Got it") rather than the
- * tour's "Go on", since there is nothing after it.
+ * onboarding IMPORT step's content ([ONBOARDING_IMPORT_STEP]) and shared chrome ([DemoStage],
+ * [OnboardingStepHeadline], [OnboardingPrimaryCta]) so the lesson stays in sync with the full tour —
+ * but without the tour's navigation machinery (no progress dots, no story tap-halves, no step funnel
+ * analytics). The CTA is terminal ("Got it") rather than the tour's "Go on".
  *
- * Stateless: [onClose] is owned by the host (`LandingScreen`), which also emits the ONBOARDING
+ * Stateless: [onClose] is owned by the host (`LandingScreen`), which also emits the BRING_GUIDE
  * screen_view and clears its visibility flag. Back closes the guide, returning the user where they were.
  */
 @Composable
 internal fun BringFromAppsGuide(onClose: () -> Unit) {
     val reduceMotion = rememberReduceMotionEnabled()
+    val step = ONBOARDING_IMPORT_STEP
     BackHandler { onClose() }
     Scaffold(containerColor = MaterialTheme.colorScheme.surface) { innerPadding ->
-        // The terminal CTA stays pinned at the bottom (always reachable); the demo + copy scroll above it
-        // so they survive short windows, large fonts and split-screen. Mirrors the tour's portrait layout.
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding)
-                    .padding(horizontal = Spacing.XL, vertical = Spacing.XL),
-        ) {
-            // The demo takes the flexible top (shrinks / scrolls within on short windows) so the lesson
-            // copy + terminal CTA below stay visible without a page scroll, mirroring the tour's stage.
-            // Decorative animation: one merged description for TalkBack (the IMPORT step's demo copy).
-            val demoDescription = stringResource(R.string.app_onboarding_step1_demo_description)
+        // Same cramped-window handling as OnboardingTour: portrait pins the CTA (the demo flexes via
+        // weight); landscape / split-screen / large fonts switch to a fully scrollable column so the
+        // copy + terminal CTA stay reachable instead of overflowing off-screen.
+        BoxWithConstraints(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+            val cramped = maxWidth > maxHeight
             Column(
                 modifier =
                     Modifier
-                        .weight(1f)
                         .fillMaxWidth()
-                        .verticalScroll(rememberScrollState())
-                        .clip(RoundedCornerShape(STAGE_RADIUS))
-                        .background(MaterialTheme.colorScheme.surfaceVariant)
-                        .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(STAGE_RADIUS))
-                        .padding(Spacing.LG)
-                        .clearAndSetSemantics {
-                            contentDescription = demoDescription
+                        .then(if (cramped) Modifier.verticalScroll(rememberScrollState()) else Modifier.fillMaxHeight())
+                        .padding(horizontal = Spacing.XL, vertical = Spacing.XL),
+            ) {
+                DemoStage(
+                    step = 0,
+                    reduceMotion = reduceMotion,
+                    demoDescription = stringResource(step.demoDescription),
+                    modifier =
+                        if (cramped) {
+                            Modifier.fillMaxWidth().heightIn(min = DEMO_MIN_HEIGHT)
+                        } else {
+                            Modifier.weight(1f).fillMaxWidth()
                         },
-            ) {
-                OnboardingImportDemo(reduceMotion = reduceMotion)
-            }
-            Spacer(Modifier.height(Spacing.LG))
-            Text(
-                text = stringResource(R.string.app_onboarding_step1_eyebrow).uppercase(),
-                fontFamily = FontFamily.Monospace,
-                fontSize = 10.sp,
-                letterSpacing = 1.6.sp,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(Modifier.height(Spacing.SM))
-            Text(
-                text = stringResource(R.string.app_onboarding_step1_title),
-                style = MaterialTheme.typography.displaySmall,
-                fontWeight = FontWeight.Medium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Spacer(Modifier.height(Spacing.MD))
-            Text(
-                text = stringResource(R.string.app_onboarding_step1_body),
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(Modifier.height(Spacing.XL))
-            // Filled-primary tier (ADR 0010): the single, terminal action of the screen. Tall acid pill.
-            Button(
-                onClick = onClose,
-                modifier = Modifier.fillMaxWidth().height(CTA_HEIGHT),
-                shape = RoundedCornerShape(percent = 50),
-                colors =
-                    ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.primaryContainer,
-                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                    ),
-            ) {
-                Text(
+                )
+                Spacer(Modifier.height(Spacing.LG))
+                OnboardingStepHeadline(content = step, leadingNumber = null)
+                Spacer(Modifier.height(Spacing.XL))
+                OnboardingPrimaryCta(
                     text = stringResource(R.string.app_hub_bring_guide_cta),
-                    style = MaterialTheme.typography.titleMedium,
+                    showTrailingArrow = false,
+                    onClick = onClose,
                 )
             }
         }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/onboarding/OnboardingScreen.kt
@@ -69,15 +69,16 @@ internal const val ONBOARDING_STEP_COUNT = 3
 internal const val ONBOARDING_TAP_PREV = "onboarding_tap_prev"
 internal const val ONBOARDING_TAP_NEXT = "onboarding_tap_next"
 
-private val STAGE_RADIUS = 24.dp
-private val CTA_HEIGHT = 56.dp
+// Shared with BringFromAppsGuide (same package), which reuses the demo card + CTA pill.
+internal val STAGE_RADIUS = 24.dp
+internal val CTA_HEIGHT = 56.dp
 private val DOT_HEIGHT = 7.dp
 private val DOT_ACTIVE_WIDTH = 22.dp
 
 // Min height the demo keeps when the layout switches to its scrollable (landscape) variant.
-private val DEMO_MIN_HEIGHT = 200.dp
+internal val DEMO_MIN_HEIGHT = 200.dp
 
-private data class OnboardingStepContent(
+internal data class OnboardingStepContent(
     // Stable concept slug for analytics — survives a future reorder of the display positions, so the
     // funnel keys on "what the step teaches", not its (mutable) 1/2/3 index. NOT user-facing.
     val key: String,
@@ -88,6 +89,9 @@ private data class OnboardingStepContent(
     @StringRes val cta: Int,
     @StringRes val demoDescription: Int,
 )
+
+/** The IMPORT step's content, reused standalone by [BringFromAppsGuide] so its copy never drifts from the tour. */
+internal val ONBOARDING_IMPORT_STEP: OnboardingStepContent get() = ONBOARDING_STEPS[0]
 
 private val ONBOARDING_STEPS =
     listOf(
@@ -287,72 +291,106 @@ internal fun OnboardingTour(
                 }
 
                 Spacer(Modifier.height(Spacing.LG))
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(
-                        text = content.number,
-                        fontFamily = FontFamily.Monospace,
-                        fontSize = 11.sp,
-                        fontWeight = FontWeight.Bold,
-                        letterSpacing = 1.sp,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
-                    Spacer(Modifier.width(Spacing.SM))
-                    Text(
-                        text = stringResource(content.eyebrow).uppercase(),
-                        fontFamily = FontFamily.Monospace,
-                        fontSize = 10.sp,
-                        letterSpacing = 1.6.sp,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                Spacer(Modifier.height(Spacing.SM))
-                Text(
-                    text = stringResource(content.title),
-                    style = MaterialTheme.typography.displaySmall,
-                    fontWeight = FontWeight.Medium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
-                Spacer(Modifier.height(Spacing.MD))
-                Text(
-                    text = stringResource(content.body),
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+                OnboardingStepHeadline(content = content, leadingNumber = content.number)
 
                 Spacer(Modifier.height(Spacing.XL))
-                // Filled-primary tier (ADR 0010): the single forward action of the screen. Tall acid pill.
-                Button(
+                OnboardingPrimaryCta(
+                    text = stringResource(content.cta),
+                    showTrailingArrow = isLast,
                     onClick = { if (isLast) finish(AnalyticsNavMethod.BUTTON) else advance(AnalyticsNavMethod.BUTTON) },
-                    modifier = Modifier.fillMaxWidth().height(CTA_HEIGHT),
-                    shape = RoundedCornerShape(percent = 50),
-                    colors =
-                        ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.primaryContainer,
-                            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                        ),
-                ) {
-                    Text(
-                        text = stringResource(content.cta),
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                    if (isLast) {
-                        Spacer(Modifier.width(Spacing.SM))
-                        Icon(
-                            painter = painterResource(R.drawable.app_ic_keyboard_arrow_right),
-                            contentDescription = null,
-                            modifier = Modifier.height(Spacing.XL),
-                        )
-                    }
-                }
+                )
                 Spacer(Modifier.height(Spacing.XL))
             }
         }
     }
 }
 
+/**
+ * The step's eyebrow (optionally preceded by [leadingNumber]), title and body. Shared between the tour
+ * (which passes the step number) and [BringFromAppsGuide] (which passes null) so typography never drifts.
+ */
+@Composable
+internal fun OnboardingStepHeadline(
+    content: OnboardingStepContent,
+    leadingNumber: String?,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            if (leadingNumber != null) {
+                Text(
+                    text = leadingNumber,
+                    fontFamily = FontFamily.Monospace,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.Bold,
+                    letterSpacing = 1.sp,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Spacer(Modifier.width(Spacing.SM))
+            }
+            Text(
+                text = stringResource(content.eyebrow).uppercase(),
+                fontFamily = FontFamily.Monospace,
+                fontSize = 10.sp,
+                letterSpacing = 1.6.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Spacer(Modifier.height(Spacing.SM))
+        Text(
+            text = stringResource(content.title),
+            style = MaterialTheme.typography.displaySmall,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Spacer(Modifier.height(Spacing.MD))
+        Text(
+            text = stringResource(content.body),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+/**
+ * Filled-primary tier (ADR 0010): the screen's single forward action, a tall acid pill. Shared between
+ * the tour (forward/finish, [showTrailingArrow] on the last step) and [BringFromAppsGuide] (terminal).
+ */
+@Composable
+internal fun OnboardingPrimaryCta(
+    text: String,
+    showTrailingArrow: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth().height(CTA_HEIGHT),
+        shape = RoundedCornerShape(percent = 50),
+        colors =
+            ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            ),
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.titleMedium,
+        )
+        if (showTrailingArrow) {
+            Spacer(Modifier.width(Spacing.SM))
+            Icon(
+                painter = painterResource(R.drawable.app_ic_keyboard_arrow_right),
+                contentDescription = null,
+                modifier = Modifier.height(Spacing.XL),
+            )
+        }
+    }
+}
+
 /** The demo illustration framed in a hairline-bordered tonal card. Decorative: one merged description. */
 @Composable
-private fun DemoStage(
+internal fun DemoStage(
     step: Int,
     reduceMotion: Boolean,
     demoDescription: String,

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/ImportHubSheet.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/ImportHubSheet.kt
@@ -47,19 +47,22 @@ private val HUB_ICON_TILE = 44.dp
 private val HUB_TILE_RADIUS = 12.dp
 
 /**
- * The import Hub — a [ModalBottomSheet] opened by the + FAB on My Bomps. Three creation paths: "import
- * audio from your device" ([onImport]), "record" a new Bomp in-app ([onRecord], ADR 0019), and "see how
- * it works" ([onHowItWorks]) that opens the onboarding tour, re-openable any time.
+ * The import Hub — a [ModalBottomSheet] opened by the + FAB on My Bomps. Rows are ordered by likely
+ * intent for a returning user: "record" a new Bomp in-app ([onRecord], ADR 0019, the acid-primary row),
+ * "bring audios from other apps" ([onBringFromApps]) that opens a focused single-step guide on sharing a
+ * voice note in from WhatsApp/Telegram, and "import audio from your device" ([onImport]) for a file
+ * already saved on the phone (the least-frequent path on Android 11+, where app-private media is not
+ * SAF-browsable). The full 3-step onboarding tour is reachable from the empty state, not from here.
  *
- * Presentational only: the caller dismisses on [onImport]/[onRecord]/[onHowItWorks]/[onDismiss] and owns
- * the file picker, the recorder Activity, and the tour state.
+ * Presentational only: the caller dismisses on [onImport]/[onRecord]/[onBringFromApps]/[onDismiss] and
+ * owns the file picker, the recorder Activity, and the guide state.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun ImportHubSheet(
     onImport: () -> Unit,
     onRecord: () -> Unit,
-    onHowItWorks: () -> Unit,
+    onBringFromApps: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -87,27 +90,15 @@ internal fun ImportHubSheet(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Spacer(Modifier.height(Spacing.SM))
-            HubRow(
-                iconPainter = painterResource(R.drawable.app_ic_add),
-                title = stringResource(R.string.app_hub_import),
-                subtitle = stringResource(R.string.app_hub_import_sub),
-                tileColor = MaterialTheme.colorScheme.primaryContainer,
-                iconColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                // Animate the sheet closed before handing off, mirroring InlineCollectionCreateSheet
-                // (sheetState.hide() then the callback) — the host then clears state + launches the picker.
-                onClick = {
-                    scope.launch {
-                        sheetState.hide()
-                        onImport()
-                    }
-                },
-            )
+            // Acid-primary row: recording is the one creation path that always works, regardless of what
+            // the user already has on the device. Animate the sheet closed before handing off, mirroring
+            // InlineCollectionCreateSheet (sheetState.hide() then the callback).
             HubRow(
                 iconPainter = painterResource(R.drawable.app_ic_mic),
                 title = stringResource(R.string.app_hub_record),
                 subtitle = stringResource(R.string.app_hub_record_sub),
-                tileColor = MaterialTheme.colorScheme.surfaceVariant,
-                iconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                tileColor = MaterialTheme.colorScheme.primaryContainer,
+                iconColor = MaterialTheme.colorScheme.onPrimaryContainer,
                 onClick = {
                     scope.launch {
                         sheetState.hide()
@@ -115,18 +106,31 @@ internal fun ImportHubSheet(
                     }
                 },
             )
-            // Soft secondary helper — neutral tile (not acid) so it never competes with the import
-            // primary. Animate the sheet closed first, then hand off, mirroring the import row.
+            // Neutral tile (not acid) so it never competes with the primary record row. The share icon
+            // mirrors the gesture the guide teaches: "Share" a voice note from another app into Bomp.
             HubRow(
-                iconPainter = painterResource(R.drawable.app_ic_play_arrow),
-                title = stringResource(R.string.app_hub_how),
-                subtitle = stringResource(R.string.app_hub_how_sub),
+                iconPainter = painterResource(R.drawable.app_ic_share),
+                title = stringResource(R.string.app_hub_bring),
+                subtitle = stringResource(R.string.app_hub_bring_sub),
                 tileColor = MaterialTheme.colorScheme.surfaceVariant,
                 iconColor = MaterialTheme.colorScheme.onSurfaceVariant,
                 onClick = {
                     scope.launch {
                         sheetState.hide()
-                        onHowItWorks()
+                        onBringFromApps()
+                    }
+                },
+            )
+            HubRow(
+                iconPainter = painterResource(R.drawable.app_ic_add),
+                title = stringResource(R.string.app_hub_import),
+                subtitle = stringResource(R.string.app_hub_import_sub),
+                tileColor = MaterialTheme.colorScheme.surfaceVariant,
+                iconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                onClick = {
+                    scope.launch {
+                        sheetState.hide()
+                        onImport()
                     }
                 },
             )

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -122,6 +122,10 @@ fun LandingScreen(viewModel: SoundsViewModel) {
     // "is it open" and the step, so an Activity recreate mid-tour cannot rewind the user to step 0
     // (§ Stateful Composables). On-demand only — no first-run auto-open, no "seen" flag.
     var onboardingStep by rememberSaveable { mutableStateOf<Int?>(null) }
+    // The Hub's "bring audios from other apps" single-step guide: true = open. rememberSaveable so an
+    // Activity recreate while it is open doesn't silently dump the user back to My Bomps (§ Stateful
+    // Composables). It reuses the IMPORT onboarding content but is a separate, lighter overlay.
+    var bringGuideVisible by rememberSaveable { mutableStateOf(false) }
     // System file picker for the Hub's "import audio" path. OpenDocument(arrayOf("audio/*")) opens the
     // full SAF browser filtered to audio (non-audio files are not selectable) — better at surfacing
     // on-device audio across OEMs than GetContent's "Recent" view. We copy the audio at save time, so we
@@ -146,10 +150,12 @@ fun LandingScreen(viewModel: SoundsViewModel) {
 
     // Key on the open/closed boolean, not the raw step: advancing or going back within the tour must
     // not re-emit screen_view=onboarding (one open = one screen view, like the other overlays).
-    LaunchedEffect(selectedTab, isAboutVisible, manageRequest, isSearchVisible, onboardingStep != null) {
+    LaunchedEffect(selectedTab, isAboutVisible, manageRequest, isSearchVisible, onboardingStep != null, bringGuideVisible) {
         val name =
             when {
-                onboardingStep != null -> CanonicalScreenName.ONBOARDING
+                // The bring-from-apps guide reuses the onboarding content, so it reports the same screen.
+                // The funnel separates its entry via ImportHubBringSelected, not via a distinct screen_view.
+                onboardingStep != null || bringGuideVisible -> CanonicalScreenName.ONBOARDING
                 isSearchVisible -> CanonicalScreenName.SEARCH_SOUND
                 isAboutVisible -> CanonicalScreenName.ABOUT
                 manageRequest != null -> CanonicalScreenName.MANAGE_COLLECTIONS
@@ -169,6 +175,7 @@ fun LandingScreen(viewModel: SoundsViewModel) {
                 manageRequest == null &&
                 immersiveListenSoundId == null &&
                 onboardingStep == null &&
+                !bringGuideVisible &&
                 tabBackStack.isNotEmpty(),
     ) {
         viewModel.selectTab(tabBackStack.removeAt(tabBackStack.lastIndex))
@@ -201,7 +208,8 @@ fun LandingScreen(viewModel: SoundsViewModel) {
     // and UI tests neither reach nor double-match nodes hidden behind the opaque overlay (e.g. a
     // collection name shown both in the chip row and in the Manage list). Drawing is untouched, so
     // the gesture still reveals the live list visually.
-    val subScreenOpen = isAboutVisible || manageRequest != null || immersiveListenSoundId != null || onboardingStep != null
+    val subScreenOpen =
+        isAboutVisible || manageRequest != null || immersiveListenSoundId != null || onboardingStep != null || bringGuideVisible
     ScaffoldedLanding(
         modifier = if (subScreenOpen) Modifier.clearAndSetSemantics {} else Modifier,
         viewModel = viewModel,
@@ -293,12 +301,21 @@ fun LandingScreen(viewModel: SoundsViewModel) {
                     context.startActivity(RecordingActivity.createIntent(context))
                 }
             },
-            onHowItWorks = {
-                tracker.log(AnalyticsEvent.OnboardingOpened(source = AnalyticsSource.IMPORT_HUB))
-                isHubVisible = false
-                onboardingStep = 0
+            onBringFromApps = {
+                if (isHubVisible) {
+                    tracker.log(AnalyticsEvent.ImportHubBringSelected)
+                    isHubVisible = false
+                    bringGuideVisible = true
+                }
             },
             onDismiss = { isHubVisible = false },
+        )
+    }
+
+    // The Hub's "bring audios from other apps" single-step guide, overlaying everything like the tour.
+    if (bringGuideVisible) {
+        com.github.barriosnahuel.vossosunboton.feature.onboarding.BringFromAppsGuide(
+            onClose = { bringGuideVisible = false },
         )
     }
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -43,7 +43,6 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -60,6 +59,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
@@ -153,10 +153,14 @@ fun LandingScreen(viewModel: SoundsViewModel) {
     }
 
     // Single onboarding-tour entry point: logs the ENTRY with the [source] surface (empty state, the
-    // welcome footer, or the overflow menu), then opens the tour at step 0.
+    // welcome footer, or the overflow menu), then opens the tour at step 0. The `onboardingStep == null`
+    // guard mirrors openHub's: it makes the open idempotent so a rapid double-tap on a trigger can't
+    // double-count `onboarding_opened` (the funnel's "started").
     val openOnboarding = { source: String ->
-        tracker.log(AnalyticsEvent.OnboardingOpened(source = source))
-        onboardingStep = 0
+        if (onboardingStep == null) {
+            tracker.log(AnalyticsEvent.OnboardingOpened(source = source))
+            onboardingStep = 0
+        }
     }
 
     // Key on the open/closed boolean, not the raw step: advancing or going back within the tour must
@@ -252,9 +256,9 @@ fun LandingScreen(viewModel: SoundsViewModel) {
             if (!sound.isPlaying) viewModel.playOrStop(sound)
         },
         onCreateClick = openHub,
-        onShowOnboarding = { openOnboarding(AnalyticsSource.EMPTY_STATE) },
-        onShowOnboardingFromWelcome = { openOnboarding(AnalyticsSource.WELCOME_FOOTER) },
-        onOpenOnboardingFromMenu = { openOnboarding(AnalyticsSource.OVERFLOW_MENU) },
+        // One source-parameterized entry point (mirrors onCreateClick): each surface binds its own
+        // AnalyticsSource at the leaf call site below, so no per-surface callback has to be threaded.
+        onShowOnboarding = openOnboarding,
     )
 
     // Exactly one sub-screen overlays the list at a time (About wins over Manage, preserving the
@@ -344,6 +348,14 @@ fun LandingScreen(viewModel: SoundsViewModel) {
             onSkip = { onboardingStep = null },
             onFinish = {
                 onboardingStep = null
+                // The tour teaches My Bomps and lands on the Hub to add a first Bomp. When it was opened
+                // from the overflow on Vault/Explore, return to My Bomps first so the saved Bomp lands on
+                // the tab the user is looking at — otherwise it goes to the unseen My Bomps list and seems
+                // to vanish.
+                if (selectedTab != AppTab.MY_SOUNDS) {
+                    tabBackStack.add(selectedTab)
+                    viewModel.selectTab(AppTab.MY_SOUNDS)
+                }
                 openHub(AnalyticsSource.ONBOARDING_FINISH)
             },
         )
@@ -465,16 +477,16 @@ private fun ScaffoldedLanding(
     // Opens the import Hub, carrying the funnel `source` of the surface that triggered it (the FAB
     // vs the empty-state CTA), so `import_hub_opened` is attributed honestly.
     onCreateClick: (String) -> Unit,
-    onShowOnboarding: () -> Unit,
-    onShowOnboardingFromWelcome: () -> Unit,
-    onOpenOnboardingFromMenu: () -> Unit,
+    // Opens the onboarding tour, carrying the funnel `source` of the surface that triggered it (empty
+    // state, welcome footer, or overflow). Each leaf surface binds its own constant.
+    onShowOnboarding: (String) -> Unit,
 ) {
     Scaffold(
         modifier = modifier,
         topBar = {
             AppTopBar(
                 onSearchClick = { viewModel.showSearch() },
-                onSeeHowItWorks = onOpenOnboardingFromMenu,
+                onSeeHowItWorks = { onShowOnboarding(AnalyticsSource.OVERFLOW_MENU) },
                 onManageCollectionsClick = onManageCollectionsClick,
                 onAboutClick = onAboutClick,
             )
@@ -548,7 +560,6 @@ private fun ScaffoldedLanding(
                     onActiveFilterEditClick = onActiveFilterEditClick,
                     onImportClick = { onCreateClick(AnalyticsSource.EMPTY_STATE) },
                     onShowOnboarding = onShowOnboarding,
-                    onShowOnboardingFromWelcome = onShowOnboardingFromWelcome,
                     viewModel = viewModel,
                     context = context,
                 )
@@ -683,6 +694,9 @@ private fun SnackbarEffects(
     }
 }
 
+// Test tag for the overflow "See how it works" item, which shares its label with the welcome footer.
+internal const val OVERFLOW_SEE_HOW_IT_WORKS_TAG = "overflow_see_how_it_works"
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun AppTopBar(
@@ -716,6 +730,10 @@ private fun AppTopBar(
                 onDismissRequest = { isMenuExpanded = false },
             ) {
                 DropdownMenuItem(
+                    // Tagged so tests can address this item without its label ("See how it works"),
+                    // which it intentionally shares with the welcome footer. Same label → same action,
+                    // so the duplication is fine for users; the tag only disambiguates for tests.
+                    modifier = Modifier.testTag(OVERFLOW_SEE_HOW_IT_WORKS_TAG),
                     text = { Text(stringResource(R.string.app_my_sounds_empty_secondary)) },
                     leadingIcon = {
                         Icon(painter = painterResource(R.drawable.app_ic_help), contentDescription = null)
@@ -973,9 +991,9 @@ internal fun SoundsList(
                         modifier = Modifier.fillMaxWidth().padding(top = Spacing.SM),
                         contentAlignment = Alignment.Center,
                     ) {
-                        TextButton(onClick = onShowOnboardingFromWelcome) {
-                            Text(stringResource(R.string.app_my_sounds_empty_secondary))
-                        }
+                        // Shared with the empty-state secondary (MySoundsEmptyState) so the two never
+                        // drift in copy or button typology.
+                        SeeHowItWorksButton(onClick = onShowOnboardingFromWelcome)
                     }
                 }
             }
@@ -1004,8 +1022,9 @@ private fun MySoundsBody(
     allCollections: List<com.github.barriosnahuel.vossosunboton.model.Collection>,
     onActiveFilterEditClick: (String) -> Unit,
     onImportClick: () -> Unit,
-    onShowOnboarding: () -> Unit,
-    onShowOnboardingFromWelcome: () -> Unit,
+    // Source-parameterized tour opener; this body binds EMPTY_STATE for the empty-state secondary and
+    // WELCOME_FOOTER for the welcome footer at their respective leaf call sites.
+    onShowOnboarding: (String) -> Unit,
     viewModel: SoundsViewModel,
     context: Context,
 ) {
@@ -1078,7 +1097,7 @@ private fun MySoundsBody(
                 // (Column gives non-weighted children the full max), pushing the CTA below the fold.
                 MySoundsEmptyState(
                     onImportClick = onImportClick,
-                    onShowOnboarding = onShowOnboarding,
+                    onShowOnboarding = { onShowOnboarding(AnalyticsSource.EMPTY_STATE) },
                     modifier = Modifier.weight(1f),
                 )
             else ->
@@ -1104,7 +1123,7 @@ private fun MySoundsBody(
                     welcomeHintPending = welcomeHintPending,
                     onWelcomeHintShown = { viewModel.markWelcomeHintShown() },
                     showWelcomeFooter = showWelcomeFooter,
-                    onShowOnboardingFromWelcome = onShowOnboardingFromWelcome,
+                    onShowOnboardingFromWelcome = { onShowOnboarding(AnalyticsSource.WELCOME_FOOTER) },
                 )
         }
     }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -29,6 +30,7 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -41,6 +43,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -54,6 +57,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -146,6 +150,13 @@ fun LandingScreen(viewModel: SoundsViewModel) {
             tracker.log(AnalyticsEvent.ImportHubOpened(source = source))
             isHubVisible = true
         }
+    }
+
+    // Single onboarding-tour entry point: logs the ENTRY with the [source] surface (empty state, the
+    // welcome footer, or the overflow menu), then opens the tour at step 0.
+    val openOnboarding = { source: String ->
+        tracker.log(AnalyticsEvent.OnboardingOpened(source = source))
+        onboardingStep = 0
     }
 
     // Key on the open/closed boolean, not the raw step: advancing or going back within the tour must
@@ -241,10 +252,9 @@ fun LandingScreen(viewModel: SoundsViewModel) {
             if (!sound.isPlaying) viewModel.playOrStop(sound)
         },
         onCreateClick = openHub,
-        onShowOnboarding = {
-            tracker.log(AnalyticsEvent.OnboardingOpened(source = AnalyticsSource.EMPTY_STATE))
-            onboardingStep = 0
-        },
+        onShowOnboarding = { openOnboarding(AnalyticsSource.EMPTY_STATE) },
+        onShowOnboardingFromWelcome = { openOnboarding(AnalyticsSource.WELCOME_FOOTER) },
+        onOpenOnboardingFromMenu = { openOnboarding(AnalyticsSource.OVERFLOW_MENU) },
     )
 
     // Exactly one sub-screen overlays the list at a time (About wins over Manage, preserving the
@@ -456,14 +466,17 @@ private fun ScaffoldedLanding(
     // vs the empty-state CTA), so `import_hub_opened` is attributed honestly.
     onCreateClick: (String) -> Unit,
     onShowOnboarding: () -> Unit,
+    onShowOnboardingFromWelcome: () -> Unit,
+    onOpenOnboardingFromMenu: () -> Unit,
 ) {
     Scaffold(
         modifier = modifier,
         topBar = {
             AppTopBar(
                 onSearchClick = { viewModel.showSearch() },
-                onAboutClick = onAboutClick,
+                onSeeHowItWorks = onOpenOnboardingFromMenu,
                 onManageCollectionsClick = onManageCollectionsClick,
+                onAboutClick = onAboutClick,
             )
         },
         // FAB only on My Bomps (design "regla por tab"): Explore is a consumption surface and Vault's
@@ -535,6 +548,7 @@ private fun ScaffoldedLanding(
                     onActiveFilterEditClick = onActiveFilterEditClick,
                     onImportClick = { onCreateClick(AnalyticsSource.EMPTY_STATE) },
                     onShowOnboarding = onShowOnboarding,
+                    onShowOnboardingFromWelcome = onShowOnboardingFromWelcome,
                     viewModel = viewModel,
                     context = context,
                 )
@@ -673,8 +687,9 @@ private fun SnackbarEffects(
 @Composable
 private fun AppTopBar(
     onSearchClick: () -> Unit,
-    onAboutClick: () -> Unit,
+    onSeeHowItWorks: () -> Unit,
     onManageCollectionsClick: () -> Unit,
+    onAboutClick: () -> Unit,
 ) {
     var isMenuExpanded by remember { mutableStateOf(false) }
     val context = LocalContext.current
@@ -693,29 +708,52 @@ private fun AppTopBar(
                     contentDescription = stringResource(R.string.app_overflow_menu),
                 )
             }
+            // Ordered by intent for a confused newcomer (help first), then organize; a divider splits
+            // "use the app" from "about the app" (share + about last, the conventional tail). Leading
+            // icons are decorative — the item text is the accessible name (emojis read poorly in TalkBack).
             DropdownMenu(
                 expanded = isMenuExpanded,
                 onDismissRequest = { isMenuExpanded = false },
             ) {
                 DropdownMenuItem(
+                    text = { Text(stringResource(R.string.app_my_sounds_empty_secondary)) },
+                    leadingIcon = {
+                        Icon(painter = painterResource(R.drawable.app_ic_help), contentDescription = null)
+                    },
+                    onClick = {
+                        isMenuExpanded = false
+                        onSeeHowItWorks()
+                    },
+                )
+                DropdownMenuItem(
                     text = { Text(stringResource(R.string.app_manage_collections_menu_item)) },
+                    leadingIcon = {
+                        Icon(painter = painterResource(R.drawable.app_ic_library_music), contentDescription = null)
+                    },
                     onClick = {
                         isMenuExpanded = false
                         onManageCollectionsClick()
                     },
                 )
-                DropdownMenuItem(
-                    text = { Text(stringResource(R.string.app_about)) },
-                    onClick = {
-                        isMenuExpanded = false
-                        onAboutClick()
-                    },
-                )
+                HorizontalDivider()
                 DropdownMenuItem(
                     text = { Text(stringResource(R.string.app_share_app_menu_item)) },
+                    leadingIcon = {
+                        Icon(painter = painterResource(R.drawable.app_ic_share), contentDescription = null)
+                    },
                     onClick = {
                         isMenuExpanded = false
                         ShareAppIntent.launch(context, PlayStoreReferrer.CONTENT_MENU)
+                    },
+                )
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.app_about)) },
+                    leadingIcon = {
+                        Icon(painter = painterResource(R.drawable.app_ic_info), contentDescription = null)
+                    },
+                    onClick = {
+                        isMenuExpanded = false
+                        onAboutClick()
                     },
                 )
             }
@@ -832,6 +870,10 @@ internal fun SoundsList(
     // My Sounds list passes these — the Vault never renders the welcome.
     welcomeHintPending: Boolean = false,
     onWelcomeHintShown: () -> Unit = {},
+    // When true (My Sounds, list is only the welcome), a "see how it works" footer trails the list so a
+    // fresh-install user can reach the onboarding tour. Off everywhere else (Vault/Explore/Search).
+    showWelcomeFooter: Boolean = false,
+    onShowOnboardingFromWelcome: () -> Unit = {},
 ) {
     val dismissingItems = remember { mutableStateSetOf<String>() }
     val coroutineScope = rememberCoroutineScope()
@@ -925,6 +967,18 @@ internal fun SoundsList(
                     )
                 }
             }
+            if (showWelcomeFooter) {
+                item(key = "welcome_onboarding_footer") {
+                    Box(
+                        modifier = Modifier.fillMaxWidth().padding(top = Spacing.SM),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        TextButton(onClick = onShowOnboardingFromWelcome) {
+                            Text(stringResource(R.string.app_my_sounds_empty_secondary))
+                        }
+                    }
+                }
+            }
         }
     }
 }
@@ -951,6 +1005,7 @@ private fun MySoundsBody(
     onActiveFilterEditClick: (String) -> Unit,
     onImportClick: () -> Unit,
     onShowOnboarding: () -> Unit,
+    onShowOnboardingFromWelcome: () -> Unit,
     viewModel: SoundsViewModel,
     context: Context,
 ) {
@@ -968,6 +1023,10 @@ private fun MySoundsBody(
     val isOnMySounds = selectedTab == AppTab.MY_SOUNDS
     val showFilterEmptyState = isOnMySounds && activeFilterId != null && sounds.isEmpty() && activeCollection != null
     val showWelcomeEmptyState = sounds.isEmpty() && isOnMySounds && !showFilterEmptyState
+    // Fresh install lands here, not on the ZRP: the welcome audio keeps the list non-empty. Surface a
+    // "see how it works" footer under the lone welcome so a new user can reach the tour without first
+    // deleting the welcome. Drops away the moment any real Bomp exists.
+    val showWelcomeFooter = isOnMySounds && sounds.isNotEmpty() && sounds.all { isWelcomeSticker(it) }
     // The ActiveFilterHeader is suppressed alongside the chip row whenever the body collapses to a
     // ZRP — same reasoning as the Vault locked state: a header above a "nothing here yet" body
     // adds noise instead of context.
@@ -1044,6 +1103,8 @@ private fun MySoundsBody(
                     onAddToCollection = { sound -> viewModel.requestAssignCollections(sound.id) },
                     welcomeHintPending = welcomeHintPending,
                     onWelcomeHintShown = { viewModel.markWelcomeHintShown() },
+                    showWelcomeFooter = showWelcomeFooter,
+                    onShowOnboardingFromWelcome = onShowOnboardingFromWelcome,
                 )
         }
     }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -153,9 +153,10 @@ fun LandingScreen(viewModel: SoundsViewModel) {
     LaunchedEffect(selectedTab, isAboutVisible, manageRequest, isSearchVisible, onboardingStep != null, bringGuideVisible) {
         val name =
             when {
-                // The bring-from-apps guide reuses the onboarding content, so it reports the same screen.
-                // The funnel separates its entry via ImportHubBringSelected, not via a distinct screen_view.
-                onboardingStep != null || bringGuideVisible -> CanonicalScreenName.ONBOARDING
+                // The bring-from-apps guide reuses the onboarding IMPORT content but is its own screen, so
+                // it reports a distinct screen_view — keeping the onboarding-tour funnel uncontaminated.
+                bringGuideVisible -> CanonicalScreenName.BRING_GUIDE
+                onboardingStep != null -> CanonicalScreenName.ONBOARDING
                 isSearchVisible -> CanonicalScreenName.SEARCH_SOUND
                 isAboutVisible -> CanonicalScreenName.ABOUT
                 manageRequest != null -> CanonicalScreenName.MANAGE_COLLECTIONS

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/MySoundsEmptyState.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/MySoundsEmptyState.kt
@@ -126,10 +126,22 @@ internal fun MySoundsEmptyState(
             Spacer(Modifier.height(Spacing.SM))
             // Text tier (ADR 0010): a low-commitment secondary below the single Import imperative —
             // inherits `primary`, no container, so it never competes with the filled CTA above.
-            TextButton(onClick = onShowOnboarding) {
-                Text(text = stringResource(R.string.app_my_sounds_empty_secondary))
-            }
+            SeeHowItWorksButton(onClick = onShowOnboarding)
         }
+    }
+}
+
+/**
+ * Text-tier (ADR 0010) "see how it works" CTA that opens the onboarding tour. Shared by this empty-state
+ * secondary and the welcome-audio footer (SoundsList) so the two never drift in copy or button typology.
+ */
+@Composable
+internal fun SeeHowItWorksButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TextButton(onClick = onClick, modifier = modifier) {
+        Text(text = stringResource(R.string.app_my_sounds_empty_secondary))
     }
 }
 

--- a/app/src/main/res/drawable/app_ic_help.xml
+++ b/app/src/main/res/drawable/app_ic_help.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M513.5-254.5Q528-269 528-290t-14.5-35.5Q499-340 478-340t-35.5 14.5Q428-311 428-290t14.5 35.5Q457-240 478-240t35.5-14.5ZM442-394h74q0-33 7.5-52t42.5-52q26-26 41-49.5t15-56.5q0-56-41-86t-97-30q-57 0-92.5 30T342-618l66 26q5-18 22.5-39t53.5-21q32 0 48 17.5t16 38.5q0 20-12 37.5T506-526q-44 39-54 59t-10 73Zm38 314q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/app_ic_info.xml
+++ b/app/src/main/res/drawable/app_ic_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M440-280h80v-240h-80v240Zm68.5-331.5Q520-623 520-640t-11.5-28.5Q497-680 480-680t-28.5 11.5Q440-657 440-640t11.5 28.5Q463-600 480-600t28.5-11.5ZM480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z" />
+    </group>
+</vector>

--- a/app/src/main/res/drawable/app_ic_library_music.xml
+++ b/app/src/main/res/drawable/app_ic_library_music.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <group android:translateY="960">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M500-360q42 0 71-29t29-71v-220h120v-80H560v220q-13-10-28-15t-32-5q-42 0-71 29t-29 71q0 42 29 71t71 29ZM320-240q-33 0-56.5-23.5T240-320v-480q0-33 23.5-56.5T320-880h480q33 0 56.5 23.5T880-800v480q0 33-23.5 56.5T800-240H320Zm0-80h480v-480H320v480ZM160-80q-33 0-56.5-23.5T80-160v-560h80v560h560v80H160Zm160-720v480-480Z" />
+    </group>
+</vector>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -223,12 +223,13 @@
     <string name="app_hub_fab_description">Sumar un Bomp</string>
     <string name="app_hub_title">¿Cómo la sumás?</string>
     <string name="app_hub_subtitle">Una voz se guarda y la tenés cerca, para escucharla cuando quieras.</string>
-    <string name="app_hub_import">Importar audio del dispositivo</string>
-    <string name="app_hub_import_sub">Notas de voz, grabaciones, lo que ya tengas guardado.</string>
     <string name="app_hub_record">Grabar un Bomp</string>
     <string name="app_hub_record_sub">Tu voz, un momento que no querés perder.</string>
-    <string name="app_hub_how">Ver cómo funciona</string>
-    <string name="app_hub_how_sub">Un minuto y le tomás la mano.</string>
+    <string name="app_hub_bring">Traé audios de otras apps</string>
+    <string name="app_hub_bring_sub">De WhatsApp, Telegram, donde sea — te mostramos cómo.</string>
+    <string name="app_hub_import">Importar audio del dispositivo</string>
+    <string name="app_hub_import_sub">Un audio que ya tengas guardado en el teléfono.</string>
+    <string name="app_hub_bring_guide_cta">Listo</string>
 
     <!-- Grabador in-app (ADR 0019) -->
     <string name="app_recorder_ready_hint">Tocá para grabar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -229,12 +229,13 @@
     <string name="app_hub_fab_description">Add a Bomp</string>
     <string name="app_hub_title">How do you add one?</string>
     <string name="app_hub_subtitle">A voice gets saved and stays close, ready whenever you want to hear it.</string>
-    <string name="app_hub_import">Import audio from your device</string>
-    <string name="app_hub_import_sub">Voice notes, recordings, whatever you already have saved.</string>
     <string name="app_hub_record">Record a Bomp</string>
     <string name="app_hub_record_sub">Your voice, a moment you don\'t want to lose.</string>
-    <string name="app_hub_how">See how it works</string>
-    <string name="app_hub_how_sub">A minute and you\'ve got it.</string>
+    <string name="app_hub_bring">Bring audios from other apps</string>
+    <string name="app_hub_bring_sub">From WhatsApp, Telegram, wherever — we\'ll show you how.</string>
+    <string name="app_hub_import">Import audio from your device</string>
+    <string name="app_hub_import_sub">An audio you already have saved on your phone.</string>
+    <string name="app_hub_bring_guide_cta">Got it</string>
 
     <!-- In-app recorder (ADR 0019) -->
     <string name="app_recorder_ready_hint">Tap to record</string>

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/onboarding/BringFromAppsGuideTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/onboarding/BringFromAppsGuideTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.onboarding
+
+import android.content.Context
+import android.os.Build
+import android.provider.Settings
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.robolectric.annotation.Config
+
+/**
+ * Smoke + close-callback coverage for the [BringFromAppsGuide] single-step guide. Runs with system
+ * animations off so the reused IMPORT demo's looping animation never keeps the Compose clock busy past
+ * `waitForIdle`, mirroring `OnboardingTourTest`.
+ */
+@Config(sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
+internal class BringFromAppsGuideTest : AbstractRobolectricTest() {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Before
+    fun setUp() {
+        Settings.Global.putFloat(
+            ApplicationProvider.getApplicationContext<Context>().contentResolver,
+            Settings.Global.ANIMATOR_DURATION_SCALE,
+            0f,
+        )
+    }
+
+    @Test
+    fun `renders the import lesson and its terminal CTA`() {
+        setGuide()
+
+        composeTestRule.onNodeWithText("Bring in the voices you already have.").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Got it").assertIsDisplayed()
+    }
+
+    @Test
+    fun `tapping Got it invokes onClose`() {
+        var closed = false
+        setGuide(onClose = { closed = true })
+
+        composeTestRule.onNodeWithText("Got it").performClick()
+        composeTestRule.waitForIdle()
+
+        assertThat(closed).isTrue()
+    }
+
+    private fun setGuide(onClose: () -> Unit = {}) {
+        composeTestRule.setContent {
+            AppTheme {
+                BringFromAppsGuide(onClose = onClose)
+            }
+        }
+        composeTestRule.waitForIdle()
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/ImportHubSheetTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/ImportHubSheetTest.kt
@@ -23,11 +23,58 @@ internal class ImportHubSheetTest : AbstractRobolectricTest() {
     val composeTestRule = createComposeRule()
 
     @Test
-    fun `hub shows title and the import row`() {
+    fun `hub shows title and the record row`() {
         setHub()
 
         composeTestRule.onNodeWithText("How do you add one?").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Import audio from your device").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Record a Bomp").assertIsDisplayed()
+    }
+
+    @Test
+    fun `hub orders the rows record then bring then import`() {
+        setHub()
+
+        val recordTop =
+            composeTestRule
+                .onNodeWithText("Record a Bomp")
+                .fetchSemanticsNode()
+                .boundsInRoot.top
+        val bringTop =
+            composeTestRule
+                .onNodeWithText("Bring audios from other apps")
+                .fetchSemanticsNode()
+                .boundsInRoot.top
+        val importTop =
+            composeTestRule
+                .onNodeWithText("Import audio from your device")
+                .fetchSemanticsNode()
+                .boundsInRoot.top
+
+        assertThat(recordTop).isLessThan(bringTop)
+        assertThat(bringTop).isLessThan(importTop)
+    }
+
+    @Test
+    fun `tapping the record row invokes onRecord`() {
+        var recorded = false
+        setHub(onRecord = { recorded = true })
+
+        composeTestRule.onNodeWithText("Record a Bomp").performClick()
+        composeTestRule.waitForIdle() // the row animates the sheet closed before invoking onRecord
+
+        assertThat(recorded).isTrue()
+    }
+
+    @Test
+    fun `tapping the bring-from-apps row invokes onBringFromApps`() {
+        var opened = false
+        setHub(onBringFromApps = { opened = true })
+
+        composeTestRule.onNodeWithText("Bring audios from other apps").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Bring audios from other apps").performClick()
+        composeTestRule.waitForIdle() // the row animates the sheet closed before invoking the callback
+
+        assertThat(opened).isTrue()
     }
 
     @Test
@@ -41,41 +88,10 @@ internal class ImportHubSheetTest : AbstractRobolectricTest() {
         assertThat(imported).isTrue()
     }
 
-    @Test
-    fun `tapping the record row invokes onRecord`() {
-        var recorded = false
-        setHub(onRecord = { recorded = true })
-
-        composeTestRule.onNodeWithText("Record a Bomp").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Record a Bomp").performClick()
-        composeTestRule.waitForIdle() // the row animates the sheet closed before invoking onRecord
-
-        assertThat(recorded).isTrue()
-    }
-
-    @Test
-    fun `hub offers the see-how-it-works row`() {
-        // PR4: the onboarding entry point now has a destination, so it joins the Hub as an enabled row.
-        setHub()
-
-        composeTestRule.onNodeWithText("See how it works").assertIsDisplayed()
-    }
-
-    @Test
-    fun `tapping the see-how-it-works row invokes onHowItWorks`() {
-        var opened = false
-        setHub(onHowItWorks = { opened = true })
-
-        composeTestRule.onNodeWithText("See how it works").performClick()
-        composeTestRule.waitForIdle() // the row animates the sheet closed before invoking the callback
-
-        assertThat(opened).isTrue()
-    }
-
     private fun setHub(
         onImport: () -> Unit = {},
         onRecord: () -> Unit = {},
-        onHowItWorks: () -> Unit = {},
+        onBringFromApps: () -> Unit = {},
         onDismiss: () -> Unit = {},
     ) {
         composeTestRule.setContent {
@@ -83,7 +99,7 @@ internal class ImportHubSheetTest : AbstractRobolectricTest() {
                 ImportHubSheet(
                     onImport = onImport,
                     onRecord = onRecord,
-                    onHowItWorks = onHowItWorks,
+                    onBringFromApps = onBringFromApps,
                     onDismiss = onDismiss,
                 )
             }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenAnalyticsTest.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.os.Build
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
@@ -20,7 +21,6 @@ import com.github.barriosnahuel.vossosunboton.commons.android.analytics.Canonica
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.FakeAnalyticsTracker
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
 import com.github.barriosnahuel.vossosunboton.model.Sound
-import com.github.barriosnahuel.vossosunboton.testSound
 import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
@@ -147,14 +147,12 @@ internal class LandingScreenAnalyticsTest : AbstractRobolectricTest() {
 
         composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
         composeTestRule.waitForIdle()
-        // A custom Bomp hides the welcome footer (also "See how it works"), so the menu item is the
-        // only match for the click below.
-        viewModel.injectSounds(listOf(testSound("a bomp", file = "a.mp3")))
-        composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithContentDescription(context.getString(R.string.app_overflow_menu)).performClick()
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText(context.getString(R.string.app_my_sounds_empty_secondary)).performClick()
+        // The menu item shares its label with the welcome footer; address it by its stable tag so this
+        // resolves the overflow entry even when the footer renders the same text.
+        composeTestRule.onNodeWithTag(OVERFLOW_SEE_HOW_IT_WORKS_TAG).performClick()
         composeTestRule.waitForIdle()
 
         val event = fake.assertEmitted("onboarding_opened")

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenAnalyticsTest.kt
@@ -20,6 +20,7 @@ import com.github.barriosnahuel.vossosunboton.commons.android.analytics.Canonica
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.FakeAnalyticsTracker
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
 import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.github.barriosnahuel.vossosunboton.testSound
 import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
@@ -137,6 +138,27 @@ internal class LandingScreenAnalyticsTest : AbstractRobolectricTest() {
         // points into `playOrStop` / `share`, and the open sub-screen clears them from the semantics tree.
         fake.assertScreenView(CanonicalScreenName.ABOUT)
         composeTestRule.onNodeWithContentDescription(context.getString(R.string.app_search)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `tapping see how it works in the overflow emits onboarding_opened with source overflow_menu`() {
+        val viewModel = givenAViewModel()
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
+        composeTestRule.waitForIdle()
+        // A custom Bomp hides the welcome footer (also "See how it works"), so the menu item is the
+        // only match for the click below.
+        viewModel.injectSounds(listOf(testSound("a bomp", file = "a.mp3")))
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithContentDescription(context.getString(R.string.app_overflow_menu)).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText(context.getString(R.string.app_my_sounds_empty_secondary)).performClick()
+        composeTestRule.waitForIdle()
+
+        val event = fake.assertEmitted("onboarding_opened")
+        assertThat(event.params["source"]).isEqualTo("overflow_menu")
     }
 
     @Test

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenAnalyticsTest.kt
@@ -206,6 +206,22 @@ internal class LandingScreenAnalyticsTest : AbstractRobolectricTest() {
     }
 
     @Test
+    fun `tapping the bring-from-apps row in the Hub emits import_hub_bring_selected`() {
+        val viewModel = givenAViewModel()
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithContentDescription(context.getString(R.string.app_hub_fab_description)).performClick()
+        composeTestRule.waitForIdle()
+        // The row animates the sheet closed before invoking onBringFromApps (see ImportHubSheetTest).
+        composeTestRule.onNodeWithText(context.getString(R.string.app_hub_bring)).performClick()
+        composeTestRule.waitForIdle()
+
+        fake.assertEmitted("import_hub_bring_selected")
+    }
+
+    @Test
     fun `finishing the onboarding tour opens the Hub with source onboarding_finish`() {
         val viewModel = givenAViewModel()
         val context = ApplicationProvider.getApplicationContext<Context>()

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenOnboardingTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenOnboardingTest.kt
@@ -86,11 +86,11 @@ internal class LandingScreenOnboardingTest : AbstractRobolectricTest() {
         composeTestRule.onNodeWithText(BRING_LABEL).performClick()
         composeTestRule.waitForIdle()
 
-        // The guide reuses the IMPORT step content + the ONBOARDING screen_view; its entry is
-        // distinguished by import_hub_bring_selected, not by a distinct screen name.
+        // The guide reuses the IMPORT step content but reports its own BRING_GUIDE screen_view (kept
+        // distinct from the onboarding tour); its entry is the import_hub_bring_selected event.
         composeTestRule.onNodeWithText(STEP1_TITLE).assertIsDisplayed()
         composeTestRule.onNodeWithText(GUIDE_CTA).assertIsDisplayed()
-        fake.assertScreenView(CanonicalScreenName.ONBOARDING)
+        fake.assertScreenView(CanonicalScreenName.BRING_GUIDE)
         fake.assertEmitted("import_hub_bring_selected")
     }
 

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenOnboardingTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenOnboardingTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
@@ -41,10 +42,11 @@ import org.junit.Test
 import org.robolectric.annotation.Config
 
 /**
- * Integration coverage for the PR4 onboarding tour wired through the real [LandingScreen]: both entry
- * points (Hub row + empty-state secondary) open it, the final CTA lands on the Hub, skipping returns
- * to My Bomps, and the step index is durable across an Activity recreate. System animations are off
- * so the looping touch-dot indicator never keeps the Compose clock busy past `waitForIdle`.
+ * Integration coverage for the onboarding tour wired through the real [LandingScreen]: every entry
+ * point (empty-state secondary, welcome footer, overflow menu) opens it, the final CTA lands on the Hub
+ * (returning to My Bomps first when opened from another tab), skipping returns to My Bomps, and the step
+ * index is durable across an Activity recreate. System animations are off so the looping touch-dot
+ * indicator never keeps the Compose clock busy past `waitForIdle`.
  */
 @Config(sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
 internal class LandingScreenOnboardingTest : AbstractRobolectricTest() {
@@ -192,6 +194,30 @@ internal class LandingScreenOnboardingTest : AbstractRobolectricTest() {
     }
 
     @Test
+    fun `finishing the tour opened from another tab returns to My Bomps before the Hub`() {
+        val viewModel = givenAViewModel()
+        composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
+        composeTestRule.waitForIdle()
+        // Open the tour from the overflow (reachable on every tab) while standing on the Vault tab.
+        viewModel.selectTab(AppTab.VAULT)
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithContentDescription(OVERFLOW_LABEL).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithTag(OVERFLOW_SEE_HOW_IT_WORKS_TAG).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Go on").performClick()
+        composeTestRule.onNodeWithText("Next").performClick()
+        composeTestRule.onNodeWithText("Start").performClick()
+        composeTestRule.waitForIdle()
+
+        // The Hub opened so the user can add a first Bomp, AND the tab returned to My Bomps so that Bomp
+        // lands where the user is looking — not into the unseen My Bomps list behind Vault.
+        composeTestRule.onNodeWithText(HUB_TITLE).assertIsDisplayed()
+        assertThat(fake.screens.last().name).isEqualTo(CanonicalScreenName.MY_SOUNDS)
+    }
+
+    @Test
     fun `skipping the tour returns to My Bomps`() {
         val viewModel = givenAViewModel()
         composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
@@ -266,6 +292,7 @@ internal class LandingScreenOnboardingTest : AbstractRobolectricTest() {
         // timeout (ADR ratchet on unbounded runBlocking flow-awaits in tests).
         const val AWAIT_TIMEOUT_MS = 5_000L
         const val HUB_TITLE = "How do you add one?"
+        const val OVERFLOW_LABEL = "More options"
         const val SECONDARY_LABEL = "See how it works"
         const val BRING_LABEL = "Bring audios from other apps"
         const val GUIDE_CTA = "Got it"

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenOnboardingTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenOnboardingTest.kt
@@ -76,16 +76,59 @@ internal class LandingScreenOnboardingTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `Hub see-how-it-works opens the tour and emits the onboarding screen view`() {
+    fun `Hub bring-from-apps opens the guide and emits the onboarding screen view`() {
         val viewModel = givenAViewModel()
         composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
         composeTestRule.waitForIdle()
 
-        openTourFromHub()
+        composeTestRule.onNodeWithContentDescription("Add a Bomp").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText(BRING_LABEL).performClick()
+        composeTestRule.waitForIdle()
 
+        // The guide reuses the IMPORT step content + the ONBOARDING screen_view; its entry is
+        // distinguished by import_hub_bring_selected, not by a distinct screen name.
         composeTestRule.onNodeWithText(STEP1_TITLE).assertIsDisplayed()
+        composeTestRule.onNodeWithText(GUIDE_CTA).assertIsDisplayed()
         fake.assertScreenView(CanonicalScreenName.ONBOARDING)
-        assertThat(fake.assertEmitted("onboarding_opened").params["source"]).isEqualTo("import_hub")
+        fake.assertEmitted("import_hub_bring_selected")
+    }
+
+    @Test
+    fun `closing the bring-from-apps guide returns to My Bomps`() {
+        val viewModel = givenAViewModel()
+        composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithContentDescription("Add a Bomp").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText(BRING_LABEL).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText(GUIDE_CTA).performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithContentDescription("Add a Bomp").assertIsDisplayed()
+    }
+
+    @Test
+    fun `bring-from-apps guide survives an Activity recreate`() {
+        val viewModel = givenAViewModel()
+        val restorationTester = StateRestorationTester(composeTestRule)
+        restorationTester.setContent { AppTheme { LandingScreen(viewModel) } }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithContentDescription("Add a Bomp").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText(BRING_LABEL).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText(GUIDE_CTA).assertIsDisplayed()
+
+        restorationTester.emulateSavedInstanceStateRestore()
+        composeTestRule.waitForIdle()
+
+        // bringGuideVisible is rememberSaveable in the host: a recreate (rotation, theme, system kill)
+        // must not silently dump the user back to My Bomps mid-guide.
+        composeTestRule.onNodeWithText(GUIDE_CTA).assertIsDisplayed()
     }
 
     @Test
@@ -109,7 +152,7 @@ internal class LandingScreenOnboardingTest : AbstractRobolectricTest() {
         composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
         composeTestRule.waitForIdle()
 
-        openTourFromHub()
+        openTourFromEmptyState(viewModel)
         composeTestRule.onNodeWithText("Go on").performClick()
         composeTestRule.onNodeWithText("Next").performClick()
         composeTestRule.onNodeWithText("Start").performClick()
@@ -124,11 +167,13 @@ internal class LandingScreenOnboardingTest : AbstractRobolectricTest() {
         composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
         composeTestRule.waitForIdle()
 
-        openTourFromHub()
+        openTourFromEmptyState(viewModel)
         composeTestRule.onNodeWithText("Skip").performClick()
         composeTestRule.waitForIdle()
 
-        composeTestRule.onNodeWithContentDescription("Add a Bomp").assertIsDisplayed()
+        // Back on the empty My Bomps (the tour was opened from there, so the list is empty → no FAB):
+        // its "see how it works" secondary is shown again, and MY_SOUNDS is re-emitted on the way back.
+        composeTestRule.onNodeWithText(SECONDARY_LABEL).performScrollTo().assertIsDisplayed()
         val mySoundsHits = fake.screens.count { it.name == CanonicalScreenName.MY_SOUNDS }
         assertThat(mySoundsHits).isAtLeast(2)
     }
@@ -140,7 +185,7 @@ internal class LandingScreenOnboardingTest : AbstractRobolectricTest() {
         restorationTester.setContent { AppTheme { LandingScreen(viewModel) } }
         composeTestRule.waitForIdle()
 
-        openTourFromHub()
+        openTourFromEmptyState(viewModel)
         composeTestRule.onNodeWithText("Go on").performClick()
         composeTestRule.onNodeWithText(STEP2_TITLE).assertIsDisplayed()
         val stepViewsBeforeRestore = fake.events.count { it.name == "onboarding_step_viewed" }
@@ -156,10 +201,12 @@ internal class LandingScreenOnboardingTest : AbstractRobolectricTest() {
         assertThat(stepViewsAfterRestore).isEqualTo(stepViewsBeforeRestore)
     }
 
-    private fun openTourFromHub() {
-        composeTestRule.onNodeWithContentDescription("Add a Bomp").performClick()
+    // The full tour is reachable from the empty My Bomps secondary (the Hub now opens the focused
+    // bring-from-apps guide instead). Injecting an empty list reveals the welcome-empty state that hosts it.
+    private fun openTourFromEmptyState(viewModel: SoundsViewModel) {
+        viewModel.injectSounds(emptyList())
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText(SECONDARY_LABEL).performClick()
+        composeTestRule.onNodeWithText(SECONDARY_LABEL).performScrollTo().performClick()
         composeTestRule.waitForIdle()
     }
 
@@ -190,6 +237,8 @@ internal class LandingScreenOnboardingTest : AbstractRobolectricTest() {
         const val AWAIT_TIMEOUT_MS = 5_000L
         const val HUB_TITLE = "How do you add one?"
         const val SECONDARY_LABEL = "See how it works"
+        const val BRING_LABEL = "Bring audios from other apps"
+        const val GUIDE_CTA = "Got it"
         const val STEP1_TITLE = "Bring in the voices you already have."
         const val STEP2_TITLE = "Keep them your way."
     }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenOnboardingTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenOnboardingTest.kt
@@ -22,6 +22,7 @@ import com.github.barriosnahuel.vossosunboton.commons.android.analytics.Canonica
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.FakeAnalyticsTracker
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
 import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.github.barriosnahuel.vossosunboton.testSound
 import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
@@ -144,6 +145,35 @@ internal class LandingScreenOnboardingTest : AbstractRobolectricTest() {
 
         composeTestRule.onNodeWithText(STEP1_TITLE).assertIsDisplayed()
         assertThat(fake.assertEmitted("onboarding_opened").params["source"]).isEqualTo("my_sounds_empty_state")
+    }
+
+    @Test
+    fun `welcome footer opens the tour with source welcome_footer`() {
+        // Fresh install = only the welcome sticker → the list is non-empty (not the ZRP), so the footer
+        // is the new user's path to the tour. The overflow's "See how it works" is closed/uncomposed, so
+        // SECONDARY_LABEL is unique to the footer here.
+        val viewModel = givenAViewModel()
+        composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText(SECONDARY_LABEL).performScrollTo().performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText(STEP1_TITLE).assertIsDisplayed()
+        assertThat(fake.assertEmitted("onboarding_opened").params["source"]).isEqualTo("welcome_footer")
+    }
+
+    @Test
+    fun `welcome footer disappears once a custom Bomp exists`() {
+        val viewModel = givenAViewModel()
+        composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
+        composeTestRule.waitForIdle()
+        viewModel.injectSounds(listOf(testSound("a bomp", file = "a.mp3")))
+        composeTestRule.waitForIdle()
+
+        // List no longer all-welcome → footer hidden; the overflow item is uncomposed (menu closed), so
+        // "See how it works" is absent entirely.
+        composeTestRule.onNodeWithText(SECONDARY_LABEL).assertDoesNotExist()
     }
 
     @Test

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
@@ -17,7 +18,6 @@ import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
 import com.github.barriosnahuel.vossosunboton.model.Sound
-import com.github.barriosnahuel.vossosunboton.testSound
 import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
@@ -108,34 +108,28 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
 
         composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
         composeTestRule.waitForIdle()
-        // A custom Bomp hides the welcome footer (also "See how it works"), so that label is unique to
-        // the menu and the order assertion isn't confused by a second match.
-        viewModel.injectSounds(listOf(testSound("a bomp", file = "a.mp3")))
-        composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithContentDescription("More options").performClick()
         composeTestRule.waitForIdle()
 
-        val helpTop =
-            composeTestRule
-                .onNodeWithText("See how it works")
-                .fetchSemanticsNode()
-                .boundsInRoot.top
-        val collectionsTop =
-            composeTestRule
-                .onNodeWithText("Manage collections")
-                .fetchSemanticsNode()
-                .boundsInRoot.top
-        val shareTop =
-            composeTestRule
-                .onNodeWithText("Share Bomp")
-                .fetchSemanticsNode()
-                .boundsInRoot.top
-        val aboutTop =
-            composeTestRule
-                .onNodeWithText("About")
-                .fetchSemanticsNode()
-                .boundsInRoot.top
+        // "Help" shares its label ("See how it works") with the welcome footer, so it is addressed by
+        // its stable tag rather than the ambiguous text; the other three labels are unique.
+        val help = composeTestRule.onNodeWithTag(OVERFLOW_SEE_HOW_IT_WORKS_TAG)
+        val collections = composeTestRule.onNodeWithText("Manage collections")
+        val share = composeTestRule.onNodeWithText("Share Bomp")
+        val about = composeTestRule.onNodeWithText("About")
+
+        // Each item is actually on screen (not merely composed) — guards the AGPLv3-required About entry
+        // and Share against being pushed off the visible menu by future growth.
+        help.assertIsDisplayed()
+        collections.assertIsDisplayed()
+        share.assertIsDisplayed()
+        about.assertIsDisplayed()
+
+        val helpTop = help.fetchSemanticsNode().boundsInRoot.top
+        val collectionsTop = collections.fetchSemanticsNode().boundsInRoot.top
+        val shareTop = share.fetchSemanticsNode().boundsInRoot.top
+        val aboutTop = about.fetchSemanticsNode().boundsInRoot.top
 
         assertThat(helpTop).isLessThan(collectionsTop)
         assertThat(collectionsTop).isLessThan(shareTop)

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
@@ -17,7 +17,9 @@ import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
 import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.github.barriosnahuel.vossosunboton.testSound
 import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
+import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
@@ -101,14 +103,43 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `overflow menu offers the share-app action`() {
+    fun `overflow menu lists help, collections, share and about in order`() {
         val viewModel = givenAViewModel()
 
         composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
         composeTestRule.waitForIdle()
+        // A custom Bomp hides the welcome footer (also "See how it works"), so that label is unique to
+        // the menu and the order assertion isn't confused by a second match.
+        viewModel.injectSounds(listOf(testSound("a bomp", file = "a.mp3")))
+        composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithContentDescription("More options").performClick()
-        composeTestRule.onNodeWithText("Share Bomp").assertIsDisplayed()
+        composeTestRule.waitForIdle()
+
+        val helpTop =
+            composeTestRule
+                .onNodeWithText("See how it works")
+                .fetchSemanticsNode()
+                .boundsInRoot.top
+        val collectionsTop =
+            composeTestRule
+                .onNodeWithText("Manage collections")
+                .fetchSemanticsNode()
+                .boundsInRoot.top
+        val shareTop =
+            composeTestRule
+                .onNodeWithText("Share Bomp")
+                .fetchSemanticsNode()
+                .boundsInRoot.top
+        val aboutTop =
+            composeTestRule
+                .onNodeWithText("About")
+                .fetchSemanticsNode()
+                .boundsInRoot.top
+
+        assertThat(helpTop).isLessThan(collectionsTop)
+        assertThat(collectionsTop).isLessThan(shareTop)
+        assertThat(shareTop).isLessThan(aboutTop)
     }
 
     @Test

--- a/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsEvent.kt
+++ b/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsEvent.kt
@@ -323,7 +323,8 @@ sealed class AnalyticsEvent(
         AnalyticsEvent(name = "vault_search_unlock_cta_shown", hasFirstVariant = false)
 
     /**
-     * Onboarding funnel · ENTRY. [source] = which surface opened it (IMPORT_HUB vs EMPTY_STATE).
+     * Onboarding funnel · ENTRY. [source] = which surface opened the full tour (today only EMPTY_STATE;
+     * the Hub now opens the focused bring-from-apps guide instead — see [ImportHubBringSelected]).
      * `hasFirstVariant = true` so first-ever opens are isolable.
      *
      * Funnel query guide (whole funnel; each sibling event adds its own notes):
@@ -438,6 +439,16 @@ sealed class AnalyticsEvent(
      * between the two creation channels. `hasFirstVariant = true`.
      */
     object ImportHubRecordSelected : AnalyticsEvent(name = "import_hub_record_selected", hasFirstVariant = true)
+
+    /**
+     * Import-Hub funnel · INTENT (bring-from-apps). The user tapped the "bring audios from other apps"
+     * row, which opens a focused single-step guide on sharing a voice note in from WhatsApp/Telegram.
+     * Unlike [ImportHubImportSelected]/[ImportHubRecordSelected] this is not an in-app conversion step
+     * (the share is initiated from the *other* app, off-funnel); it measures how many Hub opens are
+     * driven by the import-from-another-app intent — the primary use case the Hub is being reshaped
+     * around. `hasFirstVariant = true`.
+     */
+    object ImportHubBringSelected : AnalyticsEvent(name = "import_hub_bring_selected", hasFirstVariant = true)
 
     /**
      * In-app recorder funnel · COMPLETION (ADR 0019). A capture reached the review state — via

--- a/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsParam.kt
+++ b/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsParam.kt
@@ -90,8 +90,14 @@ object AnalyticsSource {
     const val MY_SOUNDS_FILTER = "my_sounds_filter"
     const val SEARCH = "search"
 
-    /** Onboarding tour entry point — the empty My Bomps "see how it works" secondary. */
+    /** Onboarding tour entry points. */
     const val EMPTY_STATE = "my_sounds_empty_state"
+
+    /** "See how it works" footer under the lone welcome audio on a fresh install. */
+    const val WELCOME_FOOTER = "welcome_footer"
+
+    /** "See how it works" item in the top bar overflow menu (reopenable any time). */
+    const val OVERFLOW_MENU = "overflow_menu"
 
     /**
      * Import-Hub open entry points — the `+` FAB on My Bomps vs the onboarding tour's closing

--- a/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsParam.kt
+++ b/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsParam.kt
@@ -90,8 +90,7 @@ object AnalyticsSource {
     const val MY_SOUNDS_FILTER = "my_sounds_filter"
     const val SEARCH = "search"
 
-    /** Onboarding entry points — the import Hub "see how it works" row vs the empty My Bomps CTA. */
-    const val IMPORT_HUB = "import_hub"
+    /** Onboarding tour entry point — the empty My Bomps "see how it works" secondary. */
     const val EMPTY_STATE = "my_sounds_empty_state"
 
     /**

--- a/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/CanonicalScreenName.kt
+++ b/commons_android/src/main/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/CanonicalScreenName.kt
@@ -33,8 +33,11 @@ object CanonicalScreenName {
     /** Manage Collections screen — canonical home for rename / delete / create across both scopes. */
     const val MANAGE_COLLECTIONS = "manage_collections"
 
-    /** On-demand onboarding tour (3 steps) opened from the import Hub or the My Bomps empty state. */
+    /** On-demand onboarding tour (3 steps) opened from the My Bomps empty state. */
     const val ONBOARDING = "onboarding"
+
+    /** Focused single-step guide opened from the import Hub's "bring audios from other apps" row. */
+    const val BRING_GUIDE = "bring_guide"
 
     /** Immersive in-app recorder opened from the import Hub's Record row (ADR 0019). */
     const val RECORD_SOUND = "record_sound"
@@ -53,6 +56,7 @@ object CanonicalScreenName {
             COLLECTION_CREATE,
             MANAGE_COLLECTIONS,
             ONBOARDING,
+            BRING_GUIDE,
             RECORD_SOUND,
         )
 }

--- a/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsCoverageMatrixTest.kt
+++ b/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsCoverageMatrixTest.kt
@@ -96,6 +96,7 @@ internal class AnalyticsCoverageMatrixTest {
                 "ImportHubOpened",
                 "ImportHubImportSelected",
                 "ImportHubRecordSelected",
+                "ImportHubBringSelected",
                 "RecordingCompleted",
                 "RecordPermissionResult",
                 "RecordingDraftBannerShown",

--- a/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsCoverageMatrixTest.kt
+++ b/commons_android/src/test/java/com/github/barriosnahuel/vossosunboton/commons/android/analytics/AnalyticsCoverageMatrixTest.kt
@@ -119,6 +119,7 @@ internal class AnalyticsCoverageMatrixTest {
                 CanonicalScreenName.COLLECTION_CREATE,
                 CanonicalScreenName.MANAGE_COLLECTIONS,
                 CanonicalScreenName.ONBOARDING,
+                CanonicalScreenName.BRING_GUIDE,
                 CanonicalScreenName.RECORD_SOUND,
             )
 


### PR DESCRIPTION
### Summary

1. User taps the **+** on My Bomps
2. The add sheet opens

**before:** the sheet led with "Import audio from your device" (acid-highlighted) — the *least* likely path, since on Android 11+ a voice note living inside WhatsApp/Telegram isn't even browsable by the file picker. The "See how it works" row dumped the user into the full 3-step tour.
**after:** the sheet leads with **Record** (now the highlighted action — it always works, with nothing pre-saved), then **Bring audios from other apps** (a new row that opens a short, focused guide on sharing a voice note in from another app), then **Import audio from your device** last.

The new row's subtitle ("…we'll show you how") sets the expectation that it teaches the share-in gesture rather than performing it — the gesture itself starts from the other app.

Separately, the **full tour** had quietly become unreachable for the audience it serves: a fresh install seeds a welcome audio, so the My Bomps list is never empty, so the empty-state — the tour's only entry — never showed.

1. User installs the app for the first time
2. Lands on My Bomps with the welcome audio

**before:** no visible way to reach the guided tour — it only lived on the (never-shown) empty state.
**after:** a "See how it works" footer sits right under the welcome audio for new users, and the same entry lives permanently in the top "⋮" menu so anyone can reopen the tour at any time.

### Technical detail

Reorders `ImportHubSheet`, reshapes its third entry into a focused guide, and restores tour discoverability via a welcome footer + the overflow menu.

- **`ImportHubSheet.kt`** — rows reordered (record → bring → import); acid `primaryContainer` tile moved to Record; `onHowItWorks` callback replaced by `onBringFromApps`.
- **`BringFromAppsGuide.kt`** (new) — single-step overlay driven by `ONBOARDING_IMPORT_STEP`, reusing the tour's `DemoStage`, `OnboardingStepHeadline` and `OnboardingPrimaryCta`. Same `BoxWithConstraints` cramped-window layout as the tour (portrait pins the CTA, landscape/large-font scrolls).
- **`OnboardingScreen.kt`** — extracted `OnboardingStepHeadline` + `OnboardingPrimaryCta`, made `DemoStage` / the IMPORT step content / sizing consts internal, so guide and tour render identical chrome from one source.
- **`LandingScreen.kt`** — new guarded `openOnboarding(source)` lambda mirroring `openHub(source)` (the `onboardingStep == null` guard makes the open idempotent, so a rapid double-tap can't double-count the funnel). Threaded as a single `onShowOnboarding: (String) -> Unit` (mirrors `onCreateClick`); each surface — empty state, welcome footer (`SoundsList` last `item`, gated by `isOnMySounds && only-welcome`), overflow — binds its own source at the leaf. New `rememberSaveable` `bringGuideVisible` wired into `subScreenOpen` / screen_view / BackHandler.
- **Tour finish from another tab** — finishing returns to My Bomps before opening the Hub; opened from the overflow on Vault/Explore, the saved Bomp would otherwise land in the unseen My Bomps list and appear to vanish.
- **`SeeHowItWorksButton`** — the Text-tier secondary CTA is one shared composable used by the empty state and the welcome footer, so the two can't drift in copy/typology (ADR 0010).
- **Overflow menu** — reordered with a `HorizontalDivider` and decorative (`contentDescription = null`) leading icons: See how it works → Manage collections → ─ → Share Bomp → About. The "help" item carries a `testTag` so tests address it without its (intentionally shared) label.
- **Drawables** (new) — `app_ic_help`, `app_ic_info`, `app_ic_library_music` (Material Symbols Outlined, decorative; menu text is the accessible name).
- **Analytics** — `import_hub_bring_selected` + a dedicated `BRING_GUIDE` screen_view; `onboarding_opened` now parameterized by source (`empty_state`, `welcome_footer`, `overflow_menu`). No new event/screen → `AnalyticsCoverageMatrixTest` untouched. Dead `AnalyticsSource.IMPORT_HUB` removed.
- **Strings** — new `app_hub_bring*` (EN + es-AR); the welcome footer + overflow item deliberately reuse `app_my_sounds_empty_secondary` — same label + same action is fine for users (no new string).
- **Out of scope** — the 3-step tour's content/analytics and the per-row actions are unchanged.

```mermaid
stateDiagram-v2
    [*] --> MyBomps
    MyBomps --> Hub: tap +
    Hub --> Recorder: Record
    Hub --> Guide: Bring from apps
    Hub --> Picker: Import from device
    MyBomps --> Tour: empty-state / welcome footer / ⋮ menu
    Guide --> MyBomps: Got it / back
```

### Code review tips

- **Tour reachability restored (the gap this follow-up closes):** the full tour is now reachable three ways — empty state, the welcome-audio footer (new users), and the ⋮ menu (anytime). Each path tags `onboarding_opened` with its own source, so the funnel can tell them apart.
- **Welcome footer gating:** renders only when `isOnMySounds && sounds.all { isWelcomeSticker(it) }` — `SoundsList` is also reused by Vault/Explore, so the `isOnMySounds` guard keeps the footer off those. Disappears the moment any non-welcome Bomp exists (tested both ways).
- **Source labeling:** `onShowOnboarding` was hardcoded to `EMPTY_STATE`; the single source-parameterized `openOnboarding(source)` is what lets the footer/overflow report distinct sources instead of mislabeling.
- **Shared onboarding chrome:** guide and tour render from the same extracted composables; a change to `OnboardingStepHeadline`/`OnboardingPrimaryCta`/`DemoStage` affects both — `OnboardingTourTest` guards the tour.
- **Baseline Profile (deferred to pre-release, not regenerated here):** this commit changes the arity of three first-frame Composables (`AppTopBar`/`ScaffoldedLanding`/`MySoundsBody`), so their committed profile rules no longer resolve until regenerated. The profile only matters at release time, so regenerating per-PR while more startup-path changes land before v2.3.0 would just produce a snapshot stale by release — regenerate once as a release-prep step (`scripts/generate-baseline-profile.sh`). Stale = slower first launches, never broken.

### Already tested

- Unit + Robolectric (CircleCI runs these): overflow order, welcome-footer show/hide, and the `overflow_menu` / `welcome_footer` analytics sources.
- Instrumented UI suite (CircleCI does not run it — ADR 0001): run locally cold-boot, 129 tests, 0 failed (2 pre-existing skips).
