### PR TITLE
feat(snackbar): intentional, coherent delete-snackbar voice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 ### Changed
 - The add-a-Bomp sheet now leads with recording and adds a "Bring audios from other apps" option that shows how to share a voice note in from WhatsApp or Telegram, with importing a saved file moved last
 - The quick tour is easier to find — it shows up right under the welcome audio for new users and lives in the top "⋮" menu so you can reopen it any time
+- Deleting an audio now names the one you removed, and the welcome's farewell no longer says goodbye — it reassures you it's kept in case you tap Undo
 
 ### Fixed
 - Bomps saved before an earlier update no longer disappear when you open the app — audios stored under the old format are recovered instead of the whole list silently emptying

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -591,8 +591,6 @@ private fun SnackbarEffects(
     snackbarHostState: SnackbarHostState,
 ) {
     val deletedEvent by viewModel.deletedSoundEvent.collectAsState()
-    val audioDeletedMessage = stringResource(R.string.app_feedback_audio_deleted)
-    val welcomeDismissedMessage = stringResource(R.string.app_welcome_sticker_feedback_dismissed)
     val welcomeInfoMessage = stringResource(R.string.app_welcome_sticker_info)
     val undoLabel = stringResource(R.string.app_undo)
     val playbackErrorMessage = stringResource(R.string.app_error_playback_failed)
@@ -675,12 +673,7 @@ private fun SnackbarEffects(
 
     LaunchedEffect(deletedEvent) {
         val event = deletedEvent ?: return@LaunchedEffect
-        val message =
-            if (isWelcomeSticker(event.sound)) {
-                welcomeDismissedMessage
-            } else {
-                audioDeletedMessage
-            }
+        val message = deletionSnackbarMessage(activityContext, event.sound)
         val result =
             snackbarHostState.showSnackbar(
                 message = message,
@@ -1006,6 +999,20 @@ internal fun SoundsList(
 internal fun deletionSnackbarDuration(
     @Suppress("UNUSED_PARAMETER") sound: Sound,
 ): SnackbarDuration = SnackbarDuration.Long
+
+// Two intentional voices sharing one brand register: the welcome leans on Undo with a warm
+// author line (never a goodbye, which a reversible action contradicts); a user audio names what
+// was deleted. Blank name (unreachable via creation, which blocks blank) falls back to the
+// nameless voice so the placeholder never renders empty.
+internal fun deletionSnackbarMessage(
+    context: Context,
+    sound: Sound,
+): String =
+    when {
+        isWelcomeSticker(sound) -> context.getString(R.string.app_welcome_sticker_feedback_dismissed)
+        sound.name.isBlank() -> context.getString(R.string.app_feedback_audio_deleted_unnamed)
+        else -> context.getString(R.string.app_feedback_audio_deleted, sound.name)
+    }
 
 @Composable
 private fun MySoundsBody(

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -9,10 +9,11 @@
     <string name="app_share_feedback_no_app_for_audio">No tenés una app para compartir audios. Probá instalando una.</string>
     <string name="app_share_feedback_copy_failed">No pude preparar este Bomp para compartir. Liberá espacio y probá de nuevo — Nahu ya se enteró y lo va a investigar.</string>
     <string name="app_share_feedback_broken_data">Los datos de este Bomp están rotos. Borralo y volvé a agregarlo — Nahu ya se enteró y lo va a investigar.</string>
-    <string name="app_undo">Deshacer!</string>
+    <string name="app_undo">Deshacer</string>
     <string name="app_snackbar_action_dismiss">Listo</string>
     <string name="app_snackbar_action_retry">Reintentar</string>
-    <string name="app_feedback_audio_deleted">Audio borrado</string>
+    <string name="app_feedback_audio_deleted">Borraste «%1$s»</string>
+    <string name="app_feedback_audio_deleted_unnamed">Audio borrado</string>
     <string name="app_feedback_button_saved">¡%1$s es tuyo!</string>
     <string name="app_addbutton_overlay_subtitle_saved">ahora es tuyo</string>
     <string name="app_addbutton_overlay_subtitle_renamed">renombrado</string>
@@ -97,7 +98,7 @@
     <string name="app_welcome_sticker_title">Tu primer audio-abrazo</string>
     <string name="app_welcome_sticker_origin">Del que armó esto</string>
     <string name="app_welcome_sticker_info">De mí para vos. Es tuyo: borralo cuando quieras.</string>
-    <string name="app_welcome_sticker_feedback_dismissed">¡Hasta luego!</string>
+    <string name="app_welcome_sticker_feedback_dismissed">Te lo guardo por si lo querés de vuelta.</string>
 
     <!-- Vault (colecciones privadas — biométrico por colección) -->
     <string name="app_navigation_menu_item_vault">Baúl</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,10 +9,11 @@
     <string name="app_share_feedback_no_app_for_audio">No app on your device can share audio. Try installing one.</string>
     <string name="app_share_feedback_copy_failed">Couldn\'t prepare this Bomp for sharing. Free up some space and try again — Nahu\'s already looking into it.</string>
     <string name="app_share_feedback_broken_data">This Bomp\'s data is broken. Remove it and add it again — Nahu\'s already on it.</string>
-    <string name="app_undo">Undo!</string>
+    <string name="app_undo">Undo</string>
     <string name="app_snackbar_action_dismiss">Got it</string>
     <string name="app_snackbar_action_retry">Try again</string>
-    <string name="app_feedback_audio_deleted">Audio deleted</string>
+    <string name="app_feedback_audio_deleted">Deleted \"%1$s\"</string>
+    <string name="app_feedback_audio_deleted_unnamed">Audio deleted</string>
     <string name="app_feedback_button_saved">%1$s is now yours!</string>
     <string name="app_addbutton_overlay_subtitle_saved">is now yours</string>
     <string name="app_addbutton_overlay_subtitle_renamed">renamed</string>
@@ -103,7 +104,7 @@
     <string name="app_welcome_sticker_title">Your first voice-hug</string>
     <string name="app_welcome_sticker_origin">From the maker</string>
     <string name="app_welcome_sticker_info">From me to you. It\'s yours — delete it whenever you like.</string>
-    <string name="app_welcome_sticker_feedback_dismissed">Catch you around!</string>
+    <string name="app_welcome_sticker_feedback_dismissed">I\'ll keep it here in case you want it back.</string>
 
     <!-- Vault tab (private collections — biometric-gated per collection) -->
     <string name="app_navigation_menu_item_vault">Vault</string>

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/DeletionSnackbarMessageTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/DeletionSnackbarMessageTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.testSound
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+internal class DeletionSnackbarMessageTest : AbstractRobolectricTest() {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `welcome deletion speaks the warm author voice, not the generic line`() {
+        val welcome = testSound(name = "Welcome", rawRes = R.raw.app_welcome_sticker)
+
+        val message = deletionSnackbarMessage(context, welcome)
+
+        assertThat(message).isEqualTo(context.getString(R.string.app_welcome_sticker_feedback_dismissed))
+        assertThat(message).isNotEqualTo(context.getString(R.string.app_feedback_audio_deleted_unnamed))
+    }
+
+    @Test
+    fun `deleting a named audio names what was deleted`() {
+        val userSound = testSound(name = "Mama riendo", file = "/audio/mama.mp3")
+
+        val message = deletionSnackbarMessage(context, userSound)
+
+        assertThat(message).contains("Mama riendo")
+        assertThat(message).isNotEqualTo(context.getString(R.string.app_feedback_audio_deleted_unnamed))
+    }
+
+    @Test
+    fun `a name with quote and percent characters renders verbatim without breaking the delimiter`() {
+        val tricky = testSound(name = "a\"b%c", file = "/audio/tricky.mp3")
+
+        val message = deletionSnackbarMessage(context, tricky)
+
+        assertThat(message).contains("a\"b%c")
+    }
+
+    @Test
+    fun `deleting a blank-named audio falls back to the nameless voice so the placeholder never renders empty`() {
+        val unnamed = testSound(name = "", file = "/audio/unnamed.mp3")
+
+        val message = deletionSnackbarMessage(context, unnamed)
+
+        assertThat(message).isEqualTo(context.getString(R.string.app_feedback_audio_deleted_unnamed))
+    }
+}


### PR DESCRIPTION
### Summary

1. The Bomper swipes a sound away — the welcome, or one of their own
2. A snackbar appears with an **Undo** action

**before:** two unrelated voices for the same gesture — the welcome says *"Catch you around!"*, a goodbye that contradicts the Undo button still sitting there; a own Bomp shows a blind *"Audio deleted"* that never says which one.
**after:** the welcome stops saying goodbye and leans on Undo (*"I'll keep it here in case you want it back."*); the generic names what you removed (*Borraste «Mamá riendo»*). One brand register, each line tuned to its case.

### Technical detail

Reworked the delete-snackbar copy into two intentional voices and gave the generic line the audio's name.

- **`strings.xml` (EN master + es-AR):** `app_feedback_audio_deleted` → format string (`Deleted "%1$s"` / `Borraste «%1$s»`); new `app_feedback_audio_deleted_unnamed` fallback; `app_welcome_sticker_feedback_dismissed` → warm non-goodbye; `app_undo` drops its "!".
- **`LandingScreen.kt`:** extracted the inline welcome-vs-generic `if/else` into `deletionSnackbarMessage(context, sound)` — welcome → warm voice, blank name → fallback, else → named generic. Removed the two pre-resolved `stringResource` vals it replaced.
- **`DeletionSnackbarMessageTest`:** Robolectric, one assertion per branch + a quote/percent-in-name case.
- **Out of scope (spec §5):** the welcome *info* snackbar, non-delete snackbars, and the `isWelcomeSticker` branching — kept on purpose (two voices justify it).

### Code review tips

- **Rebased** onto develop after the onboarding PR merged; the only conflict was CHANGELOG `### Changed` (kept all entries). `LandingScreen.kt` and both `strings.xml` auto-merged with the new code intact.
- **`app_undo` is shared** — dropping the "!" also neutralizes the "moved to Vault" undo label. Intended (Undo is a neutral action everywhere).
- **Interpretation (§6):** kept the spec table's straight EN quotes (`Deleted "%1$s"`). A name containing `"` nests awkwardly but renders fine — `getString` doesn't re-parse the arg (covered by a test). es-AR `«»` sidesteps it. Flagging in case you prefer curly quotes in EN.
- **Manual verification suggested (device-only, §6):** a long name truncates with ellipsis on the one-line snackbar — confirm it doesn't push **Undo** out of the tap area.

### Already tested

- instrumented (CircleCI doesn't run it — ADR 0001): full suite local, 129 tests, 0 failed (2 skipped)

Unit + Android Lint are covered by CI.
