### PR TITLE
fix(home): reflect My Sounds visibility toggle synchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog][]. Through v2.3.0 this project used [S
 
 ## \[unreleased]
 
+### For nerds 🤓
+
+#### Fixed
+- The My Sounds visibility toggle now updates the visible list synchronously (mirroring the pin toggle) instead of waiting for the DataStore write to round-trip back through `loadSounds`, removing the async dependency that made `SoundsViewModelVisibilityTest` time out under CI load
+
 ## \[v2.3.0] - 2026-06-28
 
 ### Added

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -96,6 +96,31 @@ internal fun isReachableOutsideMySounds(
     privateCollectionIds: Set<String>,
 ): Boolean = publicCollectionIds.isNotEmpty() || privateCollectionIds.isNotEmpty()
 
+/**
+ * Optimistic My Sounds "Todo" reprojection for a visibility toggle (ADR 0012), factored out as a
+ * pure function so the synchronous list update is unit-testable without the DataStore round-trip
+ * (`SoundsViewModel.setAudioVisibleInMySounds` applies the flag to the cache, then reprojects the
+ * visible list through this). [current] is the visible list, [catalog] the full cache already
+ * carrying the just-applied flag, [order] the canonical [Sound] sort. Hiding drops [audioId];
+ * showing inserts it from [catalog] re-sorted by [order] — preserving the welcome sticker and any
+ * pins — and is a no-op when it is already present or absent from the catalog. `loadSounds` later
+ * reprojects to the same list, so this only governs the transient window before the write lands.
+ */
+internal fun reprojectVisibilityToggle(
+    current: List<Sound>,
+    audioId: String,
+    visible: Boolean,
+    catalog: List<Sound>,
+    order: Comparator<Sound>,
+): List<Sound> =
+    if (!visible) {
+        current.filterNot { it.id == audioId }
+    } else if (current.any { it.id == audioId }) {
+        current
+    } else {
+        catalog.firstOrNull { it.id == audioId }?.let { (current + it).sortedWith(order) } ?: current
+    }
+
 data class PlaybackProgress(
     val positionMs: Int,
     val durationMs: Int,
@@ -1172,10 +1197,11 @@ class SoundsViewModel(
     }
 
     /**
-     * Persists [Sound.isVisibleInMySounds] for [audioId] and reflects it instantly in the catalog
-     * cache (ADR 0012). The DataStore write re-triggers `loadSounds` through the repo observer,
-     * which reprojects the visible list; updating [allSoundsCache] here keeps the sheet's switch and
-     * any cache-derived reads consistent in the meantime. Mirror of [togglePin]'s optimistic shape.
+     * Persists [Sound.isVisibleInMySounds] for [audioId] and reflects it instantly in BOTH the catalog
+     * cache and the visible "Todo" list (ADR 0012). The DataStore write re-triggers `loadSounds`
+     * through the repo observer, which reprojects the visible list; updating [allSoundsCache] and
+     * [_sounds] here keeps the sheet's switch and the list consistent in the meantime — a full mirror
+     * of [togglePin]'s optimistic shape, so the toggle never has to wait for the DataStore round-trip.
      */
     fun setAudioVisibleInMySounds(
         audioId: String,
@@ -1184,6 +1210,14 @@ class SoundsViewModel(
     ) {
         allSoundsCache.update { list ->
             list.map { if (it.id == audioId) it.copy(isVisibleInMySounds = visible) else it }
+        }
+        // Optimistically reproject the visible list so "Todo" updates synchronously instead of only
+        // after the DataStore write round-trips back through `loadSounds` (the source of the earlier
+        // flaky timeout under CI load). Only the unfiltered My Sounds view is visibility-driven: a
+        // public chip surfaces members by membership (ADR 0012) and other tabs don't project by
+        // visibility, so leave those to the reactive `loadSounds`, which reprojects to the same list.
+        if (_selectedTab.value == AppTab.MY_SOUNDS && _activeMySoundsFilter.value == null) {
+            _sounds.update { current -> reprojectVisibilityToggle(current, audioId, visible, allSoundsCache.value, SOUND_ORDER) }
         }
         viewModelScope.launch(ioDispatcher) {
             runCatching { repo.saveVisibility(audioId, name, visible) }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelVisibilityReprojectionTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelVisibilityReprojectionTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home
+
+import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.github.barriosnahuel.vossosunboton.testSound
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pure-function coverage for [reprojectVisibilityToggle] — the optimistic My Sounds "Todo" update
+ * that makes a visibility toggle reflect synchronously (ADR 0012), instead of only after the
+ * DataStore write round-trips back through `loadSounds` (the latency that previously flaked
+ * [SoundsViewModelVisibilityTest] under CI load). No Robolectric / dispatcher / DataStore here, so
+ * these assertions can't race a background `loadSounds` — they isolate the synchronous list logic.
+ */
+internal class SoundsViewModelVisibilityReprojectionTest {
+    // Mirror of SoundsViewModel.SOUND_ORDER (private): pinned first, then most-recent by dateAdded,
+    // then name. The production toggle passes that exact comparator into reprojectVisibilityToggle.
+    private val order: Comparator<Sound> =
+        compareByDescending<Sound> { it.isPinned }
+            .thenByDescending { it.dateAdded ?: Long.MIN_VALUE }
+            .thenBy { it.name.lowercase() }
+
+    @Test
+    fun `hiding drops the audio and preserves the rest of the ordered list`() {
+        val current = listOf(sound("alpha", 3), sound("bravo", 2), sound("charlie", 1))
+
+        val result = reprojectVisibilityToggle(current, "custom:bravo", visible = false, catalog = current, order = order)
+
+        assertThat(result.map { it.name }).containsExactly("alpha", "charlie").inOrder()
+    }
+
+    @Test
+    fun `showing inserts the audio from the catalog at its date-ordered slot`() {
+        val alpha = sound("alpha", 3)
+        val bravo = sound("bravo", 2)
+        val charlie = sound("charlie", 1)
+        // "bravo" is hidden (absent from the visible list) but present in the full catalog.
+        val current = listOf(alpha, charlie)
+
+        val result =
+            reprojectVisibilityToggle(current, "custom:bravo", visible = true, catalog = listOf(alpha, bravo, charlie), order = order)
+
+        assertThat(result.map { it.name }).containsExactly("alpha", "bravo", "charlie").inOrder()
+    }
+
+    @Test
+    fun `showing re-sorts so a pinned audio jumps ahead of unpinned newer ones`() {
+        val newest = sound("newest", 9)
+        val pinned = sound("pinned", 1, isPinned = true)
+        val current = listOf(newest)
+
+        val result = reprojectVisibilityToggle(current, "custom:pinned", visible = true, catalog = listOf(newest, pinned), order = order)
+
+        assertThat(result.map { it.name }).containsExactly("pinned", "newest").inOrder()
+    }
+
+    @Test
+    fun `showing keeps a pre-existing sticker in its slot`() {
+        // Stand-in for the welcome sticker: a non-target item must survive the show re-sort in place.
+        val sticker = sound("welcome", 5)
+        val alpha = sound("alpha", 3)
+        val current = listOf(sticker, alpha)
+
+        val result =
+            reprojectVisibilityToggle(
+                current,
+                "custom:bravo",
+                visible = true,
+                catalog = listOf(sticker, alpha, sound("bravo", 2)),
+                order = order,
+            )
+
+        assertThat(result.map { it.name }).containsExactly("welcome", "alpha", "bravo").inOrder()
+    }
+
+    @Test
+    fun `showing an already-visible audio is a no-op`() {
+        val current = listOf(sound("alpha", 3), sound("bravo", 2))
+
+        val result = reprojectVisibilityToggle(current, "custom:bravo", visible = true, catalog = current, order = order)
+
+        assertThat(result).isEqualTo(current)
+    }
+
+    @Test
+    fun `showing an audio missing from the catalog leaves the list untouched`() {
+        val current = listOf(sound("alpha", 3))
+
+        val result = reprojectVisibilityToggle(current, "custom:ghost", visible = true, catalog = current, order = order)
+
+        assertThat(result).isEqualTo(current)
+    }
+
+    private fun sound(
+        name: String,
+        dateAdded: Long,
+        isPinned: Boolean = false,
+    ): Sound = testSound(name, file = "$name.mp3", dateAdded = dateAdded, isPinned = isPinned)
+}


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change (the visibility toggle already reflected within a DataStore write on-device; this makes it synchronous). It ends the flaky `TimeoutCancellationException` that `SoundsViewModelVisibilityTest` intermittently threw under CI load, restoring trustworthy signal on that suite.

### Technical detail

Root cause: `setAudioVisibleInMySounds` updated only `allSoundsCache`; the visible "Todo" list (`_sounds`) caught up **solely** via the async `saveVisibility` write → `repo.sounds` re-emit → `drop(1).collect { loadSounds() }` → reproject. The test awaits `vm.sounds`, so its await hung on that real-IO round-trip — under CI thread starvation it overran even the 10 s cap.

- **`setAudioVisibleInMySounds`** — after applying the flag to the cache, reprojects `_sounds` synchronously, a full mirror of `togglePin`'s existing optimistic shape. Persistence stays fire-and-forget on `ioDispatcher`.
- **`reprojectVisibilityToggle` (new pure fn)** — hide drops the id; show inserts it from the cache re-sorted by `SOUND_ORDER` (welcome sticker + pins preserved), no-op if already present/absent. Factored out (like `mySoundsProjection`) so it's unit-testable without a dispatcher.
- **Guard** — only the unfiltered My Sounds view is visibility-driven; an active public chip (membership, ADR 0012) and VAULT/EXPLORE are left to `loadSounds`, which converges to the identical list (idempotent).
- **Out of scope** — the pre-existing rapid-toggle write-ordering race (two unserialized `saveVisibility` launches) is unchanged; flagged below.

### Code review tips

- Convergence hinges on `loadSounds` always re-running after the write (visibility flip changes the JSON, so `distinctUntilChanged` passes) — the optimistic value only governs the transient window.
- `reprojectVisibilityToggle` is also reached from `applyAssignment` (inside `launch(ioDispatcher)`); `MutableStateFlow.update` is atomic so the off-main call is safe and desirable ("moved to Vault" drops the card synchronously).
- No synchronous-`_sounds.value` unit assertion was added: with the live collector resuming on the real IO thread, a background `loadSounds` can clobber the sample before it reads — inherently racy. The pure-function tests cover the new logic deterministically instead.
- Pre-existing race (not introduced): back-to-back show→hide can persist out of order; final `_sounds` may converge to the opposite of the last tap. Optional follow-up: serialize `saveVisibility` per `audioId`.

### Already tested

- `SoundsViewModelVisibilityTest` (JVM): 10/10 consecutive green (forced re-exec via `cleanTestDebugUnitTest`) — the explicit anti-flake bar.
- `SoundsViewModelVisibilityReprojectionTest` (new, pure JVM): 6/6 green.
- Instrumented UI suite (`run-instrumented-tests.sh`, cold-boot AVD — CI does not run it): 129/129 green.
