### PR TITLE
fix(analytics): emit screen_view from composition, not Activity.onCreate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog][]. Through v2.3.0 this project used [S
 - Waveform envelope extraction demuxes via Media3's `MediaExtractorCompat` instead of the AEP-prohibited `MediaExtractor` (`MediaCodec` decode unchanged); all sources normalize to per-decode temp files to route around a Media3 1.10.1 truncation bug with fd/content/resource sources — envelope verified bit-comparable (1 of 48 bars off by 0.014)
 
 #### Fixed
+- `screen_view` for the add/edit-Bomp and recorder screens now fires from composition instead of `Activity.onCreate`, where the GA4 SDK silently dropped it — `add_sound`, `edit_sound` and `record_sound` had never reached the analytics export
 - The My Sounds visibility toggle now updates the visible list synchronously (mirroring the pin toggle) instead of waiting for the DataStore write to round-trip back through `loadSounds`, removing the async dependency that made `SoundsViewModelVisibilityTest` time out under CI load
 
 ## \[v2.3.0] - 2026-06-28

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivity.kt
@@ -17,8 +17,6 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.fragment.app.FragmentActivity
 import com.github.barriosnahuel.vossosunboton.R
-import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
-import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.ui.home.LandingActivity
 import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
@@ -26,6 +24,11 @@ import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
 // FragmentActivity (vs ComponentActivity) is required so the Add/Edit tagging UI can fire
 // BiometricPrompt when the user requests to assign the new audio to a private collection.
 class AddButtonActivity : FragmentActivity() {
+    // Monotonic per-instance intent sequence. Each handleIntent call is a distinct user intent and
+    // must re-emit screen_view even when the payload is structurally identical to the live screen's
+    // (e.g. re-sharing the same audio) — AddButtonScreen keys its logging effect on this.
+    private var intentSequence = 0
+
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge(statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT))
         super.onCreate(savedInstanceState)
@@ -42,6 +45,7 @@ class AddButtonActivity : FragmentActivity() {
     }
 
     private fun handleIntent(intent: Intent) {
+        intentSequence++
         val editSound: Sound? =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 intent.getParcelableExtra(LandingActivity.EXTRA_EDIT_SOUND, Sound::class.java)
@@ -78,12 +82,12 @@ class AddButtonActivity : FragmentActivity() {
                 AddButtonScreen(
                     context = this,
                     mode = AddButtonMode.Edit(sound),
+                    intentKey = intentSequence,
                     onSaved = { finish() },
                     onNavigateUp = { finish() },
                 )
             }
         }
-        AnalyticsTrackerProvider.get(this).logScreen(CanonicalScreenName.EDIT_SOUND)
     }
 
     private fun launchCreateAddButtonMode(
@@ -96,13 +100,12 @@ class AddButtonActivity : FragmentActivity() {
                     context = this,
                     mode = AddButtonMode.Create(uri),
                     source = source,
+                    intentKey = intentSequence,
                     onSaved = { finish() },
                     onNavigateUp = { finish() },
                 )
             }
         }
-        val extras = Bundle().apply { putString("source", source) }
-        AnalyticsTrackerProvider.get(this).logScreen(CanonicalScreenName.ADD_SOUND, extras)
     }
 
     companion object {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreen.kt
@@ -6,6 +6,7 @@
 package com.github.barriosnahuel.vossosunboton.feature.addbutton
 import android.content.Context
 import android.net.Uri
+import android.os.Bundle
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.layout.Arrangement
@@ -72,6 +73,7 @@ import com.github.barriosnahuel.vossosunboton.commons.android.analytics.Analytic
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsSource
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTracker
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.commons.file.getFile
 import com.github.barriosnahuel.vossosunboton.feature.recorder.RecorderDraftStoreProvider
@@ -99,6 +101,9 @@ fun AddButtonScreen(
     // Surface that opened this Create flow, forwarded to the `sound_add` event. Defaults to share
     // (the manifest ACTION_SEND path); the import Hub passes SOURCE_IMPORT. Ignored in Edit mode.
     source: String = AddButtonActivity.SOURCE_SHARE,
+    // Host-provided intent sequence: bumped per user intent so screen_view re-emits even when a
+    // new intent carries a payload structurally equal to the live one (same audio re-shared).
+    intentKey: Int = 0,
     onSaved: (String) -> Unit,
     onNavigateUp: () -> Unit,
 ) {
@@ -123,6 +128,19 @@ fun AddButtonScreen(
     val tracker = remember(context) { AnalyticsTrackerProvider.get(context.applicationContext) }
     val nameFocusRequester = remember { FocusRequester() }
     val view = LocalView.current
+
+    // screen_view is owned by this composable, not the host Activity: a manual GA4 screen_view
+    // logged from Activity.onCreate (before the Activity is in focus) is silently dropped by the
+    // SDK, so it must fire from composition — Firebase docs say to log it in onResume. Keyed by
+    // (mode, source, intentKey) so a new intent over the live screen re-emits — including one whose
+    // payload equals the current screen's — matching the one-screen_view-per-user-intent contract.
+    LaunchedEffect(mode, source, intentKey) {
+        when (mode) {
+            is AddButtonMode.Create ->
+                tracker.logScreen(CanonicalScreenName.ADD_SOUND, Bundle().apply { putString("source", source) })
+            is AddButtonMode.Edit -> tracker.logScreen(CanonicalScreenName.EDIT_SOUND)
+        }
+    }
 
     // Reactive lookup against the user's library (custom + bundled). Derivation, predicate, and
     // the supporting `produceState` live in `DuplicateNameHint.kt` so this composable stays under

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivity.kt
@@ -58,7 +58,6 @@ class RecordingActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge(statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT))
         super.onCreate(savedInstanceState)
-        AnalyticsTrackerProvider.get(this).logScreen(CanonicalScreenName.RECORD_SOUND)
         // Restore a pending draft when launched from the Landing banner; otherwise start fresh. Guarded
         // inside the VM so a config-change recreate (which keeps the VM) doesn't re-run it.
         viewModel.onEnter(resumeDraft = intent.getBooleanExtra(EXTRA_RESUME_DRAFT, false))
@@ -78,6 +77,11 @@ class RecordingActivity : FragmentActivity() {
     @Composable
     private fun RecorderHost() {
         val context = LocalContext.current
+        // screen_view fires from composition, not onCreate: a manual GA4 screen_view logged before
+        // the Activity is in focus is silently dropped by the SDK (Firebase docs: log in onResume).
+        LaunchedEffect(Unit) {
+            AnalyticsTrackerProvider.get(context.applicationContext).logScreen(CanonicalScreenName.RECORD_SOUND)
+        }
         val snackbarHostState = remember { SnackbarHostState() }
         var granted by remember { mutableStateOf(hasMicPermission()) }
         // Saveable: durable progress (the denied/settings screen, an open discard dialog) must survive an

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivityIntentDispatchTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivityIntentDispatchTest.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
@@ -24,6 +25,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.robolectric.Robolectric
 import org.robolectric.android.controller.ActivityController
@@ -45,6 +47,11 @@ import org.robolectric.annotation.Config
  */
 @Config(sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
 internal class AddButtonActivityIntentDispatchTest : AbstractRobolectricTest() {
+    // screen_view now fires from AddButtonScreen's composition (not the Activity), so screen
+    // asserts must flush the pending frame first: waitForIdle after every launch/newIntent.
+    @get:Rule
+    val composeTestRule = createEmptyComposeRule()
+
     private val context: Context get() = ApplicationProvider.getApplicationContext()
 
     private lateinit var fake: FakeAnalyticsTracker
@@ -83,6 +90,7 @@ internal class AddButtonActivityIntentDispatchTest : AbstractRobolectricTest() {
         assertThat(fake.screens.map { it.name }).contains(CanonicalScreenName.EDIT_SOUND)
 
         controller!!.newIntent(shareIntent(SAMPLE_URI))
+        composeTestRule.waitForIdle()
 
         val addScreen =
             fake.screens.lastOrNull { it.name == CanonicalScreenName.ADD_SOUND }
@@ -108,10 +116,24 @@ internal class AddButtonActivityIntentDispatchTest : AbstractRobolectricTest() {
         assertThat(fake.screens.count { it.name == CanonicalScreenName.ADD_SOUND }).isEqualTo(1)
 
         controller!!.newIntent(shareIntent(OTHER_URI))
+        composeTestRule.waitForIdle()
 
         assertThat(fake.screens.count { it.name == CanonicalScreenName.ADD_SOUND }).isEqualTo(2)
         assertThat(activity.intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java))
             .isEqualTo(OTHER_URI)
+    }
+
+    @Test
+    fun `share intent arriving with the same audio re-emits screen_view`() {
+        // Re-sharing the exact same file is still a fresh user intent: the screen must re-emit
+        // even though (mode, source) are structurally identical to the live composition's.
+        launch(shareIntent(SAMPLE_URI))
+        assertThat(fake.screens.count { it.name == CanonicalScreenName.ADD_SOUND }).isEqualTo(1)
+
+        controller!!.newIntent(shareIntent(SAMPLE_URI))
+        composeTestRule.waitForIdle()
+
+        assertThat(fake.screens.count { it.name == CanonicalScreenName.ADD_SOUND }).isEqualTo(2)
     }
 
     @Test
@@ -123,6 +145,7 @@ internal class AddButtonActivityIntentDispatchTest : AbstractRobolectricTest() {
         assertThat(fake.screens.map { it.name }).contains(CanonicalScreenName.ADD_SOUND)
 
         controller!!.newIntent(editIntent())
+        composeTestRule.waitForIdle()
 
         assertThat(fake.screens.map { it.name }).contains(CanonicalScreenName.EDIT_SOUND)
         assertThat(activity.intent.getParcelableExtra(LandingActivity.EXTRA_EDIT_SOUND, Sound::class.java))
@@ -165,6 +188,7 @@ internal class AddButtonActivityIntentDispatchTest : AbstractRobolectricTest() {
         val malformed = Intent(context, AddButtonActivity::class.java)
 
         controller!!.newIntent(malformed)
+        composeTestRule.waitForIdle()
 
         assertThat(activity.isFinishing).isTrue()
     }
@@ -176,11 +200,17 @@ internal class AddButtonActivityIntentDispatchTest : AbstractRobolectricTest() {
     private fun launch(intent: Intent): AddButtonActivity {
         val newController = Robolectric.buildActivity(AddButtonActivity::class.java, intent)
         controller = newController
-        return newController
-            .create()
-            .start()
-            .resume()
-            .get()
+        val activity =
+            newController
+                .create()
+                .start()
+                .resume()
+                // Attach the view hierarchy: without visible() the composition never gets a frame,
+                // so the screen_view LaunchedEffect would not run.
+                .visible()
+                .get()
+        composeTestRule.waitForIdle()
+        return activity
     }
 
     private fun shareIntent(uri: Uri): Intent =

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivitySdkBoundaryTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonActivitySdkBoundaryTest.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
@@ -23,6 +24,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.robolectric.Robolectric
 import org.robolectric.android.controller.ActivityController
@@ -42,6 +44,11 @@ import org.robolectric.annotation.Config
  */
 @Config(sdk = [Build.VERSION_CODES.M, Build.VERSION_CODES.TIRAMISU]) // sdk-boundary: handleIntent branches on SDK_INT >= TIRAMISU
 internal class AddButtonActivitySdkBoundaryTest : AbstractRobolectricTest() {
+    // screen_view now fires from AddButtonScreen's composition (not the Activity): flush the
+    // pending frame (waitForIdle in launch) before asserting on fake.screens.
+    @get:Rule
+    val composeTestRule = createEmptyComposeRule()
+
     private val context: Context get() = ApplicationProvider.getApplicationContext()
 
     private lateinit var fake: FakeAnalyticsTracker
@@ -81,11 +88,17 @@ internal class AddButtonActivitySdkBoundaryTest : AbstractRobolectricTest() {
     private fun launch(intent: Intent): AddButtonActivity {
         val newController = Robolectric.buildActivity(AddButtonActivity::class.java, intent)
         controller = newController
-        return newController
-            .create()
-            .start()
-            .resume()
-            .get()
+        val activity =
+            newController
+                .create()
+                .start()
+                .resume()
+                // Attach the view hierarchy: without visible() the composition never gets a frame,
+                // so the screen_view LaunchedEffect would not run.
+                .visible()
+                .get()
+        composeTestRule.waitForIdle()
+        return activity
     }
 
     private fun shareIntent(): Intent =

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenScreenViewTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/AddButtonScreenScreenViewTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.addbutton
+
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.CanonicalScreenName
+import com.github.barriosnahuel.vossosunboton.commons.android.analytics.FakeAnalyticsTracker
+import com.github.barriosnahuel.vossosunboton.testSound
+import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.robolectric.annotation.Config
+
+/**
+ * Pins that `screen_view {add_sound|edit_sound}` is emitted by [AddButtonScreen] itself, composing it
+ * directly — no host Activity. A manual GA4 `screen_view` logged from `Activity.onCreate` (before the
+ * Activity is in focus) is silently dropped by the SDK, so Activity-level logging never reaches the
+ * export; the Activity-launching tests can't catch that regression because the fake records the call
+ * either way.
+ */
+@Config(sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
+internal class AddButtonScreenScreenViewTest : AbstractRobolectricTest() {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+    private val fake = FakeAnalyticsTracker()
+
+    @Before
+    fun setUp() {
+        AnalyticsTrackerProvider.setForTest(fake)
+    }
+
+    @After
+    fun tearDown() {
+        AnalyticsTrackerProvider.setForTest(null)
+    }
+
+    @Test
+    fun `Create mode logs screen_view add_sound from the composable, tagged with its source`() {
+        composeTestRule.setContent {
+            AppTheme {
+                AddButtonScreen(
+                    context = context,
+                    mode = AddButtonMode.Create(Uri.parse(SAMPLE_URI)),
+                    source = AddButtonActivity.SOURCE_IMPORT,
+                    onSaved = {},
+                    onNavigateUp = {},
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        val screen = fake.assertScreenView(CanonicalScreenName.ADD_SOUND)
+        assertThat(screen.extras["source"]).isEqualTo(AddButtonActivity.SOURCE_IMPORT)
+    }
+
+    @Test
+    fun `Edit mode logs screen_view edit_sound from the composable`() {
+        composeTestRule.setContent {
+            AppTheme {
+                AddButtonScreen(
+                    context = context,
+                    mode = AddButtonMode.Edit(testSound(EXISTING_NAME, file = "existing.mp3")),
+                    onSaved = {},
+                    onNavigateUp = {},
+                )
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        fake.assertScreenView(CanonicalScreenName.EDIT_SOUND)
+    }
+
+    private companion object {
+        const val SAMPLE_URI = "content://media/external/audio/1"
+        const val EXISTING_NAME = "Existing sound"
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivitySmokeTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/recorder/RecordingActivitySmokeTest.kt
@@ -53,6 +53,7 @@ internal class RecordingActivitySmokeTest : AbstractRobolectricTest() {
     @Test
     fun emitsTheRecordSoundScreenView() {
         ActivityScenario.launch(RecordingActivity::class.java).use {
+            composeTestRule.waitForIdle()
             fake.assertScreenView(CanonicalScreenName.RECORD_SOUND)
         }
     }


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change.

Restores funnel observability for the creation flow: `screen_view {add_sound|edit_sound|record_sound}` had **never** reached the GA4 export (verified in BigQuery over the app's full history), leaving analytics blind exactly at the step where users abandon the add-a-Bomp funnel.

### Technical detail

Manual GA4 `screen_view` logged from `Activity.onCreate` is silently dropped — the SDK needs the Activity in focus ([Firebase docs](https://firebase.google.com/docs/analytics/screenviews): log in `onResume`). Every screen logged from composition arrives; the three logged from `onCreate` never did.

- **`AddButtonScreen`** now owns its `screen_view` via `LaunchedEffect(mode, source, intentKey)` — same pattern as `LandingScreen`'s navigation logger
- **`AddButtonActivity`** drops both `logScreen` calls; adds `intentSequence`, bumped per `handleIntent`, so re-sharing the *same* audio over the live `singleTask` instance still re-emits (structural keys alone under-fire — payload is equal)
- **`RecordingActivity`** moves `record_sound` into `RecorderHost`'s composition
- **Tests**: `AddButtonScreenScreenViewTest` (new) pins that the *composable* emits — Activity-launching tests can't catch a revert to `onCreate` logging; controller-based tests add `.visible()` + `waitForIdle` (no attach → no frame → no effect)
- **Unchanged**: event names/params, `sound_add` and the rest of the funnel instrumentation

### Code review tips

- The `intentKey` nonce is load-bearing: without it, `LaunchedEffect(mode, source)` won't re-fire for a new intent with an identical payload (same file re-shared). Covered by the new same-URI dispatch test.
- `RecordingActivity` is `singleTask` without `onNewIntent`: re-entry over a live instance doesn't re-emit — pre-existing gap, unchanged by this PR (before, only `onCreate` logged too).
- Fakes can't verify GA4 *acceptance* — only call ownership. Manual verification suggested: DebugView / `adb logcat -s FA FA-SVC` smoke on the three screens before merge (CONTRIBUTING § Analytics).
- `HomeTabFlowTest.shareButtonEmitsActionSendChooserIntent` is red in isolation on base too — verified via `git stash -u && ./scripts/run-instrumented-tests.sh -Pandroid.testInstrumentationRunnerArguments.class=com.github.barriosnahuel.vossosunboton.ui.home.HomeTabFlowTest` on origin/develop. Not from this PR (it passes within full-suite order).

### Already tested

- [x] instrumented (feature.* half, incl. addbutton + recorder): corridos local, 73/73 verdes
- [x] instrumented (ui.* + screenshots half): corridos local, 54/57 — 2 skips pre-existentes (locale-gated) + 1 rojo pre-existente verificado en base (ver Code review tips). Corrida partida en mitades cold-booted por presión de memoria del host; cobertura completa 130/130 ejecutados