### PR TITLE
feat(playback): publish listen sessions to system media surfaces (MediaSession, spec 002d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,16 @@ The format is based on [Keep a Changelog][]. Through v2.3.0 this project used [S
 
 ## \[unreleased]
 
+### Added
+- Long listens now show up in your system media controls — playing an audio from the Vault's listen screen (or reviewing a recording) surfaces a media notification with lock-screen controls, and headset/media keys pause and resume it; quick soundboard taps stay notification-free
+
 ### Changed
 - Opening a Vault audio's listen screen now always starts it from the beginning — previously a reopened audio silently resumed from where it was left mid-clip
 
 ### For nerds 🤓
 
 #### Added
+- `PlaybackSessionService` (Media3 `MediaSessionService`, `media3-session` 1.10.1) publishes listen sessions as a `mediaPlayback` foreground service with an auto-managed media notification; exported only for the Media3 bind intent, with controller-supplied media items rejected (`CuratedContentSessionCallback`) and external play/pause/seek reconciled back into the engine's published state; the session ExoPlayer now takes audio focus (spec 002d)
 - Tap-to-sound latency guardrail: a Macrobenchmark (`TapLatencyBenchmark`) measures tap → playback-start on a physical device via an engine-agnostic trace section, baselining the current player before the Media3 migration and gating the ≤100 ms budget after it
 - ADR 0022 decides the playback architecture for the Media3 migration: measured hybrid — MediaPlayer stays on the tap path (80 ms vs ExoPlayer's 390 ms on device, AEP exception documented), Media3 + MediaSession take the listening sessions (Vault immersive, recorder review)
 - Long-form playback engine (`ListenSessionEngine`, Media3 ExoPlayer 1.10.1) behind the same `PlayerController` facade: Vault immersive listen and recorder review now play on it, reporting through the existing listener/StateFlow channels; list-row taps and add-flow previews stay on MediaPlayer (ADR 0022)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,7 @@ Before adding a DataStore preference file or persistent path with sensitive data
 
 ### Exported components default to false
 
-New `Activity`/`Service`/`Receiver` in `AndroidManifest.xml` defaults `android:exported="false"`. Set `true` only with an `<intent-filter>` for external callers; document the intents in a comment above. Today's exported activities: `LandingActivity` (LAUNCHER + `push-me://open` deep link) and `AddButtonActivity` (share sheet `ACTION_SEND` with `audio/*`).
+New `Activity`/`Service`/`Receiver` in `AndroidManifest.xml` defaults `android:exported="false"`. Set `true` only with an `<intent-filter>` for external callers; document the intents in a comment above. Today's exported components: `LandingActivity` (LAUNCHER + `push-me://open` deep link), `AddButtonActivity` (share sheet `ACTION_SEND` with `audio/*`), `PlaybackSessionService` (Media3 bind intent; external media items rejected).
 
 ### Security test tagging (OWASP MASVS / CWE)
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -169,6 +169,7 @@ dependencies {
     implementation libs.androidx.tracing
     implementation libs.androidx.media3.exoplayer
     implementation libs.androidx.media3.inspector
+    implementation libs.androidx.media3.session
     implementation libs.lifecycle.viewmodel.compose
     implementation libs.lifecycle.runtime.compose
     implementation libs.coroutines.android

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/playback/MediaSessionFlowTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/playback/MediaSessionFlowTest.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.playback
+
+import android.app.ActivityManager
+import android.app.NotificationManager
+import android.content.ComponentName
+import android.os.SystemClock
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.performClick
+import androidx.media3.session.MediaController
+import androidx.media3.session.SessionToken
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.barriosnahuel.vossosunboton.AbstractUiTest
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.TestData
+import com.github.barriosnahuel.vossosunboton.awaitNodeWithContentDescription
+import com.github.barriosnahuel.vossosunboton.ui.home.LandingActivity
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.TimeUnit
+
+/**
+ * End-to-end coverage for the MediaSession integration (ADR 0022 / spec 002d): a listen session is
+ * discoverable and controllable through the real [PlaybackSessionService] + [MediaController]
+ * stack — exactly what System UI's media controls do — and an EXTERNAL pause command reconciles
+ * back into the controller's published state. Unit tests pin these transitions with a scripted
+ * fake; this suite exercises the real ExoPlayer + MediaSession + service binder chain.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class MediaSessionFlowTest : AbstractUiTest() {
+    private var mediaController: MediaController? = null
+
+    override fun tearDown() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            mediaController?.release()
+            mediaController = null
+            PlayerControllerFactory.instance.stopPlayingSound()
+        }
+        super.tearDown()
+    }
+
+    @Test
+    fun listenSessionIsControllableThroughTheSystemMediaStack() {
+        val previewUri = TestData.seedPreviewAudio(context)
+        val playerController = PlayerControllerFactory.instance
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            playerController.startUriListenSession(context, previewUri)
+        }
+        awaitCondition("session playback did not start") {
+            playerController.playbackState.value?.isPlaying == true
+        }
+
+        // Connect exactly like System UI / external media controllers do: bind the exported
+        // service and build a MediaController from its session token.
+        val controller = connectMediaController()
+
+        awaitConditionOnMain("session not visible through MediaController") { controller.isPlaying }
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            assertThat(controller.mediaMetadata.title.toString())
+                .isEqualTo(context.getString(R.string.app_playback_recording_session_title))
+        }
+
+        // External pause (media notification / media key / headset): commands the Player directly,
+        // and the engine must reconcile it into the same published state the in-app UI renders.
+        InstrumentationRegistry.getInstrumentation().runOnMainSync { controller.pause() }
+        awaitCondition("external pause did not reconcile into playbackState") {
+            playerController.playbackState.value?.isPlaying == false
+        }
+    }
+
+    @Test
+    fun listenSessionShowsAMediaNotificationWhilePlaying() {
+        val previewUri = TestData.seedPreviewAudio(context)
+        val playerController = PlayerControllerFactory.instance
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            playerController.startUriListenSession(context, previewUri)
+        }
+        awaitCondition("session playback did not start") {
+            playerController.playbackState.value?.isPlaying == true
+        }
+
+        // Media-session notifications are exempt from POST_NOTIFICATIONS (which this app does not
+        // request): the notification must be active while the session plays.
+        val notificationManager = context.getSystemService(NotificationManager::class.java)
+        awaitCondition("media notification never appeared") {
+            notificationManager.activeNotifications.isNotEmpty()
+        }
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            PlayerControllerFactory.instance.stopPlayingSound()
+        }
+        awaitCondition("media notification did not disappear with the session") {
+            notificationManager.activeNotifications.isEmpty()
+        }
+    }
+
+    @Test
+    fun shortSoundboardTapNeverStartsTheSessionService() {
+        TestData.seedCustomSounds(context, count = 1)
+
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            composeRule.awaitNodeWithContentDescription(context.getString(R.string.app_play)).performClick()
+            composeRule.awaitNodeWithContentDescription(context.getString(R.string.app_pause)).assertIsDisplayed()
+
+            // The tap path (MediaPlayer engine, ADR 0022) must not publish a system surface: no
+            // session service, no media notification — a 2-second Bomp burst is not a listen session.
+            assertThat(isSessionServiceRunning()).isFalse()
+            val notificationManager = context.getSystemService(NotificationManager::class.java)
+            assertThat(notificationManager.activeNotifications).isEmpty()
+        }
+    }
+
+    private fun connectMediaController(): MediaController {
+        val token = SessionToken(context, ComponentName(context, PlaybackSessionService::class.java))
+        val controller =
+            MediaController
+                .Builder(context, token)
+                .buildAsync()
+                .get(CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        mediaController = controller
+        return controller
+    }
+
+    @Suppress("DEPRECATION") // Still authoritative for the caller's OWN services, which is all we ask.
+    private fun isSessionServiceRunning(): Boolean {
+        val am = context.getSystemService(ActivityManager::class.java)
+        return am.getRunningServices(Int.MAX_VALUE).any {
+            it.service == ComponentName(context, PlaybackSessionService::class.java)
+        }
+    }
+
+    private fun awaitCondition(
+        message: String,
+        condition: () -> Boolean,
+    ) {
+        val deadline = SystemClock.uptimeMillis() + CONDITION_TIMEOUT_MS
+        while (SystemClock.uptimeMillis() < deadline) {
+            if (condition()) return
+            SystemClock.sleep(POLL_INTERVAL_MS)
+        }
+        assertWithMessage(message).that(condition()).isTrue()
+    }
+
+    /** Like [awaitCondition] but evaluates [condition] on the main thread ([MediaController] is main-only). */
+    private fun awaitConditionOnMain(
+        message: String,
+        condition: () -> Boolean,
+    ) {
+        awaitCondition(message) {
+            var result = false
+            InstrumentationRegistry.getInstrumentation().runOnMainSync { result = condition() }
+            result
+        }
+    }
+
+    private companion object {
+        // Cold-AVD codec spin-up + service bind + binder round-trips must settle inside this window.
+        private const val CONDITION_TIMEOUT_MS = 10_000L
+        private const val CONNECT_TIMEOUT_MS = 10_000L
+        private const val POLL_INTERVAL_MS = 100L
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,14 @@
          Settings or an import escape. The Vault still never taps the mic for playback visuals. -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
+    <!-- Listen sessions (ADR 0022): PlaybackSessionService runs as a mediaPlayback foreground
+         service while a listen session plays, so the media notification / lock-screen controls
+         stay alive with the audio. Install-time permissions, no runtime prompt. Note there is
+         deliberately NO POST_NOTIFICATIONS: media-session notifications are exempt on API 33+
+         (https://developer.android.com/develop/ui/views/notifications/notification-permission). -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+
     <application
         android:name=".MainApplication"
         android:allowBackup="true"
@@ -83,6 +91,27 @@
                 <data android:mimeType="audio/*" />
             </intent-filter>
         </activity>
+
+        <!-- Media3 listen sessions (ADR 0022): publishes the active listen session (Vault immersive,
+             recorder review) to system media surfaces — notification, lock screen, media keys.
+             Exported ONLY for the androidx.media3.session.MediaSessionService bind intent below, so
+             System UI / Assistant / companion-device controllers can connect; controller-supplied
+             media items are rejected (CuratedContentSessionCallback), leaving external callers
+             transport controls over app-curated content only. Short soundboard taps never start
+             this service. -->
+        <!-- ExportedService: suppressed by design — external media controllers (System UI, Assistant)
+             cannot hold an app-defined permission, which is why the Media3 template ships exported
+             and permissionless; access control happens at the MediaSession layer instead
+             (CuratedContentSessionCallback + no-session starts self-stop). -->
+        <service
+            android:name=".feature.playback.PlaybackSessionService"
+            android:exported="true"
+            android:foregroundServiceType="mediaPlayback"
+            tools:ignore="ExportedService">
+            <intent-filter>
+                <action android:name="androidx.media3.session.MediaSessionService" />
+            </intent-filter>
+        </service>
 
         <!-- In-app recorder (ADR 0019). Not exported: launched only by the import Hub via an explicit
              intent; it hands the captured clip to AddButtonActivity for naming + save. -->

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/ListenSessionEngine.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/ListenSessionEngine.kt
@@ -10,8 +10,10 @@ import android.net.Uri
 import android.os.Handler
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
+import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.commons.file.getFile
 import com.github.barriosnahuel.vossosunboton.model.Sound
@@ -28,12 +30,18 @@ import kotlinx.coroutines.flow.update
  * [startUri] offset) and preemption is a definitive stop, never a pause. In-session pause/resume
  * keeps the player's own head. [PlayerControllerImpl] is the only caller and enforces the
  * one-active-playback invariant across both engines. Main-thread only, like the whole controller.
+ *
+ * Sessions are also published to the system through [bridge] (media notification, lock screen,
+ * media keys). External surfaces command the [Player] DIRECTLY — not through this engine's
+ * [pause]/[resume] — so the [playerListener] reconciles player-initiated transitions back into
+ * the same consumer events, keyed off [publishedPlaying] to avoid double emission.
  */
 internal class ListenSessionEngine(
     private val playerProvider: (Context) -> Player,
     private val handler: Handler,
     private val listenerProvider: () -> PlayerControllerListener?,
     private val playbackState: MutableStateFlow<PlaybackState?>,
+    private val bridge: MediaSessionBridge,
 ) {
     private sealed class SessionTarget {
         data class SoundTarget(
@@ -47,9 +55,18 @@ internal class ListenSessionEngine(
 
     private var player: Player? = null
     private var target: SessionTarget? = null
+    private var appContext: Context? = null
 
     /** Set by start calls; consumed by the first STATE_READY so re-buffers don't re-emit start events. */
     private var startPending = false
+
+    /**
+     * The play/pause state last emitted to consumers. When a player callback reports a state we
+     * already emitted (because the transition came from [pause]/[resume]) the reconciliation in
+     * [playerListener] skips it; a mismatch means the player was commanded externally (media
+     * notification, media key, audio-focus loss) and the event must be emitted from the callback.
+     */
+    private var publishedPlaying = false
 
     val isActive: Boolean get() = target != null
 
@@ -76,6 +93,42 @@ internal class ListenSessionEngine(
                     Player.STATE_READY -> onReady()
                     Player.STATE_ENDED -> onEnded()
                     else -> Unit
+                }
+            }
+
+            override fun onIsPlayingChanged(isPlaying: Boolean) {
+                if (startPending) return // The initial start is STATE_READY's to emit, whatever the callback order.
+                val t = target
+                val p = player
+                when {
+                    isPlaying == publishedPlaying ->
+                        // Regaining after a transient suppression (audio-focus loss, re-buffer) is not a
+                        // state change to re-emit, but the self-terminating progress ticker must be re-armed.
+                        if (isPlaying) {
+                            handler.removeCallbacks(progressRunnable)
+                            handler.post(progressRunnable)
+                        }
+                    t == null || p == null -> Unit
+                    isPlaying -> publishPlaying(t, p)
+                    // ENDED is onEnded's stop; playWhenReady still true is a transient re-buffer.
+                    p.playbackState != Player.STATE_ENDED && !p.playWhenReady -> publishPaused(t, p)
+                    else -> Unit
+                }
+            }
+
+            override fun onPositionDiscontinuity(
+                oldPosition: Player.PositionInfo,
+                newPosition: Player.PositionInfo,
+                reason: Int,
+            ) {
+                // External seeks (lock-screen seekbar) move the head without passing through seekTo;
+                // publish the new position so a paused UI doesn't keep the stale one.
+                if (reason != Player.DISCONTINUITY_REASON_SEEK) return
+                val position = newPosition.positionMs.toInt()
+                when (target) {
+                    is SessionTarget.SoundTarget -> listenerProvider()?.onProgressUpdate(position)
+                    is SessionTarget.UriTarget -> playbackState.update { it?.copy(positionMs = position) }
+                    null -> Unit
                 }
             }
 
@@ -107,7 +160,7 @@ internal class ListenSessionEngine(
                 Uri.fromFile(getFile(context, sound.file!!))
             }
         target = SessionTarget.SoundTarget(sound)
-        load(context, uri, startPositionMs = 0)
+        load(context, uri, startPositionMs = 0, title = sound.name)
     }
 
     /** Starts [uri] as a session, honoring [startPositionMs] (recorder review's scrub offset). */
@@ -124,20 +177,29 @@ internal class ListenSessionEngine(
         }
         stop()
         target = SessionTarget.UriTarget(uri)
-        load(context, uri, startPositionMs)
+        load(context, uri, startPositionMs, title = context.getString(R.string.app_playback_recording_session_title))
     }
 
     private fun load(
         context: Context,
         uri: Uri,
         startPositionMs: Int,
+        title: String,
     ) {
         val p = obtainPlayer(context)
         startPending = true
-        p.setMediaItem(MediaItem.fromUri(uri))
+        p.setMediaItem(
+            MediaItem
+                .Builder()
+                .setUri(uri)
+                // Title feeds the system media surfaces (notification, lock screen).
+                .setMediaMetadata(MediaMetadata.Builder().setTitle(title).build())
+                .build(),
+        )
         p.prepare()
         if (startPositionMs > 0) p.seekTo(startPositionMs.toLong())
         p.play()
+        bridge.onSessionStarted(context.applicationContext)
     }
 
     /**
@@ -148,8 +210,15 @@ internal class ListenSessionEngine(
         val t = target ?: return
         handler.removeCallbacks(progressRunnable)
         startPending = false
-        player?.let { runCatching { it.stop() } }
+        publishedPlaying = false
+        // clearMediaItems drops the notification content and turns a later stray media-key press
+        // into a no-op — a dead session must not be resurrectable from the system surface.
+        player?.let {
+            runCatching { it.stop() }
+            runCatching { it.clearMediaItems() }
+        }
         target = null
+        appContext?.let { bridge.onSessionEnded(it) }
         when (t) {
             is SessionTarget.SoundTarget -> listenerProvider()?.onPlayerStop(t.sound, completed = false)
             is SessionTarget.UriTarget -> playbackState.value = null
@@ -167,15 +236,8 @@ internal class ListenSessionEngine(
         val p = player
         if (p != null) {
             runCatching { p.pause() }
-            handler.removeCallbacks(progressRunnable)
             startPending = false
-            val position = p.currentPosition.toInt()
-            when (t) {
-                is SessionTarget.SoundTarget ->
-                    listenerProvider()?.onPlayerPause(t.sound, positionMs = position, durationMs = p.durationMsOrZero())
-                is SessionTarget.UriTarget ->
-                    playbackState.update { it?.copy(positionMs = position, isPlaying = false) }
-            }
+            publishPaused(t, p)
         }
         return true
     }
@@ -186,14 +248,10 @@ internal class ListenSessionEngine(
         val p = player
         if (p != null && !p.isPlaying) {
             p.play()
-            val position = p.currentPosition.toInt()
-            when (t) {
-                is SessionTarget.SoundTarget ->
-                    listenerProvider()?.onPlayerStart(t.sound, durationMs = p.durationMsOrZero(), positionMs = position)
-                is SessionTarget.UriTarget ->
-                    playbackState.update { it?.copy(positionMs = position, isPlaying = true) }
-            }
-            handler.post(progressRunnable)
+            publishPlaying(t, p)
+            // Re-publish to the system: after onTaskRemoved the service is gone while the paused
+            // target survives, so an in-place resume must restore the notification (start is idempotent).
+            appContext?.let { bridge.onSessionStarted(it) }
         }
         return true
     }
@@ -207,10 +265,47 @@ internal class ListenSessionEngine(
     }
 
     private fun obtainPlayer(context: Context): Player =
-        player ?: playerProvider(context.applicationContext).also {
-            it.addListener(playerListener)
-            player = it
+        player ?: run {
+            val app = context.applicationContext
+            appContext = app
+            playerProvider(app).also {
+                it.addListener(playerListener)
+                bridge.onSessionPlayerCreated(app, it)
+                player = it
+            }
         }
+
+    /** Emits the paused state for [t] and stops progress ticking. Shared by [pause] and reconciliation. */
+    private fun publishPaused(
+        t: SessionTarget,
+        p: Player,
+    ) {
+        handler.removeCallbacks(progressRunnable)
+        publishedPlaying = false
+        val position = p.currentPosition.toInt()
+        when (t) {
+            is SessionTarget.SoundTarget ->
+                listenerProvider()?.onPlayerPause(t.sound, positionMs = position, durationMs = p.durationMsOrZero())
+            is SessionTarget.UriTarget ->
+                playbackState.update { it?.copy(positionMs = position, isPlaying = false) }
+        }
+    }
+
+    /** Emits the playing state for [t] and (re)starts progress ticking. Shared by [resume] and reconciliation. */
+    private fun publishPlaying(
+        t: SessionTarget,
+        p: Player,
+    ) {
+        publishedPlaying = true
+        val position = p.currentPosition.toInt()
+        when (t) {
+            is SessionTarget.SoundTarget ->
+                listenerProvider()?.onPlayerStart(t.sound, durationMs = p.durationMsOrZero(), positionMs = position)
+            is SessionTarget.UriTarget ->
+                playbackState.update { it?.copy(positionMs = position, isPlaying = true) }
+        }
+        handler.post(progressRunnable)
+    }
 
     private fun onReady() {
         if (!startPending) return
@@ -218,6 +313,7 @@ internal class ListenSessionEngine(
         val p = player ?: return
         val duration = p.durationMsOrZero()
         val position = p.currentPosition.toInt()
+        publishedPlaying = true
         when (val t = target) {
             is SessionTarget.SoundTarget ->
                 listenerProvider()?.onPlayerStart(t.sound, durationMs = duration, positionMs = position)
@@ -229,13 +325,16 @@ internal class ListenSessionEngine(
     }
 
     private fun onEnded() {
+        val t = target ?: return
         handler.removeCallbacks(progressRunnable)
-        when (val t = target) {
+        publishedPlaying = false
+        player?.let { runCatching { it.clearMediaItems() } }
+        target = null
+        appContext?.let { bridge.onSessionEnded(it) }
+        when (t) {
             is SessionTarget.SoundTarget -> listenerProvider()?.onPlayerStop(t.sound, completed = true)
             is SessionTarget.UriTarget -> playbackState.value = null
-            null -> Unit
         }
-        target = null
     }
 
     private fun onError(error: PlaybackException) {
@@ -243,6 +342,8 @@ internal class ListenSessionEngine(
         val t = target
         target = null
         startPending = false
+        publishedPlaying = false
+        appContext?.let { bridge.onSessionEnded(it) }
         when (t) {
             is SessionTarget.SoundTarget -> {
                 Tracker.log("playback.sound=${t.sound.name}")

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/MediaSessionBridge.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/MediaSessionBridge.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.playback
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.session.MediaSession
+import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+
+/**
+ * Seam between [ListenSessionEngine] and the system media surfaces (media notification, lock
+ * screen, media keys) : docs/adr/0022. The engine reports listen-session lifecycle transitions;
+ * the production implementation maintains the app's [MediaSession] and the
+ * [PlaybackSessionService] that publishes it to the system. Unit tests substitute a recording
+ * fake so engine transitions are assertable without Media3 system plumbing.
+ */
+internal interface MediaSessionBridge {
+    /** Called once, right after the session [Player] is created; wraps it in a [MediaSession]. */
+    fun onSessionPlayerCreated(
+        context: Context,
+        player: Player,
+    )
+
+    /** A listen session started (or restarted): publish it to the system. */
+    fun onSessionStarted(context: Context)
+
+    /** The listen session ended definitively (stop / completion / error): retract it. */
+    fun onSessionEnded(context: Context)
+}
+
+/**
+ * Rejects every controller-supplied media item: Bomp listen sessions play app-curated content
+ * only. Media3's default callback accepts any item carrying a URI, which would let any app that
+ * binds the exported [PlaybackSessionService] inject arbitrary audio into Bomp's player.
+ * Transport controls (play/pause/seek) stay available to system surfaces.
+ */
+internal object CuratedContentSessionCallback : MediaSession.Callback {
+    override fun onAddMediaItems(
+        mediaSession: MediaSession,
+        controller: MediaSession.ControllerInfo,
+        mediaItems: MutableList<MediaItem>,
+    ): ListenableFuture<MutableList<MediaItem>> =
+        Futures.immediateFailedFuture(UnsupportedOperationException("External media items are not accepted"))
+}
+
+/**
+ * Production [MediaSessionBridge]. Owns the process-lifetime [MediaSession] (same lifetime as the
+ * session player it wraps — neither is ever released, matching [PlayerControllerImpl]'s
+ * singleton design) and starts/stops [PlaybackSessionService] around each listen session so the
+ * media notification exists exactly while a session does.
+ */
+internal object MediaSessionBridgeImpl : MediaSessionBridge {
+    var mediaSession: MediaSession? = null
+        private set
+
+    override fun onSessionPlayerCreated(
+        context: Context,
+        player: Player,
+    ) {
+        if (mediaSession != null) return
+        val builder =
+            MediaSession
+                .Builder(context, player)
+                .setCallback(CuratedContentSessionCallback)
+        sessionActivityIntent(context)?.let { builder.setSessionActivity(it) }
+        mediaSession = builder.build()
+    }
+
+    override fun onSessionStarted(context: Context) {
+        // Sessions start from foreground UI, so startService is legal; the catch guards the
+        // background-start race (e.g. a tap landing right as the app backgrounds) — the session
+        // still plays, it just misses the system surface.
+        runCatching { context.startService(Intent(context, PlaybackSessionService::class.java)) }
+            .onFailure { e ->
+                Tracker.log("playback.service=start")
+                Tracker.track(RuntimeException("Media session service can't start", e))
+            }
+    }
+
+    override fun onSessionEnded(context: Context) {
+        context.stopService(Intent(context, PlaybackSessionService::class.java))
+    }
+
+    /** Tapping the media notification brings the existing task to front, state intact. */
+    private fun sessionActivityIntent(context: Context): PendingIntent? {
+        val launch = context.packageManager.getLaunchIntentForPackage(context.packageName) ?: return null
+        return PendingIntent.getActivity(
+            context,
+            0,
+            launch,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+    }
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlaybackSessionService.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlaybackSessionService.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.playback
+
+import android.content.Intent
+import androidx.media3.session.MediaSession
+import androidx.media3.session.MediaSessionService
+
+/**
+ * Publishes the active listen session (docs/adr/0022) to the system: media notification, lock
+ * screen controls and media keys. Started by [MediaSessionBridgeImpl] when a listen session
+ * begins and stopped when it ends — short soundboard taps never reach this service, so they never
+ * produce a notification. The session player is process-lifetime and owned by
+ * [PlayerControllerImpl]; this service only borrows it (remove-not-release on destroy).
+ */
+internal class PlaybackSessionService : MediaSessionService() {
+    override fun onStartCommand(
+        intent: Intent?,
+        flags: Int,
+        startId: Int,
+    ): Int {
+        // Exported component: any package can startService this explicitly. With no session there
+        // is nothing to publish — refuse to stay started instead of idling as a keep-alive.
+        val session = MediaSessionBridgeImpl.mediaSession
+        if (session == null) {
+            stopSelf(startId)
+            return START_NOT_STICKY
+        }
+        // Adopt the bridge's session on every explicit start: covers both the fresh-start and the
+        // service-restart case (addSession is not implied by onGetSession, which only serves binds).
+        if (session !in sessions) addSession(session)
+        return super.onStartCommand(intent, flags, startId)
+    }
+
+    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? = MediaSessionBridgeImpl.mediaSession
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        // Bomp is not a music app: swiping the task away ends the listening session instead of
+        // letting audio outlive the app.
+        MediaSessionBridgeImpl.mediaSession?.player?.pause()
+        stopSelf()
+    }
+
+    override fun onDestroy() {
+        MediaSessionBridgeImpl.mediaSession?.let { removeSession(it) }
+        super.onDestroy()
+    }
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerImpl.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerImpl.kt
@@ -10,6 +10,8 @@ import android.media.MediaPlayer
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.C
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
@@ -32,7 +34,8 @@ internal class PlayerControllerImpl(
     private val mediaPlayer: MediaPlayer = MediaPlayer(),
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob()),
-    private val sessionPlayerProvider: (Context) -> Player = { ExoPlayer.Builder(it).build() },
+    private val sessionPlayerProvider: (Context) -> Player = { defaultSessionPlayer(it) },
+    private val sessionBridge: MediaSessionBridge = MediaSessionBridgeImpl,
 ) : PlayerController {
     private var listener: PlayerControllerListener? = null
 
@@ -326,6 +329,7 @@ internal class PlayerControllerImpl(
             handler = handler,
             listenerProvider = { listener },
             playbackState = _playbackState,
+            bridge = sessionBridge,
         )
 
     override fun startListenSession(
@@ -510,5 +514,23 @@ internal class PlayerControllerImpl(
 
     companion object {
         private const val PROGRESS_INTERVAL_MS = 100L
+
+        /**
+         * Session engine only: listening sessions take (and yield) audio focus like any media app —
+         * a session pauses for a phone call or another player and the pause is reconciled back into
+         * the UI by [ListenSessionEngine]. The MediaPlayer tap path is untouched: a 2-second Bomp
+         * burst deliberately does not preempt whatever the user is listening to.
+         */
+        private fun defaultSessionPlayer(context: Context): Player =
+            ExoPlayer
+                .Builder(context)
+                .setAudioAttributes(
+                    AudioAttributes
+                        .Builder()
+                        .setUsage(C.USAGE_MEDIA)
+                        .setContentType(C.AUDIO_CONTENT_TYPE_SPEECH)
+                        .build(),
+                    true,
+                ).build()
     }
 }

--- a/app/src/main/res/raw/app_third_party_notices.txt
+++ b/app/src/main/res/raw/app_third_party_notices.txt
@@ -47,7 +47,7 @@ https://developer.android.com/jetpack/androidx/releases/tracing
 --------------------------------------------------------------------------------
 
 --------------------------------------------------------------------------------
-AndroidX Media3 (ExoPlayer, Inspector)
+AndroidX Media3 (ExoPlayer, Inspector, Session)
 Copyright (C) The Android Open Source Project
 Apache License, Version 2.0
 https://developer.android.com/jetpack/androidx/releases/media3

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -241,6 +241,8 @@
     <string name="app_recorder_cd_timer">Tiempo de grabación</string>
     <string name="app_recorder_cd_waveform">Progreso de reproducción</string>
     <string name="app_recorder_use">Usar este</string>
+
+    <string name="app_playback_recording_session_title">Tu grabación</string>
     <string name="app_recorder_rerecord">Regrabar</string>
     <string name="app_recorder_cd_play">Reproducir</string>
     <string name="app_recorder_cd_pause">Pausar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -247,6 +247,9 @@
     <string name="app_recorder_cd_timer">Recording time</string>
     <string name="app_recorder_cd_waveform">Playback progress</string>
     <string name="app_recorder_use">Use this</string>
+
+    <!-- Media session (system media controls) title for the recorder-review listen session. -->
+    <string name="app_playback_recording_session_title">Your recording</string>
     <string name="app_recorder_rerecord">Re-record</string>
     <string name="app_recorder_cd_play">Play</string>
     <string name="app_recorder_cd_pause">Pause</string>

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/FakeMediaSessionBridge.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/FakeMediaSessionBridge.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.playback
+
+import android.content.Context
+import androidx.media3.common.Player
+
+/**
+ * Recording [MediaSessionBridge] for controller/engine unit tests: counts lifecycle transitions
+ * instead of touching Media3 system plumbing (real [androidx.media3.session.MediaSession] +
+ * service coverage lives in the instrumented suite).
+ */
+internal class FakeMediaSessionBridge : MediaSessionBridge {
+    var playerCreatedCount = 0
+        private set
+    var startedCount = 0
+        private set
+    var endedCount = 0
+        private set
+
+    override fun onSessionPlayerCreated(
+        context: Context,
+        player: Player,
+    ) {
+        playerCreatedCount++
+    }
+
+    override fun onSessionStarted(context: Context) {
+        startedCount++
+    }
+
+    override fun onSessionEnded(context: Context) {
+        endedCount++
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlaybackSessionServiceTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlaybackSessionServiceTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.playback
+
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.google.common.truth.Truth.assertThat
+import io.mockk.mockk
+import org.junit.Test
+import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
+
+/**
+ * Smoke coverage for [PlaybackSessionService] (CLAUDE.md § Activity smoke tests, extended to the
+ * project's first Service): the lifecycle must survive without a session — the exported service
+ * can be started or bound by external packages at any time, including before any listen session
+ * ever existed in the process, and must refuse to stay started in that case.
+ */
+internal class PlaybackSessionServiceTest : AbstractRobolectricTest() {
+    @Test
+    fun `an explicit start without a session refuses to stay started`() {
+        val controller = Robolectric.buildService(PlaybackSessionService::class.java)
+
+        val service = controller.create().startCommand(0, 0).get()
+
+        assertThat(shadowOf(service).isStoppedBySelf).isTrue()
+        assertThat(service.onGetSession(mockk())).isNull()
+        controller.destroy()
+    }
+
+    @Test
+    fun `task removal without a session stops the service without crashing`() {
+        val controller = Robolectric.buildService(PlaybackSessionService::class.java)
+        val service = controller.create().get()
+
+        service.onTaskRemoved(null)
+
+        assertThat(shadowOf(service).isStoppedBySelf).isTrue()
+        controller.destroy()
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerListenSessionTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerListenSessionTest.kt
@@ -387,6 +387,7 @@ internal class PlayerControllerListenSessionTest : AbstractRobolectricTest() {
             ioDispatcher = dispatcher,
             scope = CoroutineScope(dispatcher + SupervisorJob()),
             sessionPlayerProvider = { player },
+            sessionBridge = FakeMediaSessionBridge(),
         )
     }
 }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerMediaSessionBridgeTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/playback/PlayerControllerMediaSessionBridgeTest.kt
@@ -1,0 +1,376 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.playback
+
+import android.content.Context
+import android.media.MediaPlayer
+import android.net.Uri
+import android.os.Looper
+import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.model.Sound
+import com.google.common.truth.Truth.assertThat
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.After
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.robolectric.Shadows.shadowOf
+import java.util.concurrent.ExecutionException
+
+/**
+ * System-surface contract of the listen-session engine (ADR 0022 + spec 002d): sessions are
+ * published/retracted through [MediaSessionBridge] exactly while one is active, media items carry
+ * the title the system notification renders, and player-initiated transitions (media notification,
+ * media keys, audio-focus loss command the [Player] directly) reconcile back into the same
+ * consumer events without double emission. The real MediaSession/service path is covered by the
+ * instrumented suite.
+ */
+internal class PlayerControllerMediaSessionBridgeTest : AbstractRobolectricTest() {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val playerListener = slot<Player.Listener>()
+    private val mediaItem = slot<MediaItem>()
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `starting a sound session publishes it to the system with the audio name as title`() {
+        val player = givenAnIdleSessionPlayer()
+        val bridge = FakeMediaSessionBridge()
+        val controller = controllerForTest(player = player, bridge = bridge)
+
+        controller.startListenSession(context, customSound())
+
+        assertThat(bridge.playerCreatedCount).isEqualTo(1)
+        assertThat(bridge.startedCount).isEqualTo(1)
+        assertThat(
+            mediaItem.captured.mediaMetadata.title
+                .toString(),
+        ).isEqualTo("custom audio")
+    }
+
+    @Test
+    fun `starting a uri session titles it with the recording session string`() {
+        val player = givenAnIdleSessionPlayer()
+        val bridge = FakeMediaSessionBridge()
+        val controller = controllerForTest(player = player, bridge = bridge)
+
+        controller.startUriListenSession(context, Uri.parse("file:///tmp/review.m4a"))
+
+        assertThat(
+            mediaItem.captured.mediaMetadata.title
+                .toString(),
+        ).isEqualTo(context.getString(R.string.app_playback_recording_session_title))
+    }
+
+    @Test
+    fun `a second session reuses the session player instead of recreating it`() {
+        val player = givenAnIdleSessionPlayer()
+        val bridge = FakeMediaSessionBridge()
+        val controller = controllerForTest(player = player, bridge = bridge)
+
+        controller.startListenSession(context, customSound())
+        controller.startListenSession(context, Sound("other-id", "other audio", "other.mp3"))
+
+        assertThat(bridge.playerCreatedCount).isEqualTo(1)
+        assertThat(bridge.startedCount).isEqualTo(2)
+    }
+
+    @Test
+    fun `stopping a session retracts it from the system and clears the loaded item`() {
+        val player = givenAnIdleSessionPlayer()
+        val bridge = FakeMediaSessionBridge()
+        val controller = controllerForTest(player = player, bridge = bridge)
+        controller.startListenSession(context, customSound())
+
+        controller.stopPlayingSound()
+
+        assertThat(bridge.endedCount).isEqualTo(1)
+        verify { player.clearMediaItems() }
+    }
+
+    @Test
+    fun `natural completion retracts the session from the system`() {
+        val player = givenAnIdleSessionPlayer()
+        val bridge = FakeMediaSessionBridge()
+        val controller = controllerForTest(player = player, bridge = bridge)
+        controller.startListenSession(context, customSound())
+
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_READY)
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_ENDED)
+
+        assertThat(bridge.endedCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `a session error retracts the session from the system`() {
+        val player = givenAnIdleSessionPlayer()
+        val bridge = FakeMediaSessionBridge()
+        val controller = controllerForTest(player = player, bridge = bridge)
+        controller.startListenSession(context, customSound())
+
+        playerListener.captured.onPlayerError(
+            PlaybackException("boom", null, PlaybackException.ERROR_CODE_IO_UNSPECIFIED),
+        )
+
+        assertThat(bridge.endedCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `an external pause emits onPlayerPause exactly once`() {
+        val player = givenAnIdleSessionPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        val controller = controllerForTest(player = player)
+        controller.setOnStartStopListener(listener)
+        val sound = customSound()
+        controller.startListenSession(context, sound)
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_READY)
+
+        // A media-notification / media-key pause acts on the Player directly: the engine only
+        // learns about it through the callback.
+        every { player.playWhenReady } returns false
+        every { player.currentPosition } returns 4_000L
+        playerListener.captured.onIsPlayingChanged(false)
+
+        verify(exactly = 1) { listener.onPlayerPause(sound, positionMs = 4_000, durationMs = 10_000) }
+    }
+
+    @Test
+    fun `a controller-initiated pause is not re-emitted when the player callback lands`() {
+        val player = givenAnIdleSessionPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        val controller = controllerForTest(player = player)
+        controller.setOnStartStopListener(listener)
+        controller.startListenSession(context, customSound())
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_READY)
+
+        controller.pause()
+        every { player.playWhenReady } returns false
+        playerListener.captured.onIsPlayingChanged(false)
+
+        verify(exactly = 1) { listener.onPlayerPause(any(), any(), any()) }
+    }
+
+    @Test
+    fun `an external resume emits onPlayerStart again`() {
+        val player = givenAnIdleSessionPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        val controller = controllerForTest(player = player)
+        controller.setOnStartStopListener(listener)
+        val sound = customSound()
+        controller.startListenSession(context, sound)
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_READY)
+        every { player.playWhenReady } returns false
+        playerListener.captured.onIsPlayingChanged(false)
+
+        playerListener.captured.onIsPlayingChanged(true)
+
+        verify(exactly = 2) { listener.onPlayerStart(sound, durationMs = 10_000, positionMs = any()) }
+    }
+
+    @Test
+    fun `a transient re-buffer does not masquerade as a pause`() {
+        val player = givenAnIdleSessionPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        val controller = controllerForTest(player = player)
+        controller.setOnStartStopListener(listener)
+        controller.startListenSession(context, customSound())
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_READY)
+
+        every { player.playWhenReady } returns true
+        every { player.playbackState } returns Player.STATE_BUFFERING
+        playerListener.captured.onIsPlayingChanged(false)
+
+        verify(exactly = 0) { listener.onPlayerPause(any(), any(), any()) }
+    }
+
+    @Test
+    fun `isPlaying callbacks before the first ready leave the start event to ready`() {
+        val player = givenAnIdleSessionPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        val controller = controllerForTest(player = player)
+        controller.setOnStartStopListener(listener)
+        val sound = customSound()
+        controller.startListenSession(context, sound)
+
+        playerListener.captured.onIsPlayingChanged(true)
+        verify(exactly = 0) { listener.onPlayerStart(any(), any(), any()) }
+
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_READY)
+        verify(exactly = 1) { listener.onPlayerStart(sound, durationMs = 10_000, positionMs = 0) }
+    }
+
+    @Test
+    fun `an external pause of a uri session flips playbackState to paused`() {
+        val player = givenAnIdleSessionPlayer()
+        val controller = controllerForTest(player = player)
+        controller.startUriListenSession(context, Uri.parse("file:///tmp/review.m4a"))
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_READY)
+        assertThat(controller.playbackState.value?.isPlaying).isTrue()
+
+        every { player.playWhenReady } returns false
+        every { player.currentPosition } returns 2_500L
+        playerListener.captured.onIsPlayingChanged(false)
+
+        assertThat(controller.playbackState.value?.isPlaying).isFalse()
+        assertThat(controller.playbackState.value?.positionMs).isEqualTo(2_500)
+    }
+
+    @Test
+    fun `an in-place resume re-publishes the session to the system`() {
+        val player = givenAnIdleSessionPlayer()
+        val bridge = FakeMediaSessionBridge()
+        val controller = controllerForTest(player = player, bridge = bridge)
+        controller.startListenSession(context, customSound())
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_READY)
+        controller.pause()
+
+        controller.resume()
+
+        // The paused target can outlive the service (task swiped away): resume must restart it.
+        assertThat(bridge.startedCount).isEqualTo(2)
+    }
+
+    @Test
+    fun `reaching the natural end is not reconciled as an external pause`() {
+        val player = givenAnIdleSessionPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        val controller = controllerForTest(player = player)
+        controller.setOnStartStopListener(listener)
+        controller.startListenSession(context, customSound())
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_READY)
+
+        // At natural end isPlaying flips false before/after STATE_ENDED; the stop belongs to
+        // onEnded, never to the pause reconciliation.
+        every { player.playbackState } returns Player.STATE_ENDED
+        every { player.playWhenReady } returns false
+        playerListener.captured.onIsPlayingChanged(false)
+
+        verify(exactly = 0) { listener.onPlayerPause(any(), any(), any()) }
+    }
+
+    @Test
+    fun `regaining playback after a transient suppression re-arms progress without re-emitting start`() {
+        val player = givenAnIdleSessionPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        val controller = controllerForTest(player = player)
+        controller.setOnStartStopListener(listener)
+        controller.startListenSession(context, customSound())
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_READY)
+        // Drain the ticker armed by READY: it self-terminates while the player reports not playing.
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // Transient audio-focus loss: isPlaying drops with playWhenReady still true (suppression)…
+        every { player.playWhenReady } returns true
+        playerListener.captured.onIsPlayingChanged(false)
+        // …then focus returns and playback resumes on its own.
+        playerListener.captured.onIsPlayingChanged(true)
+
+        verify(exactly = 1) { listener.onPlayerStart(any(), any(), any()) }
+        verify(exactly = 0) { listener.onPlayerPause(any(), any(), any()) }
+        // The ticker must be alive again after the regain.
+        every { player.isPlaying } returns true
+        every { player.currentPosition } returns 1_234L
+        shadowOf(Looper.getMainLooper()).idle()
+        verify { listener.onProgressUpdate(1_234) }
+    }
+
+    @Test
+    fun `an external seek publishes the new position of a sound session`() {
+        val player = givenAnIdleSessionPlayer()
+        val listener = mockk<PlayerControllerListener>(relaxed = true)
+        val controller = controllerForTest(player = player)
+        controller.setOnStartStopListener(listener)
+        controller.startListenSession(context, customSound())
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_READY)
+
+        playerListener.captured.onPositionDiscontinuity(
+            positionInfoAt(0L),
+            positionInfoAt(7_000L),
+            Player.DISCONTINUITY_REASON_SEEK,
+        )
+
+        verify { listener.onProgressUpdate(7_000) }
+    }
+
+    @Test
+    fun `an external seek publishes the new position of a uri session`() {
+        val player = givenAnIdleSessionPlayer()
+        val controller = controllerForTest(player = player)
+        controller.startUriListenSession(context, Uri.parse("file:///tmp/review.m4a"))
+        playerListener.captured.onPlaybackStateChanged(Player.STATE_READY)
+
+        playerListener.captured.onPositionDiscontinuity(
+            positionInfoAt(0L),
+            positionInfoAt(7_000L),
+            Player.DISCONTINUITY_REASON_SEEK,
+        )
+
+        assertThat(controller.playbackState.value?.positionMs).isEqualTo(7_000)
+    }
+
+    /** OWASP MASVS-PLATFORM-1 / CWE-926 (exported media session rejects controller-injected media items). */
+    @Test
+    fun `the media session callback rejects controller-supplied media items`() {
+        val future =
+            CuratedContentSessionCallback.onAddMediaItems(
+                mockk(),
+                mockk(),
+                mutableListOf(MediaItem.fromUri("https://attacker.example/audio.mp3")),
+            )
+
+        val failure = assertThrows(ExecutionException::class.java) { future.get() }
+        assertThat(failure).hasCauseThat().isInstanceOf(UnsupportedOperationException::class.java)
+    }
+
+    private fun customSound(): Sound = Sound("custom-id", "custom audio", "custom.mp3")
+
+    private fun positionInfoAt(positionMs: Long): Player.PositionInfo =
+        Player.PositionInfo(null, 0, null, null, 0, positionMs, positionMs, -1, -1)
+
+    private fun givenAnIdleSessionPlayer(): Player {
+        val player = mockk<Player>(relaxed = true)
+        every { player.addListener(capture(playerListener)) } just Runs
+        every { player.setMediaItem(capture(mediaItem)) } just Runs
+        every { player.isPlaying } returns false
+        every { player.currentPosition } returns 0L
+        every { player.duration } returns 10_000L
+        return player
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun controllerForTest(
+        player: Player,
+        bridge: FakeMediaSessionBridge = FakeMediaSessionBridge(),
+    ): PlayerControllerImpl {
+        val dispatcher = UnconfinedTestDispatcher()
+        val mp = mockk<MediaPlayer>(relaxed = true)
+        every { mp.isPlaying } returns false
+        return PlayerControllerImpl(
+            mediaPlayer = mp,
+            ioDispatcher = dispatcher,
+            scope = CoroutineScope(dispatcher + SupervisorJob()),
+            sessionPlayerProvider = { player },
+            sessionBridge = bridge,
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,6 +64,7 @@ androidx-core-splashscreen        = { module = "androidx.core:core-splashscreen"
 androidx-tracing                  = { module = "androidx.tracing:tracing",            version.ref = "tracing" }
 androidx-media3-exoplayer         = { module = "androidx.media3:media3-exoplayer",    version.ref = "media3" }
 androidx-media3-inspector         = { module = "androidx.media3:media3-inspector",    version.ref = "media3" }
+androidx-media3-session           = { module = "androidx.media3:media3-session",      version.ref = "media3" }
 
 # ---------- Compose BOM + components (no version — resolved by BOM) ----------
 compose-bom                       = { module = "androidx.compose:compose-bom",                       version.ref = "composeBom" }

--- a/scripts/check-security-test-count.sh
+++ b/scripts/check-security-test-count.sh
@@ -20,7 +20,7 @@
 
 set -euo pipefail
 
-EXPECTED_COUNT=32
+EXPECTED_COUNT=33
 
 SCAN_ROOTS=(
   app/src/test


### PR DESCRIPTION
### Summary
1. User opens an audio from the Vault's listen screen (or plays back a recording under review)
2. Locks the phone or switches apps mid-listen

**before:** the audio keeps playing but the system shows nothing — no lock-screen/quick-settings controls, headset keys do nothing, and a phone call talks over the audio.
**after:** the listen shows up in the system media controls (notification, lock screen, quick settings) with play/pause/seek and the audio's name; headset keys work; a phone call pauses it automatically. Quick soundboard taps stay exactly as they are — no notification for a 2-second Bomp (ADR 0022).

### Technical detail
MediaSession integration over the 002c engine, scoped to listen sessions per ADR 0022.

- **`PlaybackSessionService`** — Media3 `MediaSessionService` (`mediaPlayback` FGS): auto-managed media notification; started/stopped around each session so the notification lives exactly while a session does; task swipe-away ends the session (Bomp is not a music app).
- **`MediaSessionBridge`** — seam engine↔system; process-lifetime `MediaSession` + player owned in-process (service borrows via add/removeSession, never releases). `CuratedContentSessionCallback` rejects controller-supplied media items.
- **`ListenSessionEngine`** — external commands (notification, media keys, audio-focus loss) act on the `Player` directly; a `publishedPlaying` flag reconciles them into the existing listener/StateFlow events without double emission. MediaItems now carry the title the system renders.
- **Audio focus** — session player only; the MediaPlayer tap path deliberately untouched (a Bomp burst shouldn't preempt the user's music).
- **No `POST_NOTIFICATIONS`** — media-session notifications are exempt on 13+; no new runtime prompt.

### Code review tips
- The delicate piece is the reconciliation in `onIsPlayingChanged`: suppression-regain (call ends → playback resumes) must re-arm the progress ticker — this was a self-review CRITICAL, fixed + pinned by a test.
- Exported service: a no-session external start self-stops; default `onConnect` still grants standard transport commands (incl. `setRepeatMode`/speed) to connected controllers — deliberate, matches Media3 defaults.
- `MediaSession` is never released (same process-lifetime design as the engine player).
- Known cosmetic edge: tapping play mid-focus-suppression re-emits a start event (UI can't reach that state today).
- Manual verification suggested (device-only): lock-screen/QS control visuals in light/dark, real headset keys, notification tap returns to the app where you left it.

### Already tested
- [x] Instrumented suite via `./scripts/run-instrumented-tests.sh`: 130/130 green locally (includes 3 new `MediaSessionFlowTest` E2E: MediaController control + external-pause reconciliation, notification lifecycle, tap-never-starts-service)