### PR TITLE
docs(versioning): adopt CalVer YYYY.MM.DD going forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog][]. Releases through v2.3.0 followed [Semantic Versioning][]; from the next release onward this project uses [Calendar Versioning][] — the app `versionName` is `YYYY.MM`, while release tags and the headers below are `vYYYY.MM.DD`.
+The format is based on [Keep a Changelog][]. Through v2.3.0 this project used [Semantic Versioning][]; from the next release onward it uses [Calendar Versioning][] — see CONTRIBUTING § *Versioning*. Existing headers below stay as the SemVer versions they shipped as.
 
-## \[unreleased] (amplitud)
+## \[unreleased]
 
 ## \[v2.3.0] - 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog][], and this project adheres to [Semantic Versioning][].
+The format is based on [Keep a Changelog][]. Releases through v2.3.0 followed [Semantic Versioning][]; from the next release onward this project uses [Calendar Versioning][] (`YYYY.MM.DD`).
+
+## \[unreleased] (amplitud)
 
 ## \[v2.3.0] - 2026-06-28
 
@@ -324,3 +326,4 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
+[calendar versioning]: https://calver.org/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog][]. Releases through v2.3.0 followed [Semantic Versioning][]; from the next release onward this project uses [Calendar Versioning][] (`YYYY.MM.DD`).
+The format is based on [Keep a Changelog][]. Releases through v2.3.0 followed [Semantic Versioning][]; from the next release onward this project uses [Calendar Versioning][] — the app `versionName` is `YYYY.MM`, while release tags and the headers below are `vYYYY.MM.DD`.
 
 ## \[unreleased] (amplitud)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,7 +330,7 @@ Store listing PNGs (icon, feature graphic) render from SVG masters under `store-
 
 ## Labels and milestone
 
-Apply exactly **one type label** (`a:*` or `an:*`) + **zero or more concern labels** (`c:*`) to every PR before merging. Don't call `gh label list`. For the milestone, read the `## [unreleased]` line in `CHANGELOG.md` — the version in parentheses is the milestone (e.g. `(v2.0.0)` → milestone `v2.0.0`); don't call the milestones API.
+Apply exactly **one type label** (`a:*` or `an:*`) + **zero or more concern labels** (`c:*`) to every PR before merging. Don't call `gh label list`. For the milestone: under CalVer the next version is fixed **at cut**, so `## [unreleased]` carries no version — leave the milestone unset until a release exists (pre-CalVer PRs read it from a `(vX.Y.Z)` on that line). Don't call the milestones API.
 
 - **Type — user-facing** (appear in CHANGELOG `### Added/Changed/Fixed/Removed`): `a:feature`, `a:fix`, `an:enhancement`.
 - **Type — internal** (under `### For nerds 🤓` or omitted): `a:refactor`, `a:test`, `a:build`, `a:docs`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,7 +345,7 @@ Full "when to use" per label + worked combinations: CONTRIBUTING.md § *Labels &
 
 ## Changelog
 
-`CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/):
+`CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/); released headers are CalVer `## [YYYY.MM.DD]` (CONTRIBUTING § *Versioning*):
 - Sections `Added` / `Changed` / `Fixed` / `Removed` under `## [unreleased]`. Each entry: single sentence, capital, no trailing period.
 - Dependency bumps → one line for the overall bump (`"Bumped all dependencies to latest stable"`), not one per library.
 - Update `[unreleased]` per commit when the change is user-visible or architecturally significant.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,7 +345,7 @@ Full "when to use" per label + worked combinations: CONTRIBUTING.md § *Labels &
 
 ## Changelog
 
-`CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/); released headers are CalVer `## [YYYY.MM.DD]` (CONTRIBUTING § *Versioning*):
+`CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/); released headers are CalVer `## [vYYYY.MM.DD]` (CONTRIBUTING § *Versioning*):
 - Sections `Added` / `Changed` / `Fixed` / `Removed` under `## [unreleased]`. Each entry: single sentence, capital, no trailing period.
 - Dependency bumps → one line for the overall bump (`"Bumped all dependencies to latest stable"`), not one per library.
 - Update `[unreleased]` per commit when the change is user-visible or architecturally significant.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -566,7 +566,7 @@ Release-only Gradle commands (need the signing files above in the project root):
 
 - **`versionName`** (what the Bomper sees in Play / "Acerca de") is **`YYYY.MM`** — year + month of the cut (e.g. `2026.07`). The date *is* the version: it tells the Bomper how fresh the app is. No SemVer `MAJOR.MINOR.PATCH`, **no sequential counter**. Two releases in the same month share a `versionName` — Play allows it; they stay distinct by `versionCode`.
 - **`versionCode`** stays a **monotonic integer**, bumped +1 per release, independent of `versionName` (Play Store requirement). It is the true build identity.
-- **GitHub tags + release titles + `CHANGELOG.md` headers** are **`vYYYY.MM.DD`** — the `v`-prefixed cut date with day precision, so every release is a unique tag without a sequential counter (e.g. `v2026.07.15`).
+- **GitHub tags + release titles + `CHANGELOG.md` headers** are **`vYYYY.MM.DD`** — the `v`-prefixed cut date with day precision (e.g. `v2026.07.15`). Day precision keeps tags unique across months without a sequential counter. If two releases ever land the **same day** (rare — a same-afternoon hotfix), disambiguate the second **tag only** at cut (e.g. `v2026.07.15-2`); `versionCode` already separates the builds and `versionName` stays `YYYY.MM`.
 - **Forward-only frontier:** releases through `v2.3.0` were SemVer and stay as-is in tags / CHANGELOG / history. CalVer governs from the first cut after this change onward.
 
 ### Pre-release checklist
@@ -593,8 +593,6 @@ After the checklist above is green and the version bump is merged to `develop`:
      --notes-file store-listing/en-US/changelog-<versionCode>.txt \
      app/build/outputs/mapping/release/mapping.txt
    ```
-
-   The tag/title is the `v`-prefixed CalVer cut date (§ *Versioning*), e.g. `v2026.07.15`.
 
    `<versionCode>` is the value in `app/build.gradle`. Add a footer line linking to the full `CHANGELOG.md` on `develop` if the notes file omits it.
 3. **Attach nothing else.** The mapping is a backup for offline `retrace`; **never** attach the keystore, `secure.properties`, the real `google-services.json`, or the `.aab` (the `.aab` carries no mapping anyway).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -562,19 +562,20 @@ Release-only Gradle commands (need the signing files above in the project root):
 
 ### Versioning
 
-`versionName` follows **Calendar Versioning**: `YYYY.MM.DD` — the year, month, and day of the release cut (e.g. `2026.07.15`). The date *is* the version, so it tells the Bomper how fresh the app is; there is no SemVer `MAJOR.MINOR.PATCH` and **no sequential counter** — the "patch" position is the day, never a running number.
+**Calendar Versioning**, at two granularities — the user-facing version reads as a month, the GitHub tag is day-precise:
 
-- **`versionCode`** stays a **monotonic integer**, bumped +1 per release, independent of `versionName` (Play Store requirement). It is the true build identity — two cuts on the same day (not expected) are still distinct by `versionCode`.
-- **Forward-only frontier:** releases through `v2.3.0` were SemVer and stay as-is in tags / CHANGELOG / history. CalVer governs from the first release cut after this change onward.
-- **GitHub** tags and release titles use the same CalVer string; `CHANGELOG.md` headers become `## [YYYY.MM.DD]` at cut.
+- **`versionName`** (what the Bomper sees in Play / "Acerca de") is **`YYYY.MM`** — year + month of the cut (e.g. `2026.07`). The date *is* the version: it tells the Bomper how fresh the app is. No SemVer `MAJOR.MINOR.PATCH`, **no sequential counter**. Two releases in the same month share a `versionName` — Play allows it; they stay distinct by `versionCode`.
+- **`versionCode`** stays a **monotonic integer**, bumped +1 per release, independent of `versionName` (Play Store requirement). It is the true build identity.
+- **GitHub tags + release titles + `CHANGELOG.md` headers** are **`vYYYY.MM.DD`** — the `v`-prefixed cut date with day precision, so every release is a unique tag without a sequential counter (e.g. `v2026.07.15`).
+- **Forward-only frontier:** releases through `v2.3.0` were SemVer and stay as-is in tags / CHANGELOG / history. CalVer governs from the first cut after this change onward.
 
 ### Pre-release checklist
 
 A **seed** — expand it as the release process is formalized (store rollout steps aren't documented yet, so they're intentionally omitted rather than invented). Before cutting a release:
 
 - [ ] **Regenerate the Baseline Profile** — `./scripts/generate-baseline-profile.sh`, then validate on a **real device** (`StartupBenchmark.startupBaselineProfile` near `DEFAULT`, well under `None`). It's a frozen snapshot of the cold-start path (§ *Baseline Profile*); refresh it so accumulated startup changes are precompiled.
-- [ ] **Finalize `CHANGELOG.md`** — stamp `## [unreleased]` as `## [YYYY.MM.DD]`, the cut date (§ CLAUDE.md *Changelog*).
-- [ ] **Bump `versionCode` + `versionName`** in `app/build.gradle` — `versionCode` +1; `versionName` to the CalVer `YYYY.MM.DD` cut date (§ *Versioning*).
+- [ ] **Finalize `CHANGELOG.md`** — stamp `## [unreleased]` as `## [vYYYY.MM.DD]`, the cut date (§ CLAUDE.md *Changelog*).
+- [ ] **Bump `versionCode` + `versionName`** in `app/build.gradle` — `versionCode` +1; `versionName` to the CalVer `YYYY.MM` cut month (§ *Versioning*).
 - [ ] **Release lint gate** — `./gradlew app:lintVitalRelease` green.
 - [ ] **Build the AAB** — `./gradlew app:bundle`.
 - [ ] **Write the store change notes** — `store-listing/{en-US,es-AR}/changelog-<versionCode>.txt`; the GitHub release notes are sourced from the en-US file (§ *Creating the GitHub release*).
@@ -588,16 +589,16 @@ After the checklist above is green and the version bump is merged to `develop`:
 2. **Create the release + tag from `develop`**, notes from the store change file, attaching **only** the R8 mapping as the single asset:
 
    ```bash
-   gh release create YYYY.MM.DD --target develop --title "YYYY.MM.DD" \
+   gh release create vYYYY.MM.DD --target develop --title "vYYYY.MM.DD" \
      --notes-file store-listing/en-US/changelog-<versionCode>.txt \
      app/build/outputs/mapping/release/mapping.txt
    ```
 
-   The tag/title is the CalVer cut date (§ *Versioning*), e.g. `2026.07.15`.
+   The tag/title is the `v`-prefixed CalVer cut date (§ *Versioning*), e.g. `v2026.07.15`.
 
    `<versionCode>` is the value in `app/build.gradle`. Add a footer line linking to the full `CHANGELOG.md` on `develop` if the notes file omits it.
 3. **Attach nothing else.** The mapping is a backup for offline `retrace`; **never** attach the keystore, `secure.properties`, the real `google-services.json`, or the `.aab` (the `.aab` carries no mapping anyway).
-4. **Verify the asset landed** — `gh release view YYYY.MM.DD --json assets -q '.assets[].name'` must list `mapping.txt`. Print an explicit line for the maintainer to confirm, e.g. `✅ mapping.txt attached to YYYY.MM.DD` (or ⚠️ + re-run `gh release upload YYYY.MM.DD app/build/outputs/mapping/release/mapping.txt` if missing).
+4. **Verify the asset landed** — `gh release view vYYYY.MM.DD --json assets -q '.assets[].name'` must list `mapping.txt`. Print an explicit line for the maintainer to confirm, e.g. `✅ mapping.txt attached to vYYYY.MM.DD` (or ⚠️ + re-run `gh release upload vYYYY.MM.DD app/build/outputs/mapping/release/mapping.txt` if missing).
 5. **Verify Firebase actually got the mapping** — the build log must show `uploadCrashlyticsMappingFileRelease` *ran* (not skipped). Within minutes, a fresh crash on this version should de-obfuscate in the Console / via the Firebase MCP (real frames, **not** `r8-map-id-…`). This step exists because past releases shipped **without** the mapping (§ *BigQuery export* → *Stack frames come R8-obfuscated*) — so Crashlytics couldn't deobfuscate them either.
 
 Why archive the mapping: even when Firebase holds it for Console/MCP de-obfuscation, a GitHub-release copy keyed to the tag is a durable offline `retrace` backup independent of Firebase retention — and the safety net for exactly the case above, where the Firebase upload didn't happen.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -560,13 +560,21 @@ Release-only Gradle commands (need the signing files above in the project root):
 ./gradlew app:bundle             # Build the AAB for Play Store upload
 ```
 
+### Versioning
+
+`versionName` follows **Calendar Versioning**: `YYYY.MM.DD` — the year, month, and day of the release cut (e.g. `2026.07.15`). The date *is* the version, so it tells the Bomper how fresh the app is; there is no SemVer `MAJOR.MINOR.PATCH` and **no sequential counter** — the "patch" position is the day, never a running number.
+
+- **`versionCode`** stays a **monotonic integer**, bumped +1 per release, independent of `versionName` (Play Store requirement). It is the true build identity — two cuts on the same day (not expected) are still distinct by `versionCode`.
+- **Forward-only frontier:** releases through `v2.3.0` were SemVer and stay as-is in tags / CHANGELOG / history. CalVer governs from the first release cut after this change onward.
+- **GitHub** tags and release titles use the same CalVer string; `CHANGELOG.md` headers become `## [YYYY.MM.DD]` at cut.
+
 ### Pre-release checklist
 
 A **seed** — expand it as the release process is formalized (store rollout steps aren't documented yet, so they're intentionally omitted rather than invented). Before cutting a release:
 
 - [ ] **Regenerate the Baseline Profile** — `./scripts/generate-baseline-profile.sh`, then validate on a **real device** (`StartupBenchmark.startupBaselineProfile` near `DEFAULT`, well under `None`). It's a frozen snapshot of the cold-start path (§ *Baseline Profile*); refresh it so accumulated startup changes are precompiled.
-- [ ] **Finalize `CHANGELOG.md`** — move `## [unreleased]` to the version + date (§ CLAUDE.md *Changelog*).
-- [ ] **Bump `versionCode` + `versionName`** in `app/build.gradle` to match the milestone.
+- [ ] **Finalize `CHANGELOG.md`** — stamp `## [unreleased]` as `## [YYYY.MM.DD]`, the cut date (§ CLAUDE.md *Changelog*).
+- [ ] **Bump `versionCode` + `versionName`** in `app/build.gradle` — `versionCode` +1; `versionName` to the CalVer `YYYY.MM.DD` cut date (§ *Versioning*).
 - [ ] **Release lint gate** — `./gradlew app:lintVitalRelease` green.
 - [ ] **Build the AAB** — `./gradlew app:bundle`.
 - [ ] **Write the store change notes** — `store-listing/{en-US,es-AR}/changelog-<versionCode>.txt`; the GitHub release notes are sourced from the en-US file (§ *Creating the GitHub release*).
@@ -580,14 +588,16 @@ After the checklist above is green and the version bump is merged to `develop`:
 2. **Create the release + tag from `develop`**, notes from the store change file, attaching **only** the R8 mapping as the single asset:
 
    ```bash
-   gh release create vX.Y.Z --target develop --title "vX.Y.Z" \
+   gh release create YYYY.MM.DD --target develop --title "YYYY.MM.DD" \
      --notes-file store-listing/en-US/changelog-<versionCode>.txt \
      app/build/outputs/mapping/release/mapping.txt
    ```
 
+   The tag/title is the CalVer cut date (§ *Versioning*), e.g. `2026.07.15`.
+
    `<versionCode>` is the value in `app/build.gradle`. Add a footer line linking to the full `CHANGELOG.md` on `develop` if the notes file omits it.
 3. **Attach nothing else.** The mapping is a backup for offline `retrace`; **never** attach the keystore, `secure.properties`, the real `google-services.json`, or the `.aab` (the `.aab` carries no mapping anyway).
-4. **Verify the asset landed** — `gh release view vX.Y.Z --json assets -q '.assets[].name'` must list `mapping.txt`. Print an explicit line for the maintainer to confirm, e.g. `✅ mapping.txt attached to vX.Y.Z` (or ⚠️ + re-run `gh release upload vX.Y.Z app/build/outputs/mapping/release/mapping.txt` if missing).
+4. **Verify the asset landed** — `gh release view YYYY.MM.DD --json assets -q '.assets[].name'` must list `mapping.txt`. Print an explicit line for the maintainer to confirm, e.g. `✅ mapping.txt attached to YYYY.MM.DD` (or ⚠️ + re-run `gh release upload YYYY.MM.DD app/build/outputs/mapping/release/mapping.txt` if missing).
 5. **Verify Firebase actually got the mapping** — the build log must show `uploadCrashlyticsMappingFileRelease` *ran* (not skipped). Within minutes, a fresh crash on this version should de-obfuscate in the Console / via the Firebase MCP (real frames, **not** `r8-map-id-…`). This step exists because past releases shipped **without** the mapping (§ *BigQuery export* → *Stack frames come R8-obfuscated*) — so Crashlytics couldn't deobfuscate them either.
 
 Why archive the mapping: even when Firebase holds it for Console/MCP de-obfuscation, a GitHub-release copy keyed to the tag is a durable offline `retrace` backup independent of Firebase retention — and the safety net for exactly the case above, where the Firebase upload didn't happen.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Bomp is your personal collection of the voices that matter. Save them, keep them
 
 ## Project status 📖
 [![version](https://img.shields.io/badge/version-2.3.0-brightgreen.svg)](https://github.com/barriosnahuel/bomp/releases)
-[![Semver](https://img.shields.io/badge/SemVer-v2.3.0-green.svg)](http://semver.org/spec/v2.0.0.html)
+[![CalVer](https://img.shields.io/badge/CalVer-YYYY.MM.DD-green.svg)](https://calver.org/)
 [![stable](https://img.shields.io/badge/stability-experimental-green.svg)](https://nodejs.org/api/documentation.html#documentation_stability_index)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Bomp is your personal collection of the voices that matter. Save them, keep them
 
 ## Project status 📖
 [![version](https://img.shields.io/badge/version-2.3.0-brightgreen.svg)](https://github.com/barriosnahuel/bomp/releases)
-[![CalVer](https://img.shields.io/badge/CalVer-YYYY.MM.DD-green.svg)](https://calver.org/)
+[![CalVer](https://img.shields.io/badge/CalVer-YYYY.MM-green.svg)](https://calver.org/)
 [![stable](https://img.shields.io/badge/stability-experimental-green.svg)](https://nodejs.org/api/documentation.html#documentation_stability_index)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Bomp is your personal collection of the voices that matter. Save them, keep them
 
 ## Project status 📖
 [![version](https://img.shields.io/badge/version-2.3.0-brightgreen.svg)](https://github.com/barriosnahuel/bomp/releases)
-[![CalVer](https://img.shields.io/badge/CalVer-YYYY.MM-green.svg)](https://calver.org/)
+[![CalVer](https://img.shields.io/badge/versioning-CalVer-green.svg)](https://calver.org/)
 [![stable](https://img.shields.io/badge/stability-experimental-green.svg)](https://nodejs.org/api/documentation.html#documentation_stability_index)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE)
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,8 +19,8 @@ android {
         applicationId "com.github.barriosnahuel.vossosunboton"
         minSdkVersion 23
         targetSdkVersion 37
-        versionCode 8
-        versionName '2.3.0' // last SemVer release; CalVer YYYY.MM.DD from the next cut (CONTRIBUTING § Versioning)
+        versionCode 9
+        versionName '2.3.0' // last SemVer release; CalVer versionName YYYY.MM at the next cut, tag vYYYY.MM.DD (CONTRIBUTING § Versioning)
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         // Keep capture/utility drivers out of the default suite (connectedDebugAndroidTest /
         // run-instrumented-tests.sh). The store-screenshot driver still runs via

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,8 +19,8 @@ android {
         applicationId "com.github.barriosnahuel.vossosunboton"
         minSdkVersion 23
         targetSdkVersion 37
-        versionCode 9
-        versionName '2.3.0' // last SemVer release; CalVer versionName YYYY.MM at the next cut, tag vYYYY.MM.DD (CONTRIBUTING § Versioning)
+        versionCode 8
+        versionName '2.3.0' // last SemVer release; CalVer from the next cut (CONTRIBUTING § Versioning)
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         // Keep capture/utility drivers out of the default suite (connectedDebugAndroidTest /
         // run-instrumented-tests.sh). The store-screenshot driver still runs via

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,7 +20,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 37
         versionCode 8
-        versionName '2.3.0'
+        versionName '2.3.0' // last SemVer release; CalVer YYYY.MM.DD from the next cut (CONTRIBUTING § Versioning)
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         // Keep capture/utility drivers out of the default suite (connectedDebugAndroidTest /
         // run-instrumented-tests.sh). The store-screenshot driver still runs via

--- a/docs/adr/0021-calver-versioning.md
+++ b/docs/adr/0021-calver-versioning.md
@@ -1,0 +1,61 @@
+# ADR 0021 — Calendar Versioning for the app + GitHub releases
+
+- **Status:** Accepted
+- **Date:** 2026-07-04
+- **Supersedes:** the implicit Semantic Versioning convention used through v2.3.0 (never recorded as an ADR)
+
+## Context
+
+Through `v2.3.0` the app used Semantic Versioning (`MAJOR.MINOR.PATCH`). SemVer's contract
+protects consumers of a public API against breaking changes — a soundboard app for end users has
+no such API and no compatibility contract, so `2.3.0` communicates nothing to the Bomper. It is
+library ceremony applied to a consumer product. What a user *does* care about is **how fresh the
+app is**, which a date conveys directly.
+
+The `versionCode` is a separate, Play-mandated monotonic integer that users never see; it is
+unaffected by the `versionName` scheme.
+
+## Decision drivers
+
+1. **The visible version should mean something to a user** — a date reads itself ("2026.07"); a
+   SemVer triple does not.
+2. **No false precision / no ceremony** — no sequential patch counter to hand-manage.
+3. **Reversibility of the `versionCode` choice** — `versionCode` can only ever increase, so any
+   scheme that jumps it high (e.g. date-derived `YYYYMMDD` ≈ 20M) is a one-way door. Keep the
+   option open.
+
+## Decision
+
+- **`versionName` = `YYYY.MM`** (cut month, e.g. `2026.07`). No `MAJOR.MINOR.PATCH`, no sequential
+  counter. Two releases in the same month share a `versionName` — Play allows it; they stay
+  distinct by `versionCode`.
+- **GitHub tags + release titles + `CHANGELOG.md` headers = `vYYYY.MM.DD`** (`v`-prefixed cut date,
+  day precision). Day precision keeps tags unique without a sequential counter; a same-day second
+  release disambiguates the **tag only** (`v2026.07.15-2`) at cut.
+- **`versionCode` = small monotonic integer, +1 per release, bumped at cut** (not pre-bumped on
+  `develop`). `develop` carries the last released code; the release commit bumps it. Deliberately
+  **not** date-derived: date-derived is irreversible (can't return to small codes) and can be
+  adopted later at any cut (a jump up is always legal), so there is no reason to burn the runway now.
+- **Forward-only frontier:** `v2.0.0`…`v2.3.0` stay as the SemVer versions they shipped as, in
+  tags / CHANGELOG / history. CalVer governs from the first cut after this ADR onward.
+
+## Enforcement
+
+- Convention documented in `CONTRIBUTING.md` § *Versioning* (canonical) with pointers from
+  `CHANGELOG.md`, `CLAUDE.md` § *Changelog*, and `app/build.gradle`. No grep guard — the scheme is
+  low-frequency and human-checked at cut via the pre-release checklist.
+
+## Out of scope
+
+- **Deriving `versionCode` from the date or from CI** — viable future option (CI build number, or
+  `YYYYMMDD` aligned with CalVer), deferred because it is irreversible and adds build
+  non-determinism for a solo, low-cadence project. Revisit if release cadence rises.
+- **The backlog planning-name convention** — lives in `../push-me-backlog` (its own `CLAUDE.md`),
+  not here. This ADR governs only the shipped app + GitHub releases.
+
+## Revisit criteria
+
+- Release cadence rises enough that manual `versionCode` bumping becomes error-prone → adopt
+  CI/date-derived `versionCode`.
+- The app ever exposes a real compatibility contract (public API, plugin surface) → reconsider a
+  semantic component.


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change.
Sets the versioning policy for every release after v2.3.0: the app + GitHub move from SemVer to **Calendar Versioning** so the version string tells the Bomper how *fresh* the app is. Unblocks cutting the next release under the new scheme.

### Technical detail

Adopt Calendar Versioning `YYYY.MM.DD` as the public version scheme, forward-only.

- **CONTRIBUTING `§ Versioning` (new):** `YYYY.MM.DD` (year.month.day of cut), monotonic `versionCode`, forward-only frontier (≤ v2.3.0 stays SemVer). Pre-release checklist + GitHub-release steps now use `YYYY.MM.DD`.
- **CHANGELOG.md:** intro notes the SemVer→CalVer switch + `[calendar versioning]` link; fresh `## [unreleased] (amplitud)` for the next cut.
- **README.md:** SemVer badge → CalVer badge.
- **CLAUDE.md `§ Changelog`:** one-line pointer that released headers are `## [YYYY.MM.DD]`.
- **app/build.gradle:** `versionName` left at `2.3.0` (last SemVer) + a comment; it's bumped to the CalVer date *at cut* (unknown today), not now.
- **Out of scope:** historical tags/releases, the `versionCode` scheme, and the backlog codename rename (separate, in `../push-me-backlog`).

### Code review tips

- **Format interpretation — please ratify.** The spec defines CalVer as `YYYY.MM` + a sequential `.N` for same-month re-releases. Your instruction was "patch con fecha, **no** número secuencial", which overrides that `.N`. I reconciled to **`YYYY.MM.DD`** (day = patch, never sequential; same-day double-cuts stay distinct via `versionCode`). If you meant plain `YYYY.MM`, only a handful of lines change.
- **`(amplitud)` in the CHANGELOG.** The `[unreleased]` milestone pointer uses the planning codename; it gets stamped to `## [YYYY.MM.DD]` at cut, so the codename never ships in a published header — and the milestone-detection rule (paren) keeps working.
- **versionName intentionally not bumped now** — fixed at cut; only the comment was added.

### Already tested

- Agentic (beyond CI): `scripts/check-adr-invariants.sh` green; CLAUDE.md 39 820 / 40 000 chars; `./gradlew :app:help` configures (build.gradle comment parses).