### PR TITLE
docs(claude-md): screen_view must fire from composition, never onCreate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,16 +173,16 @@ Full checklists: CONTRIBUTING.md § *Testing → Pre-PR checklist* / *Pre-push c
 
 ## Analytics events
 
-Firebase Analytics goes through the `AnalyticsTracker` wrapper (`commons_android/.../analytics/`); the catalogue is three sibling files — `AnalyticsEvent` (one subclass per custom event), `CanonicalScreenName` (every `screen_view` literal), `AnalyticsUserProperty` (user-property names + lifetime counter keys).
+Firebase Analytics goes through the `AnalyticsTracker` wrapper (`commons_android/.../analytics/`); the catalogue is three sibling files — `AnalyticsEvent` (custom events), `CanonicalScreenName` (`screen_view` literals), `AnalyticsUserProperty` (user properties + counter keys).
 
 Hard rules:
 
 - Never call `FirebaseAnalytics.getInstance(...)` or `.logEvent(...)` outside the wrapper — the `analytics-wrapper-guard` CI job fails the build.
-- Auto `screen_view` is disabled via manifest meta-data; every screen emits `tracker.logScreen(CanonicalScreenName.X)` manually with a canonical literal.
+- Auto `screen_view` is disabled via manifest meta-data; every screen emits `tracker.logScreen(CanonicalScreenName.X)` manually with a canonical literal — from composition (`LaunchedEffect`), never `Activity.onCreate`: GA4 silently drops a `screen_view` logged before the Activity is in focus (guard: `AddButtonScreenScreenViewTest`).
 - The `first_*` variant is emitted by the wrapper when the event declares `hasFirstVariant = true` — call-sites never reference `first_*` directly.
-- In tests: substitute with `AnalyticsTrackerProvider.setForTest(FakeAnalyticsTracker())`, assert with `fake.assertEmitted(...)` / `fake.assertScreenView(...)`. Never mock `AnalyticsTracker` directly. Fake lives in `:commons_android` test fixtures.
+- In tests: substitute with `AnalyticsTrackerProvider.setForTest(FakeAnalyticsTracker())`, assert with `fake.assertEmitted(...)` / `fake.assertScreenView(...)`. Never mock `AnalyticsTracker` directly.
 
-Naming rules, regression-test matrix, and DebugView / `adb logcat -s FA FA-SVC` verification in CONTRIBUTING.md § *Analytics events 📊*. Don't skip the manual smoke before merging — aggregated Reports have a 24–48 h delay.
+Naming rules, regression-test matrix, and DebugView / logcat verification in CONTRIBUTING.md § *Analytics events 📊*. Don't skip the manual smoke before merging — aggregated Reports have a 24–48 h delay.
 
 ## Error tracking (non-fatals)
 


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change.

Turns the root cause behind #1272 into a write-time invariant: no future screen can reintroduce `Activity.onCreate` screen logging, the silent failure mode that kept `add_sound`/`edit_sound`/`record_sound` out of the GA4 export for the app's entire history.

### Technical detail

One rule extended in CLAUDE.md § *Analytics events*, plus minimal same-section trims to stay under the 40K CI budget (`check-adr-invariants.sh`):

- **Extended**: the manual-`screen_view` bullet now says *from composition (`LaunchedEffect`), never `Activity.onCreate`* — with the why (GA4 drops pre-focus events) and the guard test pointer
- **Trimmed (same section, reference-time detail)**: catalogue parentheticals tightened; the fake's fixture location dropped (greppable by class name); exact logcat command dropped (lives in CONTRIBUTING § *Analytics events 📊*)
- Final size: 39,997 bytes (limit 40,000) — `/claude-md-audit` remains advisable before the next addition

### Code review tips

- Verify the trims lose no write-time signal: the removed bits are findable via grep or already canonical in CONTRIBUTING.

### Already tested

- [x] `./scripts/check-adr-invariants.sh` verde local (incluye el size-budget check)