### PR TITLE
refactor(addbutton): audio duration via Media3 MetadataRetriever (ADR 0022 / 002e)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog][]. Through v2.3.0 this project used [S
 #### Added
 - ADR 0022 decides the playback architecture for the Media3 migration: measured hybrid — MediaPlayer stays on the tap path (80 ms vs ExoPlayer's 390 ms on device, AEP exception documented), Media3 + MediaSession take the listening sessions (Vault immersive, recorder review)
 - Long-form playback engine (`ListenSessionEngine`, Media3 ExoPlayer 1.10.1) behind the same `PlayerController` facade: Vault immersive listen and recorder review now play on it, reporting through the existing listener/StateFlow channels; list-row taps and add-flow previews stay on MediaPlayer (ADR 0022)
+- Audio duration extraction (import + add-preview) moved from the AEP-prohibited `MediaMetadataRetriever` to Media3's `MetadataRetriever` (`media3-inspector`), keeping the same failure UX and Crashlytics grouping (ADR 0022 / spec 002e)
 
 ## \[v2.3.0] - 2026-06-28
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -167,6 +167,7 @@ dependencies {
     implementation libs.androidx.activity.compose
     implementation libs.androidx.core.splashscreen
     implementation libs.androidx.media3.exoplayer
+    implementation libs.androidx.media3.inspector
     implementation libs.lifecycle.viewmodel.compose
     implementation libs.lifecycle.runtime.compose
     implementation libs.coroutines.android

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonPreviewFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonPreviewFlowTest.kt
@@ -39,7 +39,7 @@ internal class AddButtonPreviewFlowTest : AbstractUiTest() {
         ActivityScenario.launch<AddButtonActivity>(launchIntent(TestData.seedPreviewAudio(context))).use {
             // The IconButton's contentDescription is the same string in play and pause states
             // (the icon swaps; the a11y label stays "Preview audio"). Awaiting it confirms the
-            // Card mounted, which only happens after MediaMetadataRetriever resolves durationMs > 0.
+            // Card mounted, which only happens after Media3 metadata extraction resolves durationMs > 0.
             composeRule.awaitNodeWithContentDescription(previewLabel()).assertIsDisplayed()
             // Slider exists alongside the play button — independent confirmation of the Card layout.
             composeRule.awaitNode(sliderMatcher).assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonPreviewRecreateTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonPreviewRecreateTest.kt
@@ -78,7 +78,7 @@ internal class AddButtonPreviewRecreateTest : AbstractUiTest() {
     @Test
     fun audioPreviewCardReRendersAfterRecreate() {
         ActivityScenario.launch<AddButtonActivity>(launchIntent(TestData.seedPreviewAudio(context))).use { scenario ->
-            // Pre-recreate: card mounts after MediaMetadataRetriever resolves the duration.
+            // Pre-recreate: card mounts after Media3 metadata extraction resolves the duration.
             composeRule.awaitNodeWithContentDescription(previewLabel()).assertIsDisplayed()
             composeRule.awaitNode(sliderMatcher).assertIsDisplayed()
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
@@ -18,6 +18,7 @@ import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.model.SoundSource
 import com.github.barriosnahuel.vossosunboton.model.data.manager.CollectionsRepository
 import com.github.barriosnahuel.vossosunboton.model.data.manager.SoundsRepository
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
@@ -131,14 +132,15 @@ private class AddButtonFeatureImpl : AddButtonFeature {
     }
 
     /** Best-effort duration probe of the just-copied file; a failure is non-fatal (the audio saves). */
-    private fun extractDurationMs(
+    private suspend fun extractDurationMs(
         context: Context,
         file: File,
         fileName: String,
     ): Int? =
         runCatching {
-            readDurationMsBlocking(context, Uri.fromFile(file))
+            readDurationMs(context, Uri.fromFile(file))
         }.onFailure {
+            if (it is CancellationException) throw it
             Tracker.log("addbutton.fileName=$fileName")
             Tracker.track(RuntimeException("Failed to extract duration metadata", it))
         }.getOrNull()

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonFeature.kt
@@ -7,7 +7,6 @@ package com.github.barriosnahuel.vossosunboton.feature.addbutton
 
 import android.content.ContentResolver
 import android.content.Context
-import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.provider.OpenableColumns
 import com.github.barriosnahuel.vossosunboton.R
@@ -99,7 +98,7 @@ private class AddButtonFeatureImpl : AddButtonFeature {
                             copy(inputStream, fileOutputStream)
                             val repo = SoundsRepository(context)
                             repo.save(Sound(id, name, fileName).copy(source = source))
-                            extractDurationMs(targetFile, fileName)?.let { repo.saveDuration(id, name, it) }
+                            extractDurationMs(context, targetFile, fileName)?.let { repo.saveDuration(id, name, it) }
                             // Apply collection tags now so the audio shows up in the right place
                             // immediately. Failures don't roll back the save (the audio still
                             // exists, just untagged) but ARE reported as non-fatal so we can spot
@@ -133,17 +132,12 @@ private class AddButtonFeatureImpl : AddButtonFeature {
 
     /** Best-effort duration probe of the just-copied file; a failure is non-fatal (the audio saves). */
     private fun extractDurationMs(
+        context: Context,
         file: File,
         fileName: String,
     ): Int? =
         runCatching {
-            val retriever = MediaMetadataRetriever()
-            try {
-                retriever.setDataSource(file.absolutePath)
-                retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)?.toInt()
-            } finally {
-                retriever.release()
-            }
+            readDurationMsBlocking(context, Uri.fromFile(file))
         }.onFailure {
             Tracker.log("addbutton.fileName=$fileName")
             Tracker.track(RuntimeException("Failed to extract duration metadata", it))

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AudioPreview.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AudioPreview.kt
@@ -50,6 +50,7 @@ import com.github.barriosnahuel.vossosunboton.ui.home.formatDuration
 import com.github.barriosnahuel.vossosunboton.ui.home.formatRelativeDate
 import com.github.barriosnahuel.vossosunboton.ui.theme.DISABLED_TRACK_ALPHA
 import com.github.barriosnahuel.vossosunboton.ui.theme.PLAYING_TINT_ALPHA
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -86,8 +87,10 @@ internal fun AudioPreview(
         durationMs =
             withContext(Dispatchers.IO) {
                 runCatching {
-                    readDurationMsBlocking(context, source)
+                    readDurationMs(context, source)
                 }.onFailure {
+                    // A disposed preview cancels the extraction — propagate, don't report it as a failure.
+                    if (it is CancellationException) throw it
                     Tracker.log("addbutton.preview.uri=$source")
                     Tracker.track(RuntimeException("Failed to extract duration metadata", it))
                 }.getOrDefault(0)

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AudioPreview.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AudioPreview.kt
@@ -5,7 +5,6 @@
  */
 package com.github.barriosnahuel.vossosunboton.feature.addbutton
 import android.content.Context
-import android.media.MediaMetadataRetriever
 import android.net.Uri
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -80,20 +79,14 @@ internal fun AudioPreview(
     var durationMs by remember(source) { mutableStateOf(0) }
 
     LaunchedEffect(source) {
-        // MediaMetadataRetriever runs off-thread to avoid blocking the main looper. Failure leaves
+        // Metadata extraction runs off-thread to avoid blocking the main looper. Failure leaves
         // durationMs at 0 which keeps the Card hidden — same UX as a player that can't prepare.
         // Mirrors AddButtonFeature's canonical pattern (same wrapper message so both call-sites
         // group under one Crashlytics issue; the breadcrumb disambiguates the path).
         durationMs =
             withContext(Dispatchers.IO) {
                 runCatching {
-                    val retriever = MediaMetadataRetriever()
-                    try {
-                        retriever.setDataSource(context, source)
-                        retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)?.toInt() ?: 0
-                    } finally {
-                        retriever.release()
-                    }
+                    readDurationMsBlocking(context, source)
                 }.onFailure {
                     Tracker.log("addbutton.preview.uri=$source")
                     Tracker.track(RuntimeException("Failed to extract duration metadata", it))

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/DurationMetadata.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/DurationMetadata.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.addbutton
+
+import android.content.Context
+import android.net.Uri
+import androidx.annotation.OptIn
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.inspector.MetadataRetriever
+import java.util.concurrent.TimeUnit
+
+/**
+ * Duration of [uri]'s audio via Media3's MetadataRetriever — the ADR 0022 replacement for the
+ * AEP-prohibited [android.media.MediaMetadataRetriever]. Blocking, bounded by
+ * [METADATA_TIMEOUT_SECONDS]: call on an IO dispatcher. Throws on unreadable or duration-less
+ * sources — callers keep their per-site `runCatching` + Tracker shells so Crashlytics grouping
+ * (one shared wrapper title) and per-path breadcrumbs stay exactly as they are.
+ */
+@OptIn(UnstableApi::class) // media3-inspector's MetadataRetriever is the documented replacement; API surface still @UnstableApi.
+internal fun readDurationMsBlocking(
+    context: Context,
+    uri: Uri,
+): Int =
+    MetadataRetriever.Builder(context, MediaItem.fromUri(uri)).build().use { retriever ->
+        val durationUs = retriever.retrieveDurationUs().get(METADATA_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        check(durationUs != C.TIME_UNSET) { "Source reports no duration" }
+        (durationUs / MICROS_PER_MS).toInt()
+    }
+
+private const val METADATA_TIMEOUT_SECONDS = 10L
+private const val MICROS_PER_MS = 1_000L

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/DurationMetadata.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/DurationMetadata.kt
@@ -12,24 +12,29 @@ import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.inspector.MetadataRetriever
+import kotlinx.coroutines.runInterruptible
 import java.util.concurrent.TimeUnit
 
 /**
  * Duration of [uri]'s audio via Media3's MetadataRetriever — the ADR 0022 replacement for the
- * AEP-prohibited [android.media.MediaMetadataRetriever]. Blocking, bounded by
- * [METADATA_TIMEOUT_SECONDS]: call on an IO dispatcher. Throws on unreadable or duration-less
- * sources — callers keep their per-site `runCatching` + Tracker shells so Crashlytics grouping
- * (one shared wrapper title) and per-path breadcrumbs stay exactly as they are.
+ * AEP-prohibited [android.media.MediaMetadataRetriever]. Call from an IO dispatcher (blocks up to
+ * [METADATA_TIMEOUT_SECONDS]); cancellation-cooperative via [runInterruptible], so a disposed
+ * preview interrupts the wait instead of leaking a blocked thread (and a late Tracker call) past
+ * its scope. Throws on unreadable or duration-less sources — callers keep their per-site
+ * `runCatching` + Tracker shells (rethrowing CancellationException) so Crashlytics grouping and
+ * per-path breadcrumbs stay exactly as they are.
  */
 @OptIn(UnstableApi::class) // media3-inspector's MetadataRetriever is the documented replacement; API surface still @UnstableApi.
-internal fun readDurationMsBlocking(
+internal suspend fun readDurationMs(
     context: Context,
     uri: Uri,
 ): Int =
-    MetadataRetriever.Builder(context, MediaItem.fromUri(uri)).build().use { retriever ->
-        val durationUs = retriever.retrieveDurationUs().get(METADATA_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-        check(durationUs != C.TIME_UNSET) { "Source reports no duration" }
-        (durationUs / MICROS_PER_MS).toInt()
+    runInterruptible {
+        MetadataRetriever.Builder(context, MediaItem.fromUri(uri)).build().use { retriever ->
+            val durationUs = retriever.retrieveDurationUs().get(METADATA_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            check(durationUs != C.TIME_UNSET) { "Source reports no duration" }
+            (durationUs / MICROS_PER_MS).toInt()
+        }
     }
 
 private const val METADATA_TIMEOUT_SECONDS = 10L

--- a/app/src/main/res/raw/app_third_party_notices.txt
+++ b/app/src/main/res/raw/app_third_party_notices.txt
@@ -40,7 +40,7 @@ https://developer.android.com/jetpack/androidx/releases/biometric
 --------------------------------------------------------------------------------
 
 --------------------------------------------------------------------------------
-AndroidX Media3 (ExoPlayer)
+AndroidX Media3 (ExoPlayer, Inspector)
 Copyright (C) The Android Open Source Project
 Apache License, Version 2.0
 https://developer.android.com/jetpack/androidx/releases/media3

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,6 +61,7 @@ androidx-annotation               = { module = "androidx.annotation:annotation",
 androidx-activity-compose         = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
 androidx-core-splashscreen        = { module = "androidx.core:core-splashscreen",     version.ref = "coreSplashscreen" }
 androidx-media3-exoplayer         = { module = "androidx.media3:media3-exoplayer",    version.ref = "media3" }
+androidx-media3-inspector         = { module = "androidx.media3:media3-inspector",    version.ref = "media3" }
 
 # ---------- Compose BOM + components (no version — resolved by BOM) ----------
 compose-bom                       = { module = "androidx.compose:compose-bom",                       version.ref = "composeBom" }


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change.

Kills the second of the four AEP-prohibited media APIs (`MediaMetadataRetriever`) with zero UX cost: import and add-preview keep showing the same durations, failures keep the same feedback. Completes spec 002e of the Media3 epic.

### Technical detail

Duration extraction (import + add-preview) moves to Media3's `MetadataRetriever`:

- **`DurationMetadata.kt` (new)** — shared blocking helper (`media3-inspector`, 10 s bound, IO-dispatcher only; the retriever runs its own internal HandlerThread, verified against the library bytecode). Throws on unreadable/duration-less sources.
- **`AddButtonFeature` / `AudioPreview`** — swap the retriever inside their existing `runCatching` + `Tracker` shells: same shared Crashlytics title, same per-path breadcrumbs, same null/0 fallbacks.
- **Deps** — `media3-inspector` 1.10.1 (same version ref as exoplayer); notices entry amended (`media3-exoplayer`'s `MetadataRetriever` is deprecated in 1.10 — inspector is the documented home, still `@UnstableApi`, opted-in explicitly).
- **Unchanged:** `MediaRecorder` (mic capture) stays — not on the AEP prohibited list, confirmed in ADR 0022.

### Code review tips

- **Stacked on #1266** (needs the media3 version ref + notices baseline). Merge order: #1265 → #1266 → this.
- Semantics note: sources whose duration was unreadable used to fail silently (null/0); they now surface as the existing non-fatal — watch its Crashlytics volume post-release, UX is identical.
- **Follow-up found (pre-existing, out of scope):** the add-preview probes the raw inbound `EXTRA_STREAM` uri before save-time validation — the scheme/MIME/size allowlist (CLAUDE.md § Security boundaries) only runs in `saveNewButtonAsync`. Worth extending the validator to the preview path in its own PR; Media3's `DefaultDataSource` will happily resolve `http(s)` uris.

### Already tested

- [x] Instrumented suite: run locally, green — includes `AddButtonPreviewFlowTest`/`AddButtonPreviewRecreateTest`, which only pass when the new extractor resolves a real audio's duration (> 0) on device