### PR TITLE
docs(adr): ADR 0024 — Jetpack Navigation 3 as the navigation backbone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog][]. Through v2.3.0 this project used [S
 - ADR 0022 decides the playback architecture for the Media3 migration: measured hybrid — MediaPlayer stays on the tap path (80 ms vs ExoPlayer's 390 ms on device, AEP exception documented), Media3 + MediaSession take the listening sessions (Vault immersive, recorder review)
 - Long-form playback engine (`ListenSessionEngine`, Media3 ExoPlayer 1.10.1) behind the same `PlayerController` facade: Vault immersive listen and recorder review now play on it, reporting through the existing listener/StateFlow channels; list-row taps and add-flow previews stay on MediaPlayer (ADR 0022)
 - Audio duration extraction (import + add-preview) moved from the AEP-prohibited `MediaMetadataRetriever` to Media3's `MetadataRetriever` (`media3-inspector`), keeping the same failure UX and Crashlytics grouping (ADR 0022 / spec 002e)
+- ADR 0024 decides the navigation architecture: Jetpack Navigation 3 (multi-back-stack tabs, shared `SoundsViewModel`, hybrid creation flows keeping a share-sheet trampoline Activity), amending ADR 0011 — automatic predictive back replaces the manual per-surface machinery as screens become destinations
 
 #### Changed
 - Release tags, GitHub release titles and CHANGELOG headers move from day-precision CalVer (`vYYYY.MM.DD`) to month + sequential counter (`vYYYY.MM.N`), so the month's milestone can be created up front and assigned to every PR at creation (ADR 0023 amending ADR 0021)

--- a/docs/adr/0011-predictive-back-navigation.md
+++ b/docs/adr/0011-predictive-back-navigation.md
@@ -3,6 +3,9 @@
 - **Status:** Accepted (with explicit revisit criteria)
 - **Date:** 2026-05-21
 - **Supersedes:** —
+- **Amended:** 2026-07-05 by [ADR 0024](0024-jetpack-navigation-3.md) (§ Revisit criteria — the
+  Navigation 3 criterion fired: surfaces migrating to Nav3 destinations drop the manual machinery;
+  the convention stays for non-route overlays)
 
 ## Context
 
@@ -58,8 +61,9 @@ legitimately used by swallowers, so a blanket grep guard would over-match.
 
 ## Revisit criteria
 
-When the **Navigation 3 migration (backlog 08)** lands, predictive back between
-destinations becomes automatic. At that point the manual
+When the **Navigation 3 migration (backlog `003-nav3-migration.md`)** lands, predictive back
+between destinations becomes automatic — decided by [ADR 0024](0024-jetpack-navigation-3.md);
+this criterion fired. At that point the manual
 `predictiveBackTransition`, the layering, the `clearAndSetSemantics` occlusion,
 and the per-surface handlers in `SearchOverlay` / `AboutScreen` /
 `ManageCollectionsScreen` are simplified or removed. Re-evaluate this ADR then.

--- a/docs/adr/0024-jetpack-navigation-3.md
+++ b/docs/adr/0024-jetpack-navigation-3.md
@@ -1,0 +1,153 @@
+# ADR 0024 — Jetpack Navigation 3 as the in-app navigation backbone
+
+- **Status:** Accepted
+- **Date:** 2026-07-05
+- **Supersedes:** Amends [ADR 0011](0011-predictive-back-navigation.md) (its revisit
+  criterion — "when the Navigation 3 migration lands" — fires with this epic: the manual
+  `predictiveBackTransition` machinery is simplified or removed for every surface that becomes a
+  Nav3 destination; the convention survives only for non-route overlays). Reaffirms
+  [ADR 0002](0002-no-hilt-manual-viewmodel-factory.md) (Nav3 scopes ViewModels without a DI
+  framework). Does not touch [ADR 0003](0003-channel-for-one-shot-ui-events.md) (one-shot event
+  model unchanged). Informs [ADR 0019](0019-in-app-bomp-recorder.md) (`RecordingActivity` is
+  remodeled as a graph destination in sub-spec `003c`; recorder behavior — capture, bounds, draft
+  recovery — stands).
+
+## Context
+
+The app has **no `NavHost` today**. Navigation is hand-rolled state in `LandingScreen.kt`:
+
+- **Tabs:** `AppTab { MY_SOUNDS, VAULT, EXPLORE_SOUNDS }` selected via a `StateFlow` in
+  `SoundsViewModel`, plus a manual `tabBackStack = mutableStateListOf<AppTab>()` popped by a
+  `BackHandler` — rudimentary multi-tab history, not a per-tab stack.
+- **Seven overlays** (About, ManageCollections, ImmersiveListen, OnboardingTour, BringFromApps,
+  ImportHub bottom sheet, Search) toggled by booleans / `rememberSaveable` state, most wiring
+  predictive back manually per ADR 0011 (layering + `clearAndSetSemantics` + per-surface handlers).
+- **Three Activities:** `LandingActivity` (launcher + `push-me://open` deep link),
+  `AddButtonActivity` (creation/edit hub with 4 entry points, one external via `ACTION_SEND`),
+  `RecordingActivity` (recorder, hands off to `AddButtonActivity`).
+- **Deep links:** a manual `when (uri.path)` in `LandingActivity.handleDeeplink` with a closed
+  allowlist and a fall-back-to-Home security invariant (CLAUDE.md § *Deep link path allowlist*).
+
+That model is at its load limit: back semantics are re-derived per surface, overlay payloads need
+hand-written `Saver`s, and every upcoming feature (adaptive layouts spec `001`, trimmer `009`,
+smart naming `010`, re-record `011`) would grow the boolean lattice. Meanwhile Jetpack
+Navigation 3 reached GA (stable `1.1.x`; `1.1.4` at this ADR's date) with a Compose-first,
+owner-held back stack model: predictive back between destinations is automatic, destinations are
+plain `@Serializable` keys, and the Scenes API provides the list-detail/two-pane layouts the
+adaptive spec needs.
+
+## Decision
+
+Migrate in-app navigation to **Jetpack Navigation 3** (`androidx.navigation3:navigation3-runtime`
++ `navigation3-ui`, stable `1.1.x`). Four sub-decisions:
+
+### D1 — Navigation 3, not Compose Navigation 2 nor third-party
+
+Nav3 gives natively what this codebase wires by hand: automatic predictive back between
+destinations (retires most of ADR 0011's manual machinery), a typed back stack the app owns
+(`NavBackStack` of `@Serializable` keys — the `tabBackStack` + booleans model, formalized),
+`SavedStateHandle`/ViewModel integration, and Scenes for adaptive layouts (spec `001` consumes
+them). Compose Navigation 2 is in maintenance orbit — Google's investment moved to Nav3, and
+migrating twice (2 → 3) would cost more than adopting 3 directly. Third-party routers
+(Decompose, Voyager, Circuit) add a non-platform dependency and idioms without a compensating
+capability. Google's official `navigation-3` skill — linked at `.claude/skills/navigation-3/`
+(CLAUDE.md § *Sources of truth*) — is the prescribed technical source.
+
+### D2 — Multi-back-stack for the tabs
+
+Each of the three tabs keeps its own stack (recipe `multiple-backstacks`); back pops within the
+active tab before crossing tabs. This is the platform-native expectation, Nav3 provides it
+directly, and the future multi-step flows (`009`/`011`) land inside a tab's stack without a
+second migration. The current single `tabBackStack` list is retired.
+
+### D3 — `SoundsViewModel` stays shared; ephemeral ViewModels go per-destination
+
+`SoundsViewModel` is scoped to the Activity/NavHost level: Search and cross-tab counters share
+`SoundsRepository` state, and the tabs are views over the same catalogue — per-destination copies
+would fragment it. Screen-lifetime ViewModels (recorder, future trimmer) scope to their
+destination via Nav3's ViewModel integration. Both continue through manual `viewModelFactory`
+(ADR 0002 reaffirmed — no DI framework needed).
+
+### D4 — Hybrid for the creation Activities
+
+**Internal** creation/edit flows (Edit from My Sounds, Import → name, Record → preview → name)
+become graph destinations: continuous predictive back and coherent step-wise back semantics
+(name → back → preview → back → record), which Activities can't give without faking it. The
+**external** `ACTION_SEND audio/*` entry stays a thin **trampoline Activity** delegating to the
+same naming destination/logic: the share-sheet contract (`excludeFromRecents`, back returns to
+the source app, no ghost entry in Recents) is a task/manifest-level guarantee that a graph
+destination inside Landing's task cannot honor. Full fusion was rejected for exactly that
+contract; keeping full Activities for internal flows was rejected because it forfeits the epic's
+user-visible payoff. Inbound-URI validation (CLAUDE.md § *Security boundaries*) is untouched —
+the same validator runs regardless of who invokes it.
+
+### Deep links: declarative, same allowlist
+
+The `push-me://open` allowlist moves into the graph as declarative mappings (`/home` → Home,
+`/explore` → Explore) with the **unknown-path → Home fallback preserved as the `else`** — the
+security invariant of CLAUDE.md § *Deep link path allowlist* survives the API change verbatim,
+including the extra "Explore without bundled audios → Home" guard.
+
+### Execution: three PRs
+
+This ADR (docs) → `003b` Landing/NavHost core (adds the dependency, migrates tabs + overlays +
+deep links) → `003c` creation flows + trampoline. Split because the Landing migration verifies
+against existing behavior ("no screen changes") while the creation remodel has its own blast
+radius (share-sheet contract, back semantics). Rationale lives in the master spec's
+*Descomposición en PRs*.
+
+## Options considered (and rejected)
+
+- **Compose Navigation 2** — mature, but string/route-centric with predictive back and typed
+  stacks retrofitted; guaranteed second migration once Nav3 is the default. Rejected: pay the
+  migration once.
+- **Third-party (Decompose / Voyager / Circuit)** — capable, but off-platform idioms, extra
+  dependency risk, and no Scenes/Material-adaptive alignment. Rejected.
+- **Single unified back stack (vs D2)** — simpler mental model but loses per-tab history, against
+  platform convention, and re-opens when multi-step flows land. Rejected.
+- **Full fusion of creation flows (vs D4)** — everything a destination, including the share-sheet
+  entry. Rejected: breaks `excludeFromRecents` + back-to-source-app, i.e. Bomp would appear
+  "open" in Recents after a share.
+- **Do nothing** — the boolean lattice keeps compounding; every future feature re-derives back
+  semantics; adaptive spec `001` would build Scenes-like behavior by hand. Rejected.
+
+## Consequences
+
+- `androidx.navigation3` (`navigation3-runtime`, `navigation3-ui`) enters the production
+  dependency graph in `003b` (with `app_third_party_notices.txt` updated there — this PR is
+  docs-only).
+- ADR 0011's manual predictive-back machinery (layering, `clearAndSetSemantics` occlusion,
+  per-surface handlers) is removed or simplified for every surface that becomes a destination.
+  The `predictiveBackTransition` convention remains valid for non-route overlays (Search stays
+  one deliberately — UI layered over a destination, not a place you navigate to).
+- Overlay payloads currently carried by hand-written `Saver`s (e.g. the `ManageRequest` sealed
+  class) become typed route arguments; the back stack itself is saveable/restorable across
+  process death (`rememberNavBackStack` + `@Serializable` keys).
+- `VaultSessionState` keeps its process-scoped, non-persisted semantics: Vault access is modeled
+  as conditional navigation, and a restored back stack must re-request biometrics.
+- Once internal navigation goes through the graph, `startActivity` stops being a legitimate
+  internal-navigation mechanism; a grep invariant for it is added to
+  `scripts/check-adr-invariants.sh` by `003b`/`003c` (where the code changes), not by this PR.
+- `DeepLinkTest` is rewritten against Nav3's API in `003b`; the asserted behavior (allowlist +
+  Home fallback) is the invariant, not the API shape.
+
+## Revisit criteria
+
+Reopen this decision when **any** of:
+
+1. **Nav3 stagnates or a needed capability regresses** (e.g. Scenes or predictive back breaks on
+   a stable release without a fix path) while Compose Navigation or a successor reactivates.
+2. **The trampoline proves unable to preserve the share-sheet contract** in `003c` prototyping —
+   D4's hybrid premise fails and the creation-flow split must be redrawn.
+3. **A future feature needs navigation semantics Nav3 cannot express** (deep-link shapes, task
+   manipulation) forcing parallel manual routing back in — the single-backbone premise breaks.
+
+## Cross-references
+
+- Specs: `../push-me-backlog/backlog/003-nav3-migration.md` (+ sub-specs `003a`–`003c`; decision
+  log in its § 3).
+- Skill: `.claude/skills/navigation-3/` (linked skill, CLAUDE.md § *Sources of truth*; recipes
+  `multiple-backstacks`, `conditional`, `deeplinks-advanced`, `bottomsheet`, `passingarguments`,
+  `results-event`, `migration-guide`).
+- Navigation 3 guide: https://developer.android.com/guide/navigation/navigation-3
+- Release notes: https://developer.android.com/jetpack/androidx/releases/navigation3


### PR DESCRIPTION
### Summary
Internal — no user-visible behavior change.

Records the architecture decision for the Navigation 3 epic (backlog `003-nav3-migration.md`), unblocking the Landing→NavHost migration PR: the repo's ADR-first override requires this decision merged before the Nav3 dependency can enter the graph. The user-visible payoff it sets up: continuous predictive back across tabs, overlays and creation flows.

### Technical detail
New `docs/adr/0024-jetpack-navigation-3.md` formalizing the owner's decisions (spec 003 § 3):

- **D1 — Navigation 3** (GA 1.1.x) over Compose Navigation 2 / third-party routers: native predictive back, typed `NavBackStack`, Scenes for the adaptive spec.
- **D2 — Multi-back-stack tabs** (per-tab history), retiring the manual `tabBackStack`.
- **D3 — `SoundsViewModel` stays Activity/NavHost-scoped**; ephemeral screen VMs go per-destination (ADR 0002 reaffirmed — no DI framework).
- **D4 — Hybrid creation flows**: internal flows become graph destinations; the external `ACTION_SEND` keeps a trampoline Activity to preserve the share-sheet contract (`excludeFromRecents`, back-to-source).
- **ADR 0011 back-annotated**: its Nav3 revisit criterion fired — amended header + updated stale `backlog 08` pointer.
- **Deliberately unchanged**: no code, no dependency yet (both land in the follow-up PRs), ADR 0003 untouched.

### Code review tips
- The deep-link security invariant (unknown path → Home) is restated in the ADR — check the wording matches CLAUDE.md § *Deep link path allowlist* since both must stay coherent.
- The `navigation-3` skill referenced as prescribed source is a **local symlink** to `~/Workspace/android-skills` (untracked); the ADR wording says "linked", matching CLAUDE.md. Vendoring it is a separate decision.

### Already tested
- [x] `./scripts/check-adr-invariants.sh` green locally (also enforced by CI + pre-push hook)