### PR TITLE
refactor(vault): waveform demux via Media3 MediaExtractorCompat (ADR 0022 / 002f)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is based on [Keep a Changelog][]. Through v2.3.0 this project used [S
 - Long-form playback engine (`ListenSessionEngine`, Media3 ExoPlayer 1.10.1) behind the same `PlayerController` facade: Vault immersive listen and recorder review now play on it, reporting through the existing listener/StateFlow channels; list-row taps and add-flow previews stay on MediaPlayer (ADR 0022)
 - Audio duration extraction (import + add-preview) moved from the AEP-prohibited `MediaMetadataRetriever` to Media3's `MetadataRetriever` (`media3-inspector`), keeping the same failure UX and Crashlytics grouping (ADR 0022 / spec 002e)
 
+#### Changed
+- Waveform envelope extraction demuxes via Media3's `MediaExtractorCompat` instead of the AEP-prohibited `MediaExtractor` (`MediaCodec` decode unchanged); all sources normalize to per-decode temp files to route around a Media3 1.10.1 truncation bug with fd/content/resource sources — envelope verified bit-comparable (1 of 48 bars off by 0.014)
+
 #### Fixed
 - The My Sounds visibility toggle now updates the visible list synchronously (mirroring the pin toggle) instead of waiting for the DataStore write to round-trip back through `loadSounds`, removing the async dependency that made `SoundsViewModelVisibilityTest` time out under CI load
 

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/recorder/WaveformExtractorContentUriTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/recorder/WaveformExtractorContentUriTest.kt
@@ -45,5 +45,12 @@ internal class WaveformExtractorContentUriTest {
         assertThat(peaks!!.size).isEqualTo(RECORDER_WAVEFORM_BARS)
         // A real envelope varies bar to bar; the old synthetic/placeholder path would be uniform.
         assertThat(peaks.toSet().size).isGreaterThan(1)
+        // Source normalization copies the uri to a temp file — it must not outlive the decode.
+        assertThat(
+            context.cacheDir
+                .listFiles()
+                .orEmpty()
+                .filter { it.name.startsWith("waveform_src_") },
+        ).isEmpty()
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/SourceFile.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/SourceFile.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.vault
+
+import android.content.Context
+import android.net.Uri
+import java.io.File
+
+/** A local file ready for the extractor; [deleteAfter] marks per-decode temp copies. */
+internal class SourceFile(
+    val file: File,
+    val deleteAfter: Boolean,
+)
+
+/**
+ * Copies a bundled raw resource to a per-decode temp file. No persistent cache on purpose: a
+ * disk cache keyed by the resource int would go stale across app updates (aapt reassigns ids)
+ * and locale changes (qualified raw overrides share the id); the in-memory envelope cache
+ * already makes repeat decodes per process free.
+ */
+internal fun copyRawResToTempFile(
+    context: Context,
+    rawRes: Int,
+): File = writeTempFile(context) { target -> context.resources.openRawResource(rawRes).use { it.copyTo(target) } }
+
+/** Copies a content/file uri's stream to a per-decode temp file (deleted after the decode). */
+internal fun copyUriToTempFile(
+    context: Context,
+    uri: Uri,
+): File =
+    writeTempFile(context) { target ->
+        checkNotNull(context.contentResolver.openInputStream(uri)) { "unreadable uri" }.use { it.copyTo(target) }
+    }
+
+/** Creates the temp, runs [write] into it, and deletes it on ANY failure before rethrowing. */
+private inline fun writeTempFile(
+    context: Context,
+    write: (java.io.OutputStream) -> Unit,
+): File {
+    val target = File.createTempFile("waveform_src_", null, context.cacheDir)
+    var written = false
+    try {
+        target.outputStream().use { write(it) }
+        written = true
+    } finally {
+        if (!written) target.delete()
+    }
+    return target
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/WaveformExtractor.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/WaveformExtractor.kt
@@ -7,9 +7,11 @@ package com.github.barriosnahuel.vossosunboton.feature.vault
 
 import android.content.Context
 import android.media.MediaCodec
-import android.media.MediaExtractor
 import android.media.MediaFormat
 import android.net.Uri
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.inspector.MediaExtractorCompat
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.commons.file.getFile
 import com.github.barriosnahuel.vossosunboton.feature.waveform.WAVEFORM_MIN_BAR
@@ -40,6 +42,7 @@ import kotlin.math.min
  * a tiny `FloatArray`), and returns `null` on any failure so the UI falls back to a neutral
  * placeholder rather than a fake-looking wave.
  */
+@OptIn(UnstableApi::class) // media3-inspector's MediaExtractorCompat is the drop-in for the AEP-prohibited MediaExtractor.
 internal object WaveformExtractor {
     private val cache = ConcurrentHashMap<String, FloatArray>()
 
@@ -51,13 +54,11 @@ internal object WaveformExtractor {
     ): FloatArray? {
         cache[sound.id]?.let { return it }
         val peaks =
-            decode(barCount, dispatcher, "Vault waveform extraction failed", "immersive") { extractor ->
+            decode(context, barCount, dispatcher, "Vault waveform extraction failed", "immersive") {
                 if (sound.file != null) {
-                    extractor.setDataSource(getFile(context, sound.file!!).path)
+                    SourceFile(getFile(context, sound.file!!), deleteAfter = false)
                 } else {
-                    context.resources.openRawResourceFd(sound.rawRes).use { afd ->
-                        extractor.setDataSource(afd.fileDescriptor, afd.startOffset, afd.declaredLength)
-                    }
+                    SourceFile(copyRawResToTempFile(context, sound.rawRes), deleteAfter = true)
                 }
             }
         return peaks?.also { cache[sound.id] = it }
@@ -77,38 +78,53 @@ internal object WaveformExtractor {
         barCount: Int,
         dispatcher: CoroutineDispatcher = Dispatchers.IO,
     ): FloatArray? =
-        decode(barCount, dispatcher, "Recorder waveform extraction failed", "recorder") { extractor ->
-            // Content-resolver overload: handles a content:// FileProvider URI directly, where an
-            // AssetFileDescriptor's declaredLength is often UNKNOWN and would break the fd overload.
-            extractor.setDataSource(context, uri, null)
+        decode(context, barCount, dispatcher, "Recorder waveform extraction failed", "recorder") {
+            // The content:// stream is copied to a temp file first — see the source-normalization
+            // contract on [decodeEnvelope]; the temp is deleted once the envelope is folded.
+            SourceFile(copyUriToTempFile(context, uri), deleteAfter = true)
         }
 
     /** Visible for the cold-start / no-data fallback path and tests. */
     fun cached(soundId: String): FloatArray? = cache[soundId]
 
     private suspend fun decode(
+        context: Context,
         barCount: Int,
         dispatcher: CoroutineDispatcher,
         failureMessage: String,
         failureModule: String,
-        configureSource: (MediaExtractor) -> Unit,
+        resolveSource: () -> SourceFile,
     ): FloatArray? =
         withContext(dispatcher) {
-            runCatching { decodeEnvelope(barCount, configureSource) }
-                .onFailure { error ->
-                    if (error is CancellationException) throw error
-                    Tracker.log("$failureModule.waveform_fail=${error.javaClass.simpleName}")
-                    Tracker.track(RuntimeException(failureMessage, error))
-                }.getOrNull()
+            runCatching {
+                val source = resolveSource()
+                try {
+                    decodeEnvelope(context, barCount, source)
+                } finally {
+                    if (source.deleteAfter) source.file.delete()
+                }
+            }.onFailure { error ->
+                if (error is CancellationException) throw error
+                Tracker.log("$failureModule.waveform_fail=${error.javaClass.simpleName}")
+                Tracker.track(RuntimeException(failureMessage, error))
+            }.getOrNull()
         }
 
+    /**
+     * Every source is normalized to a LOCAL FILE PATH before touching the extractor:
+     * MediaExtractorCompat 1.10.1 truncates after the first sample for fd-with-offset,
+     * `content://` and `android.resource://` sources (verified empirically on this project's
+     * audio; unreported upstream as of 2026-07). Path and `file://` sources demux correctly.
+     * Revisit the normalization when a fixed Media3 release lands.
+     */
     private suspend fun decodeEnvelope(
+        context: Context,
         barCount: Int,
-        configureSource: (MediaExtractor) -> Unit,
+        source: SourceFile,
     ): FloatArray {
-        val extractor = MediaExtractor()
+        val extractor = MediaExtractorCompat(context)
         try {
-            configureSource(extractor)
+            extractor.setDataSource(source.file.path)
             val trackIndex = audioTrackIndex(extractor)
             require(trackIndex >= 0) { "no audio track" }
             extractor.selectTrack(trackIndex)
@@ -138,7 +154,7 @@ internal object WaveformExtractor {
 
     private suspend fun decodeLoop(
         codec: MediaCodec,
-        extractor: MediaExtractor,
+        extractor: MediaExtractorCompat,
         accumulator: PeakAccumulator,
     ) {
         val bufferInfo = MediaCodec.BufferInfo()
@@ -154,7 +170,7 @@ internal object WaveformExtractor {
     /** Queues one input sample (or end-of-stream). Returns true once the stream is exhausted. */
     private fun feedInput(
         codec: MediaCodec,
-        extractor: MediaExtractor,
+        extractor: MediaExtractorCompat,
     ): Boolean {
         val inIndex = codec.dequeueInputBuffer(DEQUEUE_TIMEOUT_US)
         if (inIndex < 0) return false
@@ -190,7 +206,7 @@ internal object WaveformExtractor {
         return bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0
     }
 
-    private fun audioTrackIndex(extractor: MediaExtractor): Int {
+    private fun audioTrackIndex(extractor: MediaExtractorCompat): Int {
         for (i in 0 until extractor.trackCount) {
             val mime = extractor.getTrackFormat(i).getString(MediaFormat.KEY_MIME).orEmpty()
             if (mime.startsWith("audio/")) return i


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change.

Kills the third of the four AEP-prohibited media APIs: the waveform envelope (Vault immersive + recorder review) now demuxes through Media3 instead of `MediaExtractor`. The envelope the user sees is verified bit-comparable: same audio, same 48 bars, a single bar differing by 0.014 on the 0–1 scale (a trailing-frame boundary the two demuxers round differently — visually imperceptible). Closes spec 002f with the "migrate" outcome.

### Technical detail

- **`WaveformExtractor`** — `android.media.MediaExtractor` → `androidx.media3.inspector.MediaExtractorCompat`; the `MediaCodec` decode loop is untouched (not a prohibited API).
- **Upstream bug found & routed around** — MediaExtractorCompat 1.10.1 truncates after the FIRST sample for fd-with-offset, `content://` and `android.resource://` sources (probe: 1 sample/51 bytes vs 14 samples/2786 bytes via path; same file, same loop). Unreported upstream as of 2026-07 — worth filing. Workaround: **every source normalizes to a local file path** first.
- **`SourceFile.kt` (new)** — per-decode temp copies (bundled rawRes + content uris), deleted on every path including copy failures. Deliberately NO persistent disk cache: a cache keyed by the resource int would go stale across app updates (aapt reassigns ids) and locale changes (qualified `raw-es` overrides share the id); the in-memory envelope cache already makes repeat decodes per process free.
- **Acceptance** — golden capture on the same emulator, all three source overloads, old vs new implementation, numeric diff quantified above.
- **Unchanged:** envelope bucketing/normalization (`PeakAccumulator`), render (ADR 0020), failure UX (null → placeholder, same Crashlytics grouping).

### Code review tips

- **Full instrumented suite is red in this dev environment on `develop` too** — verified with `git checkout develop && ./scripts/run-instrumented-tests.sh` (wandering unrelated failures + `DELETE_FAILED_INTERNAL_ERROR` from the emulator's PackageManager after ~15 cold-boots in 24 h; a host reboot should clear it). Not caused by this diff.
- The two test classes covering this change ran green in a targeted pass: `WaveformExtractorContentUriTest` (real decode + new temp-leak assert) and `VaultImmersiveListenTest`.
- The recorder path now copies the clip to a temp before demuxing (was: streamed via content resolver) — bounded by recorder clips (≤60 s, own FileProvider); flag if an untrusted uri ever reaches this API.

### Already tested

- [x] Golden envelope comparison pre/post on the same emulator: 3/3 source types, 48 bars, max delta 0.014 (1 bar)
- [x] Unit + lint suites green locally
- [x] Targeted instrumented pass green: `WaveformExtractorContentUriTest` + `VaultImmersiveListenTest` (full-suite red pre-exists on base in this environment — see review tips)