### PR TITLE
chore(release): cut v2.3.0 (versionCode 8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][], and this project adheres to [Semantic Versioning][].
 
-## \[unreleased] (v2.3.0)
+## \[v2.3.0] - 2026-06-28
 
 ### Added
 - Record a Bomp without leaving the app — the add sheet's "Record" option opens a full-screen recorder: tap to record, listen back on a real waveform, and save it like any other Bomp; if you leave mid-recording, a banner offers to pick it back up

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Bomp is your personal collection of the voices that matter. Save them, keep them
 [<img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" height="80"/>](https://play.google.com/store/apps/details?id=com.github.barriosnahuel.vossosunboton)
 
 ## Project status 📖
-[![version](https://img.shields.io/badge/version-2.2.0-brightgreen.svg)](https://github.com/barriosnahuel/bomp/releases)
-[![Semver](https://img.shields.io/badge/SemVer-v2.2.0-green.svg)](http://semver.org/spec/v2.0.0.html)
+[![version](https://img.shields.io/badge/version-2.3.0-brightgreen.svg)](https://github.com/barriosnahuel/bomp/releases)
+[![Semver](https://img.shields.io/badge/SemVer-v2.3.0-green.svg)](http://semver.org/spec/v2.0.0.html)
 [![stable](https://img.shields.io/badge/stability-experimental-green.svg)](https://nodejs.org/api/documentation.html#documentation_stability_index)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE)
 

--- a/store-listing/en-US/changelog-8.txt
+++ b/store-listing/en-US/changelog-8.txt
@@ -1,0 +1,8 @@
+What's new in this version.
+
+▸ Record a Bomp without leaving the app: tap Record, listen back on a real waveform, and save it like any other.
+▸ Scrub the waveform to jump anywhere in your recording — before, during or after playback.
+▸ Bringing audios in from other apps is clearer, with a quick guide for sharing a voice note from WhatsApp or Telegram.
+▸ Bomps saved in an older format now reappear instead of vanishing.
+
+Thanks for bomping.

--- a/store-listing/es-AR/changelog-8.txt
+++ b/store-listing/es-AR/changelog-8.txt
@@ -1,0 +1,8 @@
+Novedades de esta versión.
+
+▸ Grabá un Bomp sin salir de la app: tocá Grabar, escuchalo sobre una onda real y guardalo como cualquier otro.
+▸ Arrastrá la onda para saltar a cualquier parte de tu grabación — antes, durante o después de escuchar.
+▸ Traer audios desde otras apps es más claro, con una guía rápida para compartir una nota de voz desde WhatsApp o Telegram.
+▸ Los Bomps guardados en un formato anterior vuelven a aparecer, en vez de desaparecer.
+
+Gracias por bompear.


### PR DESCRIPTION
### Summary

Internal — release housekeeping to cut **v2.3.0 (versionCode 8)**. No app behavior change. The store **"What's new"** for v2.3.0 ships with this; `develop` already carries the v2.3.0 features and the regenerated Baseline Profile (#1256, merged).

- **What's new (en-US + es-AR):** leads with the headline of this release — recording a Bomp without leaving the app — plus waveform scrub, the clearer bring-from-other-apps guide, and the old-format recovery fix.
- **CHANGELOG / README:** the release is finalized and the version badges move with it.

### Code review tips

- **The `changelog-8` copy is a draft for your review** — es-AR voseo + en-US, DNA-checked (Bomp/Bompear untranslated, no soundboard/sticker/share-with-followers, no reserved terms, no permanence claim). 443 / 479 chars (≤500). Easy to iterate.
- "What's new" is a **release** field uploaded with the AAB — not part of any custom listing.
- `versionCode 8 / versionName 2.3.0` already live on `develop`; this PR does **not** touch `app/build.gradle`.
- **Release steps that remain after merge (yours, outward-facing):** build the signed AAB from merged `develop` (`./gradlew app:bundleRelease` with the **real** `google-services.json` — do **not** pass `-x uploadCrashlyticsMappingFileRelease`, that's CI-only; it auto-uploads the R8 mapping to Firebase), then `gh release create v2.3.0 --target develop --notes-file store-listing/en-US/changelog-8.txt app/build/outputs/mapping/release/mapping.txt`, verify the mapping landed on the release + in Firebase, and run the manual analytics smoke in DebugView.

### Already tested

- Release lint gate `./gradlew app:lintVitalRelease` — green locally.
- Instrumented UI suite (`./scripts/run-instrumented-tests.sh`, cold-boot AVD) — 129 tests, 0 failed (2 skipped), run 1/1 passed.
- Char counts en-US 443 / es-AR 479 (≤500); CHANGELOG heading + README badges verified.