### PR TITLE
docs: monthly-sequential release tags (vYYYY.MM.N) to enable milestone-at-PR-creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is based on [Keep a Changelog][]. Through v2.3.0 this project used [S
 - Long-form playback engine (`ListenSessionEngine`, Media3 ExoPlayer 1.10.1) behind the same `PlayerController` facade: Vault immersive listen and recorder review now play on it, reporting through the existing listener/StateFlow channels; list-row taps and add-flow previews stay on MediaPlayer (ADR 0022)
 - Audio duration extraction (import + add-preview) moved from the AEP-prohibited `MediaMetadataRetriever` to Media3's `MetadataRetriever` (`media3-inspector`), keeping the same failure UX and Crashlytics grouping (ADR 0022 / spec 002e)
 
+#### Changed
+- Release tags, GitHub release titles and CHANGELOG headers move from day-precision CalVer (`vYYYY.MM.DD`) to month + sequential counter (`vYYYY.MM.N`), so the month's milestone can be created up front and assigned to every PR at creation (ADR 0023 amending ADR 0021)
+
 #### Fixed
 - The My Sounds visibility toggle now updates the visible list synchronously (mirroring the pin toggle) instead of waiting for the DataStore write to round-trip back through `loadSounds`, removing the async dependency that made `SoundsViewModelVisibilityTest` time out under CI load
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,7 +330,7 @@ Store listing PNGs (icon, feature graphic) render from SVG masters under `store-
 
 ## Labels and milestone
 
-Apply exactly **one type label** (`a:*` or `an:*`) + **zero or more concern labels** (`c:*`) to every PR before merging. Don't call `gh label list`. For the milestone: under CalVer the next version is fixed **at cut**, so `## [unreleased]` carries no version — leave the milestone unset until a release exists (pre-CalVer PRs read it from a `(vX.Y.Z)` on that line). Don't call the milestones API.
+Apply exactly **one type label** (`a:*` or `an:*`) + **zero or more concern labels** (`c:*`) to every PR before merging. Don't call `gh label list`. Milestone: assign the current month's `vYYYY.MM.N` **at PR creation**, creating it if missing; a no-release month renames it to the next month. See [ADR 0023](docs/adr/0023-monthly-sequential-release-tags.md).
 
 - **Type — user-facing** (appear in CHANGELOG `### Added/Changed/Fixed/Removed`): `a:feature`, `a:fix`, `an:enhancement`.
 - **Type — internal** (under `### For nerds 🤓` or omitted): `a:refactor`, `a:test`, `a:build`, `a:docs`.
@@ -345,7 +345,7 @@ Full "when to use" per label + worked combinations: CONTRIBUTING.md § *Labels &
 
 ## Changelog
 
-`CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/); released headers are CalVer `## [vYYYY.MM.DD]` (CONTRIBUTING § *Versioning*):
+`CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/); released headers are CalVer `## [vYYYY.MM.N]` (CONTRIBUTING § *Versioning*):
 - Sections `Added` / `Changed` / `Fixed` / `Removed` under `## [unreleased]`. Each entry: single sentence, capital, no trailing period.
 - Dependency bumps → one line for the overall bump (`"Bumped all dependencies to latest stable"`), not one per library.
 - Update `[unreleased]` per commit when the change is user-visible or architecturally significant.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -570,11 +570,11 @@ Release-only Gradle commands (need the signing files above in the project root):
 
 ### Versioning
 
-**Calendar Versioning**, at two granularities — the user-facing version reads as a month, the GitHub tag is day-precise:
+**Calendar Versioning**, at two granularities — the user-facing version reads as a month, the GitHub tag adds a sequential counter:
 
 - **`versionName`** (what the Bomper sees in Play / "Acerca de") is **`YYYY.MM`** — year + month of the cut (e.g. `2026.07`). The date *is* the version: it tells the Bomper how fresh the app is. No SemVer `MAJOR.MINOR.PATCH`, **no sequential counter**. Two releases in the same month share a `versionName` — Play allows it; they stay distinct by `versionCode`.
 - **`versionCode`** stays a **monotonic integer**, bumped +1 per release, independent of `versionName` (Play Store requirement). It is the true build identity.
-- **GitHub tags + release titles + `CHANGELOG.md` headers** are **`vYYYY.MM.DD`** — the `v`-prefixed cut date with day precision (e.g. `v2026.07.15`). Day precision keeps tags unique across months without a sequential counter. If two releases ever land the **same day** (rare — a same-afternoon hotfix), disambiguate the second **tag only** at cut (e.g. `v2026.07.15-2`); `versionCode` already separates the builds and `versionName` stays `YYYY.MM`.
+- **GitHub tags + release titles + `CHANGELOG.md` headers** are **`vYYYY.MM.N`** — the `v`-prefixed cut month plus a 1-based counter within the month (e.g. `v2026.07.1`; a second July release is `v2026.07.2`). The counter keeps tags unique at any cadence, and — unlike a cut *date* — the name is knowable from the start of the month, which is what lets the month's **milestone** exist while PRs are still being opened (CLAUDE.md § *Labels and milestone*); git already records the cut date on the tag. Rationale + trade-off vs the earlier day-precision scheme: [ADR 0023](docs/adr/0023-monthly-sequential-release-tags.md).
 - **Forward-only frontier:** releases through `v2.3.0` were SemVer and stay as-is in tags / CHANGELOG / history. CalVer governs from the first cut after this change onward.
 
 ### Pre-release checklist
@@ -583,7 +583,7 @@ A **seed** — expand it as the release process is formalized (store rollout ste
 
 - [ ] **Regenerate the Baseline Profile** — `./scripts/generate-baseline-profile.sh`, then validate on a **real device** (`StartupBenchmark.startupBaselineProfile` near `DEFAULT`, well under `None`). It's a frozen snapshot of the cold-start path (§ *Baseline Profile*); refresh it so accumulated startup changes are precompiled.
 - [ ] **Run the tap-to-sound latency gate** — `TapLatencyBenchmark` on a **real device** (§ *Performance → What it measures*): median must stay ≤ 100 ms and in line with the last row of `macrobenchmark/RESULTS.md`; **append this run's row** there (that file is the versioned before/today series — there is no automatic threshold).
-- [ ] **Finalize `CHANGELOG.md`** — stamp `## [unreleased]` as `## [vYYYY.MM.DD]`, the cut date (§ CLAUDE.md *Changelog*).
+- [ ] **Finalize `CHANGELOG.md`** — stamp `## [unreleased]` as `## [vYYYY.MM.N] - YYYY-MM-DD`, the cut month + the month's next counter (`.1` for the month's first release), keeping the Keep-a-Changelog cut-date suffix (§ CLAUDE.md *Changelog*). The tag must match the month's open milestone — if the milestone was carried over from an earlier no-release month, rename it to the cut month first.
 - [ ] **Bump `versionCode` + `versionName`** in `app/build.gradle` — `versionCode` +1; `versionName` to the CalVer `YYYY.MM` cut month (§ *Versioning*).
 - [ ] **Release lint gate** — `./gradlew app:lintVitalRelease` green.
 - [ ] **Build the AAB** — `./gradlew app:bundle`.
@@ -598,15 +598,16 @@ After the checklist above is green and the version bump is merged to `develop`:
 2. **Create the release + tag from `develop`**, notes from the store change file, attaching **only** the R8 mapping as the single asset:
 
    ```bash
-   gh release create vYYYY.MM.DD --target develop --title "vYYYY.MM.DD" \
+   gh release create vYYYY.MM.N --target develop --title "vYYYY.MM.N" \
      --notes-file store-listing/en-US/changelog-<versionCode>.txt \
      app/build/outputs/mapping/release/mapping.txt
    ```
 
    `<versionCode>` is the value in `app/build.gradle`. Add a footer line linking to the full `CHANGELOG.md` on `develop` if the notes file omits it.
 3. **Attach nothing else.** The mapping is a backup for offline `retrace`; **never** attach the keystore, `secure.properties`, the real `google-services.json`, or the `.aab` (the `.aab` carries no mapping anyway).
-4. **Verify the asset landed** — `gh release view vYYYY.MM.DD --json assets -q '.assets[].name'` must list `mapping.txt`. Print an explicit line for the maintainer to confirm, e.g. `✅ mapping.txt attached to vYYYY.MM.DD` (or ⚠️ + re-run `gh release upload vYYYY.MM.DD app/build/outputs/mapping/release/mapping.txt` if missing).
+4. **Verify the asset landed** — `gh release view vYYYY.MM.N --json assets -q '.assets[].name'` must list `mapping.txt`. Print an explicit line for the maintainer to confirm, e.g. `✅ mapping.txt attached to vYYYY.MM.N` (or ⚠️ + re-run `gh release upload vYYYY.MM.N app/build/outputs/mapping/release/mapping.txt` if missing).
 5. **Verify Firebase actually got the mapping** — the build log must show `uploadCrashlyticsMappingFileRelease` *ran* (not skipped). Within minutes, a fresh crash on this version should de-obfuscate in the Console / via the Firebase MCP (real frames, **not** `r8-map-id-…`). This step exists because past releases shipped **without** the mapping (§ *BigQuery export* → *Stack frames come R8-obfuscated*) — so Crashlytics couldn't deobfuscate them either.
+6. **Close the release's milestone** — the `vYYYY.MM.N` milestone gathering this release's PRs closes at cut; the next month's (or same-month `.N+1`) milestone is created lazily when its first PR opens (CLAUDE.md § *Labels and milestone*).
 
 Why archive the mapping: even when Firebase holds it for Console/MCP de-obfuscation, a GitHub-release copy keyed to the tag is a durable offline `retrace` backup independent of Firebase retention — and the safety net for exactly the case above, where the Firebase upload didn't happen.
 
@@ -925,7 +926,17 @@ Those tools need the **Firebase App Id** (not a secret — it ships inside the A
 
 ## Labels & milestone examples 🏷️
 
-The *rule* (one type label + optional concern labels; how to derive the milestone from the CHANGELOG) and the bare label names live in CLAUDE.md § *Labels and milestone*. Full "when to use" per label, then worked combinations:
+The *rule* (one type label + optional concern labels; the month's `vYYYY.MM.N` milestone assigned at PR creation) and the bare label names live in CLAUDE.md § *Labels and milestone*. Full "when to use" per label, then worked combinations:
+
+### Milestone operations
+
+**Deriving `N`:** the next counter after the month's last cut — check existing `vYYYY.MM.*` tags and closed milestones; `.1` if the month has none yet. `gh` has no first-class milestone commands, so use the API:
+
+```bash
+gh api repos/{owner}/{repo}/milestones -f title="v2026.07.1"                  # create (month's first PR)
+gh api -X PATCH repos/{owner}/{repo}/milestones/<number> -f title="v2026.08.1" # rename on a no-release month
+gh pr create --milestone "v2026.07.1" ...                                      # assign at PR creation
+```
 
 ### Type — user-facing (appear under `### Added/Changed/Fixed/Removed` in CHANGELOG)
 

--- a/docs/adr/0021-calver-versioning.md
+++ b/docs/adr/0021-calver-versioning.md
@@ -1,6 +1,6 @@
 # ADR 0021 — Calendar Versioning for the app + GitHub releases
 
-- **Status:** Accepted
+- **Status:** Accepted (the tag / release-title / CHANGELOG-header scheme `vYYYY.MM.DD` amended to `vYYYY.MM.N` by [ADR 0023](0023-monthly-sequential-release-tags.md); everything else stands)
 - **Date:** 2026-07-04
 - **Supersedes:** the implicit Semantic Versioning convention used through v2.3.0 (never recorded as an ADR)
 

--- a/docs/adr/0023-monthly-sequential-release-tags.md
+++ b/docs/adr/0023-monthly-sequential-release-tags.md
@@ -1,0 +1,58 @@
+# ADR 0023 — Monthly-sequential release tags (`vYYYY.MM.N`)
+
+- **Status:** Accepted
+- **Date:** 2026-07-05
+- **Amends:** [ADR 0021](0021-calver-versioning.md) — only the tag / release-title / CHANGELOG-header scheme (`vYYYY.MM.DD` → `vYYYY.MM.N`). The rest of ADR 0021 — `versionName` = `YYYY.MM`, small monotonic `versionCode`, the forward-only SemVer frontier — stands unchanged.
+
+## Context
+
+ADR 0021 chose **day-precision** tags (`vYYYY.MM.DD`) explicitly to avoid a sequential counter
+("no false precision / no ceremony"): day precision made tags unique on its own, with a `-2`
+suffix hack reserved for the rare same-day second release.
+
+That choice has a side effect ADR 0021 did not weigh: **the tag name is unknowable until cut
+day**. GitHub milestones are named after the release tag, so under day precision no milestone
+can exist while the release's PRs are being opened. CLAUDE.md § *Labels and milestone* had to
+compensate with "leave the milestone unset until a release exists", which loses per-release
+traceability of PRs at exactly the moment it is cheapest to record — PR creation. Backfilling
+milestones after the cut is manual toil that in practice does not happen.
+
+A month-plus-sequential name (`v2026.07.1`) is knowable the moment the month starts (assuming
+≥1 release/month), so the milestone can be created up front and assigned on every PR as it is
+opened.
+
+## Decision
+
+- **GitHub tags + release titles + `CHANGELOG.md` headers become `vYYYY.MM.N`** — cut month
+  plus a 1-based counter within the month (e.g. `v2026.07.1`; a second July release is
+  `v2026.07.2`).
+- **The month's milestone is created lazily — when its first PR opens — and assigned to every PR
+  at creation** (rule in CLAUDE.md § *Labels and milestone*). The cut closes it.
+- **A month that ends with no release renames its milestone to the next month** — GitHub keeps
+  the associated PRs, so nothing is lost and no empty milestone accumulates.
+- **The same-day `-2` disambiguation hack dies** — the counter handles any cadence.
+- `versionName` (`YYYY.MM`) and `versionCode` are untouched; two same-month releases still share
+  a `versionName` and stay distinct by `versionCode` *and now also by tag*.
+- **No migration:** no CalVer cut ever happened (last tag is SemVer `v2.3.0`), so the day-precision
+  scheme has zero real tags — changing it now is free.
+
+## Trade-off accepted
+
+This reverses ADR 0021's "no sequential counter" driver *for tags only*. What the counter buys —
+a name knowable before the cut, hence milestone-at-creation traceability — outweighs what day
+precision bought (the cut date embedded in the name), because git and GitHub already record the
+tag's date as metadata; the day in the name was redundant, while the milestone linkage has no
+substitute. The user-facing `versionName` keeps ADR 0021's no-counter rationale intact.
+
+## Enforcement
+
+Same as ADR 0021: `CONTRIBUTING.md` § *Versioning* is canonical, human-checked at cut via the
+pre-release checklist. No grep guard — the scheme is low-frequency. The milestone-at-creation
+rule is enforced socially at PR review (a PR without milestone is visible at a glance).
+
+## Revisit criteria
+
+- If months routinely end with no release, the rename chore recurs monthly → reconsider (e.g.
+  quarterly milestones, or dropping milestone traceability and returning to day precision).
+- If PR-to-release traceability ever stops mattering (e.g. releases become fully automated,
+  one-PR-per-release), the driver disappears — day precision would again be the simpler scheme.


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change.

Unblocks per-release PR traceability: with month + sequential tags (`v2026.07.1`) the release name is knowable before the cut, so the month's milestone can exist up front and every PR gets it at creation — replacing the old "leave the milestone unset until a release exists" rule.

### Technical detail

Release tags, GitHub release titles and CHANGELOG headers move from day-precision CalVer (`vYYYY.MM.DD`) to month + sequential counter (`vYYYY.MM.N`).

- **ADR 0023 (new)** — amends ADR 0021's tag scheme only; records why the "no sequential counter" driver is reversed for tags (git already stores the cut date as metadata; the milestone linkage has no substitute). Back-pointer added in ADR 0021's Status, following the 0008 ↔ 0018 convention.
- **CONTRIBUTING** — § *Versioning* rewritten; same-day `-2` hack removed; checklist stamps `## [vYYYY.MM.N] - YYYY-MM-DD` (cut-date suffix survives in the header); new release step closes the milestone at cut; new § *Milestone operations* documents deriving `N` + the `gh api` commands.
- **CLAUDE.md** — § *Labels and milestone* rule rewritten to assign the month's milestone at PR creation; § *Changelog* header format updated. Net **−42 bytes** (file was 118 bytes from the 40K gate).
- **Deliberately unchanged:** `versionName` (`YYYY.MM`), `versionCode`, the SemVer frontier (≤ `v2.3.0`), and the no-grep-guard enforcement posture from ADR 0021.

### Code review tips

- No CalVer tag exists yet (last: `v2.3.0`), so the scheme change touches zero real tags.
- Milestone housekeeping applied on GitHub tonight: the pre-existing `v2026.07.01` milestone (11 PRs/issues, created 2026-07-04) was renamed to the canonical `v2026.07.1` — rename preserves associations; a duplicate empty milestone briefly created in the process was deleted.
- This PR itself carries the new milestone — first application of the rule it introduces.

### Already tested

- ADR grep guards + CLAUDE.md 40K gate: `./scripts/check-adr-invariants.sh` green local
- Instrumented suite: exempt (docs-only change, CLAUDE.md § *Pre-PR checklists*)

🤖 Generated with [Claude Code](https://claude.com/claude-code)