### PR TITLE
refactor(playback): long-form listen sessions on Media3 ExoPlayer (ADR 0022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@ The format is based on [Keep a Changelog][]. Through v2.3.0 this project used [S
 
 ## \[unreleased]
 
+### Changed
+- Opening a Vault audio's listen screen now always starts it from the beginning — previously a reopened audio silently resumed from where it was left mid-clip
+
 ### For nerds 🤓
 
 #### Added
 - ADR 0022 decides the playback architecture for the Media3 migration: measured hybrid — MediaPlayer stays on the tap path (80 ms vs ExoPlayer's 390 ms on device, AEP exception documented), Media3 + MediaSession take the listening sessions (Vault immersive, recorder review)
+- Long-form playback engine (`ListenSessionEngine`, Media3 ExoPlayer 1.10.1) behind the same `PlayerController` facade: Vault immersive listen and recorder review now play on it, reporting through the existing listener/StateFlow channels; list-row taps and add-flow previews stay on MediaPlayer (ADR 0022)
 
 ## \[v2.3.0] - 2026-06-28
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -166,6 +166,7 @@ dependencies {
     implementation libs.compose.material3
     implementation libs.androidx.activity.compose
     implementation libs.androidx.core.splashscreen
+    implementation libs.androidx.media3.exoplayer
     implementation libs.lifecycle.viewmodel.compose
     implementation libs.lifecycle.runtime.compose
     implementation libs.coroutines.android

--- a/app/src/debug/java/com/github/barriosnahuel/vossosunboton/StrictModeConfigurator.kt
+++ b/app/src/debug/java/com/github/barriosnahuel/vossosunboton/StrictModeConfigurator.kt
@@ -137,6 +137,13 @@ private val KNOWN_THIRD_PARTY_VIOLATIONS =
             library = "Firebase Analytics (embedded)",
             classNamePrefix = "com.google.android.gms.internal.measurement",
         ),
+        // Media3 ExoPlayer's renderer/codec internals hit greylist (NonSdkApi) APIs when a listen
+        // session starts (ADR 0022). Reproduced on device the first time ExoPlayer prepares a
+        // stream; the violation's top app-code frame is androidx.media3 code, not ours.
+        KnownThirdPartyViolation(
+            library = "Media3 ExoPlayer",
+            classNamePrefix = "androidx.media3.",
+        ),
         // Same logical SDK as above, delivered via GMS Dynamite on real devices with Play Services. The
         // dynamic module ships obfuscated class names (m7.apj, m7.api, ...) so a classNamePrefix match would
         // either be unsafe (`m7.` is too generic) or break on every Play Services revision. The Dynamite

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/ListenSessionEngine.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/ListenSessionEngine.kt
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.playback
+
+import android.content.Context
+import android.net.Uri
+import android.os.Handler
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
+import com.github.barriosnahuel.vossosunboton.commons.file.getFile
+import com.github.barriosnahuel.vossosunboton.model.Sound
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Long-form listen-session engine (Media3 ExoPlayer) : docs/adr/0022. Owns the lazily-created
+ * session [Player] for the listening surfaces (Vault immersive, recorder review) and reports
+ * through the SAME channels as the MediaPlayer engine — [PlayerControllerListener] for Sound
+ * targets, [playbackState] for Uri targets — so consumers render sessions identically.
+ *
+ * Sessions have NO cross-open position retention: starts are always from 0 (or the explicit
+ * [startUri] offset) and preemption is a definitive stop, never a pause. In-session pause/resume
+ * keeps the player's own head. [PlayerControllerImpl] is the only caller and enforces the
+ * one-active-playback invariant across both engines. Main-thread only, like the whole controller.
+ */
+internal class ListenSessionEngine(
+    private val playerProvider: (Context) -> Player,
+    private val handler: Handler,
+    private val listenerProvider: () -> PlayerControllerListener?,
+    private val playbackState: MutableStateFlow<PlaybackState?>,
+) {
+    private sealed class SessionTarget {
+        data class SoundTarget(
+            val sound: Sound,
+        ) : SessionTarget()
+
+        data class UriTarget(
+            val uri: Uri,
+        ) : SessionTarget()
+    }
+
+    private var player: Player? = null
+    private var target: SessionTarget? = null
+
+    /** Set by start calls; consumed by the first STATE_READY so re-buffers don't re-emit start events. */
+    private var startPending = false
+
+    val isActive: Boolean get() = target != null
+
+    /** [Sound.id] of the active session target, or null when idle / playing a Uri. */
+    val targetSoundId: String? get() = (target as? SessionTarget.SoundTarget)?.sound.let { it?.id }
+
+    private val progressRunnable =
+        object : Runnable {
+            override fun run() {
+                val p = player ?: return
+                if (p.isPlaying) {
+                    val position = p.currentPosition.toInt()
+                    listenerProvider()?.onProgressUpdate(position)
+                    playbackState.update { it?.copy(positionMs = position) }
+                    handler.postDelayed(this, PROGRESS_INTERVAL_MS)
+                }
+            }
+        }
+
+    private val playerListener =
+        object : Player.Listener {
+            override fun onPlaybackStateChanged(playbackState: Int) {
+                when (playbackState) {
+                    Player.STATE_READY -> onReady()
+                    Player.STATE_ENDED -> onEnded()
+                    else -> Unit
+                }
+            }
+
+            override fun onPlayerError(error: PlaybackException) {
+                this@ListenSessionEngine.onError(error)
+            }
+        }
+
+    /**
+     * Starts [sound] as a session. Fresh sessions always start from 0 (no saved-position lookup,
+     * ADR 0022); when [sound] is the current PAUSED session target this is the in-session play
+     * toggle and resumes in place. After natural completion the target is cleared, so a replay is
+     * a fresh from-0 start — never a MediaPlayer fallback.
+     */
+    fun startSound(
+        context: Context,
+        sound: Sound,
+    ) {
+        val current = target
+        if (current is SessionTarget.SoundTarget && current.sound.id == sound.id && player?.isPlaying == false) {
+            resume()
+            return
+        }
+        stop()
+        val uri =
+            if (sound.isBundled()) {
+                Uri.parse("android.resource://${context.packageName}/${sound.rawRes}")
+            } else {
+                Uri.fromFile(getFile(context, sound.file!!))
+            }
+        target = SessionTarget.SoundTarget(sound)
+        load(context, uri, startPositionMs = 0)
+    }
+
+    /** Starts [uri] as a session, honoring [startPositionMs] (recorder review's scrub offset). */
+    fun startUri(
+        context: Context,
+        uri: Uri,
+        startPositionMs: Int,
+    ) {
+        val current = target
+        if (current is SessionTarget.UriTarget && current.uri == uri && player?.isPlaying == false) {
+            // Same uri, paused → resume in place (mirrors startPlayingUri's resume shortcut).
+            resume()
+            return
+        }
+        stop()
+        target = SessionTarget.UriTarget(uri)
+        load(context, uri, startPositionMs)
+    }
+
+    private fun load(
+        context: Context,
+        uri: Uri,
+        startPositionMs: Int,
+    ) {
+        val p = obtainPlayer(context)
+        startPending = true
+        p.setMediaItem(MediaItem.fromUri(uri))
+        p.prepare()
+        if (startPositionMs > 0) p.seekTo(startPositionMs.toLong())
+        p.play()
+    }
+
+    /**
+     * Stops and clears the session, emitting the definitive stop for its target — preemption of a
+     * session is a stop, never a pause (no retention). No-op when idle.
+     */
+    fun stop() {
+        val t = target ?: return
+        handler.removeCallbacks(progressRunnable)
+        startPending = false
+        player?.let { runCatching { it.stop() } }
+        target = null
+        when (t) {
+            is SessionTarget.SoundTarget -> listenerProvider()?.onPlayerStop(t.sound, completed = false)
+            is SessionTarget.UriTarget -> playbackState.value = null
+        }
+    }
+
+    /**
+     * Pauses the session in place. Returns false when idle (caller falls through to MediaPlayer).
+     * Unconditional even mid-prepare — `Player.pause()` is just `playWhenReady = false`, so a tap
+     * that pauses before STATE_READY cancels the pending start instead of letting audio pop later
+     * (also consumes [startPending] so READY won't emit a stale start event).
+     */
+    fun pause(): Boolean {
+        val t = target ?: return false
+        val p = player
+        if (p != null) {
+            runCatching { p.pause() }
+            handler.removeCallbacks(progressRunnable)
+            startPending = false
+            val position = p.currentPosition.toInt()
+            when (t) {
+                is SessionTarget.SoundTarget ->
+                    listenerProvider()?.onPlayerPause(t.sound, positionMs = position, durationMs = p.durationMsOrZero())
+                is SessionTarget.UriTarget ->
+                    playbackState.update { it?.copy(positionMs = position, isPlaying = false) }
+            }
+        }
+        return true
+    }
+
+    /** Resumes the paused session in place, re-emitting the start event. Returns false when idle. */
+    fun resume(): Boolean {
+        val t = target ?: return false
+        val p = player
+        if (p != null && !p.isPlaying) {
+            p.play()
+            val position = p.currentPosition.toInt()
+            when (t) {
+                is SessionTarget.SoundTarget ->
+                    listenerProvider()?.onPlayerStart(t.sound, durationMs = p.durationMsOrZero(), positionMs = position)
+                is SessionTarget.UriTarget ->
+                    playbackState.update { it?.copy(positionMs = position, isPlaying = true) }
+            }
+            handler.post(progressRunnable)
+        }
+        return true
+    }
+
+    /** Moves the session head. Returns false when idle (caller falls through to MediaPlayer). */
+    fun seekTo(positionMs: Int): Boolean {
+        if (target == null) return false
+        player?.let { runCatching { it.seekTo(positionMs.toLong()) } }
+        playbackState.update { it?.copy(positionMs = positionMs) }
+        return true
+    }
+
+    private fun obtainPlayer(context: Context): Player =
+        player ?: playerProvider(context.applicationContext).also {
+            it.addListener(playerListener)
+            player = it
+        }
+
+    private fun onReady() {
+        if (!startPending) return
+        startPending = false
+        val p = player ?: return
+        val duration = p.durationMsOrZero()
+        val position = p.currentPosition.toInt()
+        when (val t = target) {
+            is SessionTarget.SoundTarget ->
+                listenerProvider()?.onPlayerStart(t.sound, durationMs = duration, positionMs = position)
+            is SessionTarget.UriTarget ->
+                playbackState.value = PlaybackState(uri = t.uri, positionMs = position, durationMs = duration, isPlaying = true)
+            null -> Unit
+        }
+        handler.post(progressRunnable)
+    }
+
+    private fun onEnded() {
+        handler.removeCallbacks(progressRunnable)
+        when (val t = target) {
+            is SessionTarget.SoundTarget -> listenerProvider()?.onPlayerStop(t.sound, completed = true)
+            is SessionTarget.UriTarget -> playbackState.value = null
+            null -> Unit
+        }
+        target = null
+    }
+
+    private fun onError(error: PlaybackException) {
+        handler.removeCallbacks(progressRunnable)
+        val t = target
+        target = null
+        startPending = false
+        when (t) {
+            is SessionTarget.SoundTarget -> {
+                Tracker.log("playback.sound=${t.sound.name}")
+                Tracker.track(RuntimeException("Listen session can't play audio", error))
+                listenerProvider()?.onPlayerError(t.sound)
+            }
+            is SessionTarget.UriTarget -> {
+                Tracker.log("playback.uri=${t.uri}")
+                Tracker.track(RuntimeException("Listen session can't play preview", error))
+                playbackState.value = null
+            }
+            null -> Unit
+        }
+    }
+
+    private fun Player.durationMsOrZero(): Int {
+        val d = duration
+        return if (d == C.TIME_UNSET) 0 else d.toInt()
+    }
+
+    private companion object {
+        private const val PROGRESS_INTERVAL_MS = 100L
+    }
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerController.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerController.kt
@@ -27,6 +27,7 @@ internal data class PlaybackState(
     val isPlaying: Boolean,
 )
 
+@Suppress("TooManyFunctions") // Single-facade contract by design (ADR 0005): every playback surface routes here.
 internal interface PlayerController {
     /**
      * Emits a non-null value while a Uri-bound (preview) playback is active. Consumers filter by
@@ -62,6 +63,33 @@ internal interface PlayerController {
      * continues from its own head and ignores this.
      */
     fun startPlayingUri(
+        context: Context,
+        uri: Uri,
+        startPositionMs: Int = 0,
+    )
+
+    /**
+     * Starts [sound] as a LISTEN SESSION on the long-form engine (Media3 ExoPlayer) — the Vault
+     * immersive surface. Fresh sessions ALWAYS start from 0: session sounds deliberately have no
+     * cross-open position retention, unlike [startPlayingSound]'s saved-position semantics
+     * (ADR 0022). When [sound] is the current paused session target this resumes in place — it is
+     * the immersive's play toggle, valid mid-clip and after natural completion alike. Any current
+     * playback on either engine is preempted ([startPlayingSound] targets pause with position; a
+     * previous session stops). Events flow through the same [PlayerControllerListener] as list
+     * playback, so consumers render sessions identically.
+     */
+    fun startListenSession(
+        context: Context,
+        sound: Sound,
+    )
+
+    /**
+     * Starts [uri] as a listen session on the long-form engine — the recorder-review surface.
+     * [startPositionMs] preserves review's resume-from-offset semantics (ADR 0022). Progress is
+     * reported via [playbackState] only, exactly like [startPlayingUri] (no Sound to pass to the
+     * listener).
+     */
+    fun startUriListenSession(
         context: Context,
         uri: Uri,
         startPositionMs: Int = 0,

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerImpl.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerImpl.kt
@@ -10,6 +10,8 @@ import android.media.MediaPlayer
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import kotlinx.coroutines.CoroutineDispatcher
@@ -30,6 +32,7 @@ internal class PlayerControllerImpl(
     private val mediaPlayer: MediaPlayer = MediaPlayer(),
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob()),
+    private val sessionPlayerProvider: (Context) -> Player = { ExoPlayer.Builder(it).build() },
 ) : PlayerController {
     private var listener: PlayerControllerListener? = null
 
@@ -86,6 +89,15 @@ internal class PlayerControllerImpl(
         context: Context,
         sound: Sound,
     ) {
+        if (session.targetSoundId == sound.id) {
+            // The immersive's play toggle routes here (same VM path as list rows): the sound is the
+            // paused session target → resume the session in place, don't load it on MediaPlayer.
+            prepareJob?.cancel()
+            session.resume()
+            return
+        }
+        session.stop()
+
         val currentTarget = target
         if (currentTarget is PlaybackTarget.SoundTarget && currentTarget.sound.id == sound.id && !mediaPlayer.isPlaying) {
             // Same sound, paused → resume in place. MediaPlayer kept the data source and the
@@ -168,6 +180,8 @@ internal class PlayerControllerImpl(
         uri: Uri,
         startPositionMs: Int,
     ) {
+        session.stop()
+
         val currentTarget = target
         if (currentTarget is PlaybackTarget.UriTarget && currentTarget.uri == uri && !mediaPlayer.isPlaying) {
             prepareJob?.cancel()
@@ -299,7 +313,54 @@ internal class PlayerControllerImpl(
             }
         }
 
+    // --- Long-form listen-session engine (Media3 ExoPlayer) : docs/adr/0022 ---
+
+    /**
+     * The second engine behind this facade. Mutually exclusive with [target]: every start path
+     * preempts the other engine first, keeping the ADR 0005 one-active-playback invariant across
+     * both engines.
+     */
+    private val session =
+        ListenSessionEngine(
+            playerProvider = sessionPlayerProvider,
+            handler = handler,
+            listenerProvider = { listener },
+            playbackState = _playbackState,
+        )
+
+    override fun startListenSession(
+        context: Context,
+        sound: Sound,
+    ) {
+        prepareJob?.cancel()
+        preemptMediaPlayerEngine()
+        session.startSound(context, sound)
+    }
+
+    override fun startUriListenSession(
+        context: Context,
+        uri: Uri,
+        startPositionMs: Int,
+    ) {
+        prepareJob?.cancel()
+        preemptMediaPlayerEngine()
+        session.startUri(context, uri, startPositionMs)
+    }
+
+    /**
+     * Pauses-with-position whatever the MediaPlayer engine has loaded and returns it to IDLE, so a
+     * session can start. The paused sound keeps its saved position (ADR 0007/0008) — returning to
+     * it from a list row resumes where it left off.
+     */
+    private fun preemptMediaPlayerEngine() {
+        if (target == null) return
+        preemptCurrentTargetPreservingPosition()
+        handler.removeCallbacks(progressRunnable)
+        mediaPlayer.reset()
+    }
+
     override fun stopPlayingSound() {
+        session.stop()
         val isPlayingNow = mediaPlayer.isPlaying
         val hasUriState = _playbackState.value != null
         val t = target
@@ -327,7 +388,7 @@ internal class PlayerControllerImpl(
 
     override fun pause() {
         val t = target
-        if (t == null || !mediaPlayer.isPlaying) return
+        if (session.pause() || t == null || !mediaPlayer.isPlaying) return
         val paused = runCatching { mediaPlayer.pause() }
         paused.onFailure { e ->
             if (e is IllegalStateException) {
@@ -351,10 +412,15 @@ internal class PlayerControllerImpl(
     }
 
     override fun resume() {
+        if (session.isActive) {
+            val uriBlocked = session.targetSoundId == null && (_playbackState.value?.isPlaying != false)
+            if (!uriBlocked) session.resume()
+            return
+        }
+
         val t = target
-        if (t == null || mediaPlayer.isPlaying) return
         val uriBlocked = t is PlaybackTarget.UriTarget && (_playbackState.value?.isPlaying != false)
-        if (uriBlocked) return
+        if (t == null || mediaPlayer.isPlaying || uriBlocked) return
         resumeCurrentTarget()
     }
 
@@ -393,6 +459,7 @@ internal class PlayerControllerImpl(
     }
 
     override fun seekTo(positionMs: Int) {
+        if (session.seekTo(positionMs)) return
         // Wrapped like every other MediaPlayer call here: a seek racing a stop/complete can land in an
         // invalid state and throw IllegalStateException — swallow + report rather than crash.
         runCatching { mediaPlayer.seekTo(positionMs) }
@@ -409,6 +476,9 @@ internal class PlayerControllerImpl(
     }
 
     override fun forgetSound(sound: Sound) {
+        if (session.targetSoundId == sound.id) {
+            session.stop()
+        }
         savedSoundPositions.remove(sound.id)
         val t = target
         if (t is PlaybackTarget.SoundTarget && t.sound.id == sound.id) {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
@@ -223,7 +223,8 @@ class RecordingActivity : FragmentActivity() {
             // Paused on this clip: the player head already holds the scrubbed position — resume from it.
             current != null && current.uri == uri -> controller.resume()
             // Fresh start (before first play / after completion): resume from the remembered scrub offset.
-            else -> controller.startPlayingUri(this, uri, startPositionMs)
+            // Long-form engine (ADR 0022): the review is a listening session, not a quick tap.
+            else -> controller.startUriListenSession(this, uri, startPositionMs)
         }
     }
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreen.kt
@@ -131,7 +131,16 @@ internal fun ImmersiveListenHost(
         isPlaying = isThisPlaying,
         progressFraction = fraction,
         peaks = peaks,
-        onPlayPause = { viewModel.playOrStop(sound.copy(isPlaying = isThisPlaying)) },
+        onPlayPause = {
+            // Pause keeps the shared toggle; play goes to the session API so a replay after natural
+            // completion stays on the long-form engine and starts from 0 (ADR 0022) — routing it
+            // through playOrStop would fall back to MediaPlayer once the session target cleared.
+            if (isThisPlaying) {
+                viewModel.playOrStop(sound.copy(isPlaying = true))
+            } else {
+                viewModel.startListenSession(sound)
+            }
+        },
         onRestart = { viewModel.seekTo(0, soundId) },
         onSeek = { f -> durationMs?.let { d -> seekTargetMs(d.toLong(), f)?.let { viewModel.seekTo(it, soundId) } } },
         onBack = onBack,

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -251,9 +251,10 @@ fun LandingScreen(viewModel: SoundsViewModel) {
             manageRequest = ManageRequest.Focused(collectionId)
         },
         onImmersivePlay = { sound ->
-            // Vault play opens immersive listen mode and starts playback (unless already playing).
+            // Vault play opens immersive listen mode and starts a listen session — always from 0 on
+            // the long-form engine (ADR 0022), unless the audio is already mid-session.
             immersiveListenSoundId = sound.id
-            if (!sound.isPlaying) viewModel.playOrStop(sound)
+            if (!sound.isPlaying) viewModel.startListenSession(sound)
         },
         onCreateClick = openHub,
         // One source-parameterized entry point (mirrors onCreateClick): each surface binds its own
@@ -274,16 +275,15 @@ fun LandingScreen(viewModel: SoundsViewModel) {
     }
 
     // Immersive listen mode for a Vault audio — layers above everything (it covers the top bar, so
-    // About/Manage are unreachable while it is open). Back pauses playback (position retained) so no
-    // audio keeps playing headless behind the Vault list, then closes the overlay.
+    // About/Manage are unreachable while it is open). Back STOPS playback definitively (sessions have
+    // no cross-open retention — ADR 0022) so no audio keeps playing headless behind the Vault list,
+    // then closes the overlay.
     immersiveListenSoundId?.let { listeningId ->
         com.github.barriosnahuel.vossosunboton.feature.vault.ImmersiveListenHost(
             viewModel = viewModel,
             soundId = listeningId,
             onBack = {
-                viewModel.playingSound.value
-                    ?.takeIf { it.id == listeningId }
-                    ?.let { viewModel.playOrStop(it) }
+                viewModel.stopPlayback()
                 immersiveListenSoundId = null
             },
         )

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -844,6 +844,28 @@ class SoundsViewModel(
         }
     }
 
+    /**
+     * Starts [sound] as an immersive listen session on the long-form engine — always from 0, no
+     * cross-open position retention (ADR 0022). Same play analytics as a list tap; playback events
+     * arrive through the same [PlayerControllerListener] callbacks, so the UI state
+     * ([playingSound], [playbackProgress], [pausedProgress]) works unchanged. In-session toggles
+     * keep routing through [playOrStop] — the controller resolves the engine.
+     */
+    fun startListenSession(sound: Sound) {
+        PlayerControllerFactory.instance.startListenSession(getApplication(), sound)
+        tracker.log(AnalyticsEvent.SoundPlay(surface = currentSurface))
+        val newCount = tracker.incrementCounter(AnalyticsUserProperty.LIFETIME_PLAYS)
+        tracker.setUserProperty(AnalyticsUserProperty.LIFETIME_PLAYS, newCount.toString())
+    }
+
+    /**
+     * Definitive stop of whatever is playing on either engine (position discarded). The immersive's
+     * back gesture uses this — a session must not survive its surface (ADR 0022: no retention).
+     */
+    fun stopPlayback() {
+        PlayerControllerFactory.instance.stopPlayingSound()
+    }
+
     fun seekTo(positionMs: Int) {
         PlayerControllerFactory.instance.seekTo(positionMs)
         _playbackProgress.update { it?.copy(positionMs = positionMs) }

--- a/app/src/main/res/raw/app_third_party_notices.txt
+++ b/app/src/main/res/raw/app_third_party_notices.txt
@@ -40,6 +40,13 @@ https://developer.android.com/jetpack/androidx/releases/biometric
 --------------------------------------------------------------------------------
 
 --------------------------------------------------------------------------------
+AndroidX Media3 (ExoPlayer)
+Copyright (C) The Android Open Source Project
+Apache License, Version 2.0
+https://developer.android.com/jetpack/androidx/releases/media3
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
 Firebase Android SDK (Analytics, Crashlytics, Performance)
 Copyright (C) Google LLC
 Apache License, Version 2.0 (plus Firebase ToS)

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerListenSessionTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerListenSessionTest.kt
@@ -1,0 +1,392 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.playback
+
+import android.content.Context
+import android.media.MediaPlayer
+import android.net.Uri
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
+import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.google.common.truth.Truth.assertThat
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import io.mockk.verifyOrder
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.After
+import org.junit.Test
+
+/**
+ * Routing contract of the long-form listen-session engine (ADR 0022): sessions run on the injected
+ * Media3 [Player], list/preview playback stays on [MediaPlayer], and the ADR 0005 one-active-playback
+ * invariant holds across both engines. The real ExoPlayer path is covered by the instrumented suite;
+ * these tests pin the controller's routing with a scripted fake.
+ */
+internal class PlayerControllerListenSessionTest : AbstractRobolectricTest() {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val playerListener = slot<Player.Listener>()
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `startListenSession loads prepares and plays on the session player without seeking`() {
+        val player = givenAnIdleSessionPlayer()
+        val controller = controllerForTest(player = player)
+
+        controller.startListenSession(context, customSound())
+
+        verifyOrder {
+            player.setMediaItem(any())
+            player.prepare()
+            player.play()
+        }
+        verify(exactly = 0) { player.seekTo(any()) }
+    }
+
+    @Test
+    fun `session ready emits onPlayerStart with the player duration`() {
+        val player = givenAnIdleSessionPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        val controller = controllerForTest(player = player)
+        controller.setOnStartStopListener(listener)
+        val sound = customSound()
+
+        controller.startListenSession(context, sound)
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_READY)
+
+        verify { listener.onPlayerStart(sound, durationMs = 10_000, positionMs = 0) }
+    }
+
+    @Test
+    fun `a re-buffer after the first ready does not re-emit onPlayerStart`() {
+        val player = givenAnIdleSessionPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        val controller = controllerForTest(player = player)
+        controller.setOnStartStopListener(listener)
+
+        controller.startListenSession(context, customSound())
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_READY)
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_BUFFERING)
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_READY)
+
+        verify(exactly = 1) { listener.onPlayerStart(any(), any(), any()) }
+    }
+
+    @Test
+    fun `startListenSession preempts a playing row sound pausing it with position`() {
+        val mp = givenAMediaPlayerPlaying(positionMs = 1_234)
+        val player = givenAnIdleSessionPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        val controller = controllerForTest(mp = mp, player = player)
+        controller.setOnStartStopListener(listener)
+        val rowSound = bundledSound("row")
+        controller.startPlayingSound(context, rowSound)
+
+        controller.startListenSession(context, customSound())
+
+        verify { listener.onPlayerPause(match { it.id == rowSound.id }, positionMs = 1_234, durationMs = 10_000) }
+        verify { mp.reset() }
+    }
+
+    @Test
+    fun `starting a row sound stops an active session definitively`() {
+        val mp = givenAnIdleMediaPlayer()
+        val player = givenAnIdleSessionPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        val controller = controllerForTest(mp = mp, player = player)
+        controller.setOnStartStopListener(listener)
+        val sessionSound = customSound()
+        controller.startListenSession(context, sessionSound)
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_READY)
+
+        controller.startPlayingSound(context, bundledSound("row"))
+
+        verify { player.stop() }
+        verify { listener.onPlayerStop(match { it.id == sessionSound.id }, completed = false) }
+    }
+
+    @Test
+    fun `pause routes to the session engine and reports a positional pause`() {
+        val mp = givenAnIdleMediaPlayer()
+        val player = givenAnIdleSessionPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        val controller = controllerForTest(mp = mp, player = player)
+        controller.setOnStartStopListener(listener)
+        val sound = customSound()
+        controller.startListenSession(context, sound)
+        every { player.isPlaying } returns true
+        every { player.currentPosition } returns 2_500L
+
+        controller.pause()
+
+        verify { player.pause() }
+        verify { listener.onPlayerPause(match { it.id == sound.id }, positionMs = 2_500, durationMs = 10_000) }
+        verify(exactly = 0) { mp.pause() }
+    }
+
+    @Test
+    fun `startPlayingSound of the paused session target resumes the session in place`() {
+        val mp = givenAnIdleMediaPlayer()
+        val player = givenAnIdleSessionPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        val controller = controllerForTest(mp = mp, player = player)
+        controller.setOnStartStopListener(listener)
+        val sound = customSound()
+        controller.startListenSession(context, sound)
+        every { player.isPlaying } returns false
+        every { player.currentPosition } returns 2_500L
+
+        controller.startPlayingSound(context, sound.copy(isPlaying = false))
+
+        verify { player.play() }
+        verify { listener.onPlayerStart(match { it.id == sound.id }, durationMs = 10_000, positionMs = 2_500) }
+        verify(exactly = 0) { mp.prepare() }
+    }
+
+    @Test
+    fun `session natural completion emits onPlayerStop completed true`() {
+        val player = givenAnIdleSessionPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        val controller = controllerForTest(player = player)
+        controller.setOnStartStopListener(listener)
+        val sound = customSound()
+        controller.startListenSession(context, sound)
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_READY)
+
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_ENDED)
+
+        verify { listener.onPlayerStop(match { it.id == sound.id }, completed = true) }
+    }
+
+    @Test
+    fun `seekTo routes to the session player while a session is active`() {
+        val mp = givenAnIdleMediaPlayer()
+        val player = givenAnIdleSessionPlayer()
+        val controller = controllerForTest(mp = mp, player = player)
+        controller.startListenSession(context, customSound())
+
+        controller.seekTo(7_000)
+
+        verify { player.seekTo(7_000L) }
+        verify(exactly = 0) { mp.seekTo(any()) }
+    }
+
+    @Test
+    fun `stopPlayingSound stops the session and emits a definitive stop`() {
+        val player = givenAnIdleSessionPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        val controller = controllerForTest(player = player)
+        controller.setOnStartStopListener(listener)
+        val sound = customSound()
+        controller.startListenSession(context, sound)
+
+        controller.stopPlayingSound()
+
+        verify { player.stop() }
+        verify { listener.onPlayerStop(match { it.id == sound.id }, completed = false) }
+    }
+
+    @Test
+    fun `forgetSound of the session sound stops the session`() {
+        val player = givenAnIdleSessionPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        val controller = controllerForTest(player = player)
+        controller.setOnStartStopListener(listener)
+        val sound = customSound()
+        controller.startListenSession(context, sound)
+
+        controller.forgetSound(sound)
+
+        verify { player.stop() }
+        verify { listener.onPlayerStop(match { it.id == sound.id }, completed = false) }
+    }
+
+    @Test
+    fun `uri session honors startPositionMs and feeds playbackState on ready`() {
+        val player = givenAnIdleSessionPlayer()
+        val controller = controllerForTest(player = player)
+        val uri = Uri.parse("file:///tmp/review.m4a")
+
+        controller.startUriListenSession(context, uri, startPositionMs = 500)
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_READY)
+
+        verify { player.seekTo(500L) }
+        val state = controller.playbackState.value
+        assertThat(state).isNotNull()
+        assertThat(state!!.uri).isEqualTo(uri)
+        assertThat(state.durationMs).isEqualTo(10_000)
+        assertThat(state.isPlaying).isTrue()
+    }
+
+    @Test
+    fun `starting a preview uri on the media player stops an active session`() {
+        val mp = givenAnIdleMediaPlayer()
+        val player = givenAnIdleSessionPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        val controller = controllerForTest(mp = mp, player = player)
+        controller.setOnStartStopListener(listener)
+        val sessionSound = customSound()
+        controller.startListenSession(context, sessionSound)
+
+        controller.startPlayingUri(context, Uri.parse("file:///tmp/preview.mp3"))
+
+        verify { player.stop() }
+        verify { listener.onPlayerStop(match { it.id == sessionSound.id }, completed = false) }
+    }
+
+    @Test
+    fun `session error reports through the listener and clears the session`() {
+        val player = givenAnIdleSessionPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        val controller = controllerForTest(player = player)
+        controller.setOnStartStopListener(listener)
+        val sound = customSound()
+        controller.startListenSession(context, sound)
+
+        playerListener.captured.onPlayerError(
+            PlaybackException("boom", null, PlaybackException.ERROR_CODE_UNSPECIFIED),
+        )
+
+        verify { listener.onPlayerError(match { it.id == sound.id }) }
+        verify { Tracker.track(any()) }
+        // A follow-up seek must fall through to the MediaPlayer path — the session is gone.
+        controller.seekTo(100)
+        verify(exactly = 0) { player.seekTo(100L) }
+    }
+
+    @Test
+    fun `replay after natural completion starts a fresh session not a MediaPlayer fallback`() {
+        val mp = givenAnIdleMediaPlayer()
+        val player = givenAnIdleSessionPlayer()
+        val controller = controllerForTest(mp = mp, player = player)
+        val sound = customSound()
+        controller.startListenSession(context, sound)
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_READY)
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_ENDED)
+
+        controller.startListenSession(context, sound)
+
+        verify(exactly = 2) { player.prepare() }
+        verify(exactly = 0) { player.seekTo(any()) }
+        verify(exactly = 0) { mp.prepare() }
+    }
+
+    @Test
+    fun `resume routes to the paused session`() {
+        val mp = givenAnIdleMediaPlayer()
+        val player = givenAnIdleSessionPlayer()
+        val controller = controllerForTest(mp = mp, player = player)
+        val sound = customSound()
+        controller.startListenSession(context, sound)
+        every { player.isPlaying } returns false
+
+        controller.resume()
+
+        verify { player.play() }
+        verify(exactly = 0) { mp.start() }
+    }
+
+    @Test
+    fun `starting a second sound session preempts the first with a definitive stop`() {
+        val player = givenAnIdleSessionPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        val controller = controllerForTest(player = player)
+        controller.setOnStartStopListener(listener)
+        val first = customSound()
+        controller.startListenSession(context, first)
+
+        controller.startListenSession(context, Sound("other-id", "other audio", "other.mp3"))
+
+        verify { listener.onPlayerStop(match { it.id == first.id }, completed = false) }
+    }
+
+    @Test
+    fun `forgetSound of a non-session sound does not stop the active session`() {
+        val player = givenAnIdleSessionPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        val controller = controllerForTest(player = player)
+        controller.setOnStartStopListener(listener)
+        controller.startListenSession(context, customSound())
+
+        controller.forgetSound(bundledSound("unrelated"))
+
+        verify(exactly = 0) { player.stop() }
+        verify(exactly = 0) { listener.onPlayerStop(any(), any()) }
+    }
+
+    @Test
+    fun `pause before ready cancels the pending start so ready emits no start event`() {
+        val player = givenAnIdleSessionPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        val controller = controllerForTest(player = player)
+        controller.setOnStartStopListener(listener)
+        controller.startListenSession(context, customSound())
+
+        controller.pause()
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_READY)
+
+        verify { player.pause() }
+        verify(exactly = 0) { listener.onPlayerStart(any(), any(), any()) }
+    }
+
+    private fun customSound(): Sound = Sound("custom-id", "custom audio", "custom.mp3")
+
+    private fun bundledSound(name: String): Sound = Sound(name, rawRes = 1)
+
+    private fun givenAnIdleSessionPlayer(): Player {
+        val player = mockk<Player>(relaxed = true)
+        every { player.addListener(capture(playerListener)) } just Runs
+        every { player.isPlaying } returns false
+        every { player.currentPosition } returns 0L
+        every { player.duration } returns 10_000L
+        return player
+    }
+
+    private fun givenAnIdleMediaPlayer(): MediaPlayer {
+        val mp = mockk<MediaPlayer>(relaxed = true)
+        every { mp.isPlaying } returns false
+        return mp
+    }
+
+    private fun givenAMediaPlayerPlaying(positionMs: Int): MediaPlayer {
+        val mp = mockk<MediaPlayer>(relaxed = true)
+        every { mp.isPlaying } returns true
+        every { mp.currentPosition } returns positionMs
+        every { mp.duration } returns 10_000
+        mockkStatic(MediaPlayerHelper::class)
+        every { MediaPlayerHelper.setupSoundSource(any(), any(), any<Int>()) } returns true
+        return mp
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun controllerForTest(
+        mp: MediaPlayer = givenAnIdleMediaPlayer(),
+        player: Player,
+    ): PlayerControllerImpl {
+        val dispatcher = UnconfinedTestDispatcher()
+        return PlayerControllerImpl(
+            mediaPlayer = mp,
+            ioDispatcher = dispatcher,
+            scope = CoroutineScope(dispatcher + SupervisorJob()),
+            sessionPlayerProvider = { player },
+        )
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/about/CreditEntryTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/about/CreditEntryTest.kt
@@ -13,14 +13,14 @@ import org.junit.Test
 
 internal class CreditEntryTest : AbstractRobolectricTest() {
     @Test
-    fun `parseCreditEntries returns 10 entries for the bundled notices file`() {
+    fun `parseCreditEntries returns 11 entries for the bundled notices file`() {
         val context = ApplicationProvider.getApplicationContext<android.content.Context>()
         val text =
             context.resources
                 .openRawResource(R.raw.app_third_party_notices)
                 .bufferedReader()
                 .use { it.readText() }
-        assertThat(parseCreditEntries(text)).hasSize(10)
+        assertThat(parseCreditEntries(text)).hasSize(11)
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ appcompat                 = "1.7.1"
 annotation                = "1.10.0"
 activityCompose           = "1.13.0"
 coreSplashscreen          = "1.2.0"
+media3                    = "1.10.1"
 composeBom                = "2026.06.01"
 lifecycleCompose          = "2.11.0"
 material                  = "1.14.0"
@@ -59,6 +60,7 @@ androidx-appcompat                = { module = "androidx.appcompat:appcompat",  
 androidx-annotation               = { module = "androidx.annotation:annotation",     version.ref = "annotation" }
 androidx-activity-compose         = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
 androidx-core-splashscreen        = { module = "androidx.core:core-splashscreen",     version.ref = "coreSplashscreen" }
+androidx-media3-exoplayer         = { module = "androidx.media3:media3-exoplayer",    version.ref = "media3" }
 
 # ---------- Compose BOM + components (no version — resolved by BOM) ----------
 compose-bom                       = { module = "androidx.compose:compose-bom",                       version.ref = "composeBom" }

--- a/scripts/check-adr-invariants.sh
+++ b/scripts/check-adr-invariants.sh
@@ -80,6 +80,24 @@ Route through PlayerController.startPlayingUri / startPlayingSound, or supersede
 fi
 
 # ============================================================================
+# ADR 0022 — docs/adr/0022-hybrid-playback-engines-media3.md
+# Invariant: the only ExoPlayer construction in src/main lives inside
+# feature/playback/PlayerControllerImpl.kt (the session engine receives it via
+# provider). New listening surfaces must route through PlayerController's
+# listen-session APIs, not build their own player.
+# ============================================================================
+ALLOWED_EXOPLAYER="app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerImpl.kt"
+unexpected_exoplayer=$(
+    grep -rlE --include="*.kt" 'ExoPlayer\s*\.\s*Builder' $MAIN_DIRS 2>/dev/null \
+        | grep -vxF "$ALLOWED_EXOPLAYER" || true
+)
+if [ -n "$unexpected_exoplayer" ]; then
+    fail "ADR 0022 broken: ExoPlayer.Builder outside PlayerControllerImpl.kt:
+$unexpected_exoplayer
+Route through PlayerController.startListenSession / startUriListenSession, or supersede ADR 0022."
+fi
+
+# ============================================================================
 # ADR 0006 — docs/adr/0006-no-kotlin-assert-in-tests.md
 # Invariant: no bare kotlin.assert(...) in any test sourceset. The JVM only
 # evaluates the condition under -ea, so a misused assert silently no-ops on


### PR DESCRIPTION
### Summary

1. User opens the Vault and taps play on an audio — the immersive listen screen opens
2. Listens partway through and goes back
3. Taps play on the same audio again

**before:** it silently resumed mid-clip from wherever it was left — a surprise the owner explicitly chose to drop.
**after:** the immersive always starts from the beginning; under the hood both listening surfaces (Vault immersive + recorder review) now play on the modern Media3 engine, while the botonera tap keeps its measured-fast current engine (80 ms — ADR 0022).

### Technical detail

Implements ADR 0022's surface→engine map behind the unchanged `PlayerController` facade:

- **`ListenSessionEngine` (new)** — owns a lazy ExoPlayer for sessions; reports through the SAME listener/StateFlow channels, so `SoundsViewModel` and every consumer render sessions identically. No cross-open retention: preemption is a stop, never a pause.
- **`PlayerController`** — two new APIs (`startListenSession`, `startUriListenSession`); every start path preempts the other engine synchronously, keeping ADR 0005's one-active-playback invariant cross-engine.
- **Routing** — `LandingScreen` immersive play/back rewired (play toggles route plays to the session API so a post-completion replay can't fall back to MediaPlayer — self-review catch, regression-tested); `RecordingActivity` fresh start moved to the session API (resume-from-offset preserved).
- **Guards** — `check-adr-invariants.sh` gains the ADR 0022 ExoPlayer-constructor fence; StrictMode debug allowlist entry for Media3's greylist hits (reproduced on device).
- **Deps** — `media3-exoplayer` 1.10.1 + third-party notices + `CreditEntryTest` 10→11.
- **Unchanged on purpose:** `MediaPlayer` tap path bit-for-bit (all its existing tests untouched and green); `MediaSession` and `media3-session` deliberately deferred to 002d.

### Code review tips

- **Stacked on #1265** (ADR 0022) — repo rule: ADR lands before the code that implements it. Merge #1265 first.
- **After #1264 merges:** this branch needs `CreditEntryTest` bumped 11→12 (both branches add one notices entry; the identical-line merge would auto-resolve with the wrong count and fail post-merge — flagging because CI can't).
- The cross-engine preemption seam is the highest-blast-radius spot: 19 routing unit tests pin it with a scripted fake Player; the real ExoPlayer path runs in the instrumented `VaultImmersiveListenTest`.
- Known minor edge (noted, not fixed): resuming during a session re-buffer can freeze the progress bar until the next event.
- ExoPlayer is created lazily and never released (MediaPlayer-singleton precedent; keeps its playback thread for the process).

### Already tested

- [x] Instrumented suite: run locally on final code, 127/127 green (includes `VaultImmersiveListenTest` exercising the new engine end-to-end)
- [x] Playback routing unit suite: 19/19 green (new `PlayerControllerListenSessionTest`)