### PR TITLE
refactor(nav): migrate Landing to Jetpack Navigation 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ The format is based on [Keep a Changelog][]. Through v2.3.0 this project used [S
 - Opening a Vault audio's listen screen now always starts it from the beginning — previously a reopened audio silently resumed from where it was left mid-clip
 
 ### Fixed
-- Opening the app no longer briefly flashes the "This is where the voices live" empty state while your Bomps are still loading — the list now waits for the first load before deciding what to show
+- Opening the app no longer briefly flashes an empty state — inspirational or a collection filter's "no results" — while your Bomps are still loading; the list now waits for the first load before deciding what to show
+- An audio hidden from My Bomps (Vault-only) can no longer briefly reappear in the list right after opening the app — concurrent list refreshes could land out of order and show a stale view
 
 ### For nerds 🤓
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog][]. Through v2.3.0 this project used [S
 - ADR 0024 decides the navigation architecture: Jetpack Navigation 3 (multi-back-stack tabs, shared `SoundsViewModel`, hybrid creation flows keeping a share-sheet trampoline Activity), amending ADR 0011 — automatic predictive back replaces the manual per-surface machinery as screens become destinations
 
 #### Changed
+- In-app navigation runs on Jetpack Navigation 3 (`NavBackStack` per tab + typed destinations, ADR 0024): predictive back between screens is now automatic, tab history follows the platform's multi-back-stack semantics, and the manual per-overlay back wiring is gone
 - Release tags, GitHub release titles and CHANGELOG headers move from day-precision CalVer (`vYYYY.MM.DD`) to month + sequential counter (`vYYYY.MM.N`), so the month's milestone can be created up front and assigned to every PR at creation (ADR 0023 amending ADR 0021)
 - Waveform envelope extraction demuxes via Media3's `MediaExtractorCompat` instead of the AEP-prohibited `MediaExtractor` (`MediaCodec` decode unchanged); all sources normalize to per-decode temp files to route around a Media3 1.10.1 truncation bug with fd/content/resource sources — envelope verified bit-comparable (1 of 48 bars off by 0.014)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog][]. Through v2.3.0 this project used [S
 ### Changed
 - Opening a Vault audio's listen screen now always starts it from the beginning — previously a reopened audio silently resumed from where it was left mid-clip
 
+### Fixed
+- Opening the app no longer briefly flashes the "This is where the voices live" empty state while your Bomps are still loading — the list now waits for the first load before deciding what to show
+
 ### For nerds 🤓
 
 #### Added

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.google.firebase.crashlytics'
 apply plugin: 'com.google.firebase.firebase-perf'
 apply plugin: 'org.jetbrains.kotlin.plugin.compose'
+apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply from: "$project.rootProject.projectDir/linters.gradle"
 
 android {
@@ -172,6 +173,8 @@ dependencies {
     implementation libs.androidx.media3.session
     implementation libs.lifecycle.viewmodel.compose
     implementation libs.lifecycle.runtime.compose
+    implementation libs.androidx.navigation3.runtime
+    implementation libs.androidx.navigation3.ui
     implementation libs.coroutines.android
     implementation libs.coroutines.core
     implementation libs.androidx.datastore.preferences

--- a/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultImmersiveListenTest.kt
+++ b/app/src/androidTest/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultImmersiveListenTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.barriosnahuel.vossosunboton.AbstractUiTest
 import com.github.barriosnahuel.vossosunboton.R
@@ -63,6 +64,25 @@ internal class VaultImmersiveListenTest : AbstractUiTest() {
 
             // Back closes listen mode and reveals the Vault list again.
             composeRule.awaitNodeWithText(AUDIO_NAME).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun systemBackFromImmersiveListenModeStopsPlaybackAndReturnsToTheVaultList() {
+        seedVaultAudio()
+
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            composeRule.awaitNodeWithText(vaultLabel()).performClick()
+            composeRule.awaitNodeWithContentDescription(playLabel()).performClick()
+            composeRule.awaitNodeWithText(listenModeLabel()).assertIsDisplayed()
+
+            Espresso.pressBack()
+
+            // System back (the NavDisplay pop path) must mirror the top-bar back: listen mode
+            // closes AND the session stops — the row is back to its idle play affordance instead
+            // of a headless session still running behind the list.
+            composeRule.awaitNodeWithText(AUDIO_NAME).assertIsDisplayed()
+            composeRule.awaitNodeWithContentDescription(playLabel()).assertIsDisplayed()
         }
     }
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/collections/ManageCollectionsScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/collections/ManageCollectionsScreen.kt
@@ -64,7 +64,6 @@ import com.github.barriosnahuel.vossosunboton.model.Collection
 import com.github.barriosnahuel.vossosunboton.model.CollectionAccess
 import com.github.barriosnahuel.vossosunboton.ui.home.AppTab
 import com.github.barriosnahuel.vossosunboton.ui.home.SoundsViewModel
-import com.github.barriosnahuel.vossosunboton.ui.predictiveBackTransition
 import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
 import kotlinx.coroutines.delay
 
@@ -118,7 +117,7 @@ internal fun ManageCollectionsScreen(
     var deepLinkConsumed by rememberSaveable { mutableStateOf(false) }
 
     Scaffold(
-        modifier = modifier.predictiveBackTransition(onBack = onBack),
+        modifier = modifier,
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.app_manage_collections_title)) },

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/onboarding/BringFromAppsGuide.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/onboarding/BringFromAppsGuide.kt
@@ -5,7 +5,6 @@
  */
 package com.github.barriosnahuel.vossosunboton.feature.onboarding
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -40,7 +39,6 @@ import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
 internal fun BringFromAppsGuide(onClose: () -> Unit) {
     val reduceMotion = rememberReduceMotionEnabled()
     val step = ONBOARDING_IMPORT_STEP
-    BackHandler { onClose() }
     Scaffold(containerColor = MaterialTheme.colorScheme.surface) { innerPadding ->
         // Same cramped-window handling as OnboardingTour: portrait pins the CTA (the demo flexes via
         // weight); landscape / split-screen / large fonts switch to a fully scrollable column so the

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/ImmersiveListenScreen.kt
@@ -53,7 +53,6 @@ import com.github.barriosnahuel.vossosunboton.ui.AppIcons
 import com.github.barriosnahuel.vossosunboton.ui.home.SoundsViewModel
 import com.github.barriosnahuel.vossosunboton.ui.home.formatDuration
 import com.github.barriosnahuel.vossosunboton.ui.home.formatFullDate
-import com.github.barriosnahuel.vossosunboton.ui.predictiveBackTransition
 import com.github.barriosnahuel.vossosunboton.ui.theme.ImmersiveListenTheme
 import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
 
@@ -98,7 +97,7 @@ internal fun ImmersiveListenHost(
     if (sound == null) {
         // Library not hydrated yet (cold start / process recreate). Hold an opaque backdrop that
         // still honours back instead of flashing the Vault list behind it.
-        ImmersiveBackdrop(modifier = Modifier.predictiveBackTransition(onBack = onBack)) {
+        ImmersiveBackdrop(modifier = Modifier) {
             Column(modifier = Modifier.fillMaxSize().safeDrawingPadding()) {
                 ImmersiveTopBar(onBack = onBack)
             }
@@ -184,7 +183,7 @@ internal fun ImmersiveListenScreen(
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    ImmersiveBackdrop(modifier = modifier.predictiveBackTransition(onBack = onBack)) {
+    ImmersiveBackdrop(modifier = modifier) {
         // safeDrawingPadding keeps the content clear of the status/navigation bars while the
         // backdrop gradient still bleeds full-screen behind them (edge-to-edge).
         Column(modifier = Modifier.fillMaxSize().safeDrawingPadding()) {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultScreen.kt
@@ -42,6 +42,7 @@ import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsEvent
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsSource
@@ -293,7 +294,11 @@ private fun VaultBody(
     onActiveFilterEditClick: (String) -> Unit,
     onImmersivePlay: (Sound) -> Unit,
 ) {
-    val vaultAudios by viewModel.vaultAudios.collectAsState()
+    // Read BEFORE `vaultAudios`: loadSounds() writes the vault list before flipping the flag, so
+    // the mirrored flag→list read order guarantees a `true` flag never pairs with a stale empty
+    // list (cold-start ZRP flash). Don't move below the vaultAudios read.
+    val initialLoadComplete by viewModel.isInitialLoadComplete.collectAsStateWithLifecycle()
+    val vaultAudios by viewModel.vaultAudios.collectAsStateWithLifecycle()
     val activeFilter by viewModel.activeVaultFilter.collectAsState()
     val playbackProgress by viewModel.playbackProgress.collectAsState()
     val pausedProgress by viewModel.pausedProgress.collectAsState()
@@ -305,7 +310,9 @@ private fun VaultBody(
     val systemCollectionLabel = stringResource(R.string.app_vault_baul_name)
     val activeName =
         activeCollection?.let { if (it.isSystem) systemCollectionLabel else it.name }.orEmpty()
-    val showZrp = vaultAudios.isEmpty() && activeFilter == null
+    // Gated on the initial load (read above, before vaultAudios) so a cold start on the Vault tab
+    // never flashes the ZRP while the first loadSounds is still hydrating vaultAudios.
+    val showZrp = vaultAudios.isEmpty() && activeFilter == null && initialLoadComplete
     val showFilterEmpty = vaultAudios.isEmpty() && activeFilter != null
     // Header rendered alongside the chip row whenever the body shows real audios. ZRP and
     // filtered-empty states both hide it — header on top of an empty body is just noise.

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/vault/VaultScreen.kt
@@ -310,10 +310,11 @@ private fun VaultBody(
     val systemCollectionLabel = stringResource(R.string.app_vault_baul_name)
     val activeName =
         activeCollection?.let { if (it.isSystem) systemCollectionLabel else it.name }.orEmpty()
-    // Gated on the initial load (read above, before vaultAudios) so a cold start on the Vault tab
-    // never flashes the ZRP while the first loadSounds is still hydrating vaultAudios.
+    // Both empty states gate on the initial load (read above, before vaultAudios) so a cold start
+    // on the Vault tab never flashes the ZRP — nor the filtered "no results" for a persisted
+    // chip — while the first loadSounds + collections snapshot are still hydrating vaultAudios.
     val showZrp = vaultAudios.isEmpty() && activeFilter == null && initialLoadComplete
-    val showFilterEmpty = vaultAudios.isEmpty() && activeFilter != null
+    val showFilterEmpty = vaultAudios.isEmpty() && activeFilter != null && initialLoadComplete
     // Header rendered alongside the chip row whenever the body shows real audios. ZRP and
     // filtered-empty states both hide it — header on top of an empty body is just noise.
     val showHeader = !showZrp && !showFilterEmpty

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/about/AboutScreen.kt
@@ -75,7 +75,6 @@ import com.github.barriosnahuel.vossosunboton.commons.android.analytics.Analytic
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsTrackerProvider
 import com.github.barriosnahuel.vossosunboton.commons.android.error.Tracker
 import com.github.barriosnahuel.vossosunboton.ui.AppIcons
-import com.github.barriosnahuel.vossosunboton.ui.predictiveBackTransition
 import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
 import com.github.barriosnahuel.vossosunboton.util.withDeviceHl
 import kotlinx.coroutines.launch
@@ -123,7 +122,7 @@ fun AboutScreen(onBack: () -> Unit) {
     }
 
     Scaffold(
-        modifier = Modifier.predictiveBackTransition(onBack = onBack),
+        modifier = Modifier,
         topBar = {
             TopAppBar(
                 title = {},

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/ImportHubSheet.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/ImportHubSheet.kt
@@ -17,14 +17,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -37,7 +33,6 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
-import kotlinx.coroutines.launch
 
 // Dim applied to a disabled row's icon + text. Standard Material disabled opacity; a disabled
 // control is exempt from the WCAG 1.4.3 contrast minimum (§ Accessibility). All Hub rows are live
@@ -47,94 +42,70 @@ private val HUB_ICON_TILE = 44.dp
 private val HUB_TILE_RADIUS = 12.dp
 
 /**
- * The import Hub — a [ModalBottomSheet] opened by the + FAB on My Bomps. Rows are ordered by likely
- * intent for a returning user: "record" a new Bomp in-app ([onRecord], ADR 0019, the acid-primary row),
- * "bring audios from other apps" ([onBringFromApps]) that opens a focused single-step guide on sharing a
- * voice note in from WhatsApp/Telegram, and "import audio from your device" ([onImport]) for a file
- * already saved on the phone (the least-frequent path on Android 11+, where app-private media is not
- * SAF-browsable). The full 3-step onboarding tour is reachable from the empty state, not from here.
+ * The import Hub's sheet content — rendered inside the modal bottom sheet that the Nav3
+ * `BottomSheetSceneStrategy` provides for `ImportHubRoute` (swipe/scrim/back dismissal pop the
+ * route; ADR 0024). Rows are ordered by likely intent for a returning user: "record" a new Bomp
+ * in-app ([onRecord], ADR 0019, the acid-primary row), "bring audios from other apps"
+ * ([onBringFromApps]) that opens a focused single-step guide on sharing a voice note in from
+ * WhatsApp/Telegram, and "import audio from your device" ([onImport]) for a file already saved on
+ * the phone (the least-frequent path on Android 11+, where app-private media is not SAF-browsable).
+ * The full 3-step onboarding tour is reachable from the empty state, not from here.
  *
- * Presentational only: the caller dismisses on [onImport]/[onRecord]/[onBringFromApps]/[onDismiss] and
- * owns the file picker, the recorder Activity, and the guide state.
+ * Presentational only: the caller pops the route on [onImport]/[onRecord]/[onBringFromApps] and
+ * owns the file picker, the recorder Activity, and the guide destination.
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun ImportHubSheet(
     onImport: () -> Unit,
     onRecord: () -> Unit,
     onBringFromApps: () -> Unit,
-    onDismiss: () -> Unit,
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    val scope = rememberCoroutineScope()
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = sheetState,
-        containerColor = MaterialTheme.colorScheme.surface,
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Spacing.XL, vertical = Spacing.LG),
+        verticalArrangement = Arrangement.spacedBy(Spacing.SM),
     ) {
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = Spacing.XL, vertical = Spacing.LG),
-            verticalArrangement = Arrangement.spacedBy(Spacing.SM),
-        ) {
-            Text(
-                text = stringResource(R.string.app_hub_title),
-                style = MaterialTheme.typography.titleLarge,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Text(
-                text = stringResource(R.string.app_hub_subtitle),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(Modifier.height(Spacing.SM))
-            // Acid-primary row: recording is the one creation path that always works, regardless of what
-            // the user already has on the device. Animate the sheet closed before handing off, mirroring
-            // InlineCollectionCreateSheet (sheetState.hide() then the callback).
-            HubRow(
-                iconPainter = painterResource(R.drawable.app_ic_mic),
-                title = stringResource(R.string.app_hub_record),
-                subtitle = stringResource(R.string.app_hub_record_sub),
-                tileColor = MaterialTheme.colorScheme.primaryContainer,
-                iconColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                onClick = {
-                    scope.launch {
-                        sheetState.hide()
-                        onRecord()
-                    }
-                },
-            )
-            // Neutral tile (not acid) so it never competes with the primary record row. The share icon
-            // mirrors the gesture the guide teaches: "Share" a voice note from another app into Bomp.
-            HubRow(
-                iconPainter = painterResource(R.drawable.app_ic_share),
-                title = stringResource(R.string.app_hub_bring),
-                subtitle = stringResource(R.string.app_hub_bring_sub),
-                tileColor = MaterialTheme.colorScheme.surfaceVariant,
-                iconColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                onClick = {
-                    scope.launch {
-                        sheetState.hide()
-                        onBringFromApps()
-                    }
-                },
-            )
-            HubRow(
-                iconPainter = painterResource(R.drawable.app_ic_add),
-                title = stringResource(R.string.app_hub_import),
-                subtitle = stringResource(R.string.app_hub_import_sub),
-                tileColor = MaterialTheme.colorScheme.surfaceVariant,
-                iconColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                onClick = {
-                    scope.launch {
-                        sheetState.hide()
-                        onImport()
-                    }
-                },
-            )
-        }
+        Text(
+            text = stringResource(R.string.app_hub_title),
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = stringResource(R.string.app_hub_subtitle),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(Spacing.SM))
+        // Acid-primary row: recording is the one creation path that always works, regardless of what
+        // the user already has on the device.
+        HubRow(
+            iconPainter = painterResource(R.drawable.app_ic_mic),
+            title = stringResource(R.string.app_hub_record),
+            subtitle = stringResource(R.string.app_hub_record_sub),
+            tileColor = MaterialTheme.colorScheme.primaryContainer,
+            iconColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            onClick = onRecord,
+        )
+        // Neutral tile (not acid) so it never competes with the primary record row. The share icon
+        // mirrors the gesture the guide teaches: "Share" a voice note from another app into Bomp.
+        HubRow(
+            iconPainter = painterResource(R.drawable.app_ic_share),
+            title = stringResource(R.string.app_hub_bring),
+            subtitle = stringResource(R.string.app_hub_bring_sub),
+            tileColor = MaterialTheme.colorScheme.surfaceVariant,
+            iconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            onClick = onBringFromApps,
+        )
+        HubRow(
+            iconPainter = painterResource(R.drawable.app_ic_add),
+            title = stringResource(R.string.app_hub_import),
+            subtitle = stringResource(R.string.app_hub_import_sub),
+            tileColor = MaterialTheme.colorScheme.surfaceVariant,
+            iconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            onClick = onImport,
+        )
     }
 }
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -522,9 +522,16 @@ private fun TabContent(
     // the others are not composed.
     val listState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
-    LaunchedEffect(Unit) {
-        viewModel.scrollToTopEvent.collect {
-            listState.animateScrollToItem(0)
+    // Only the ACTIVE tab collects the one-shot scroll event: during a tab transition (or a
+    // predictive-back preview) two TabContent instances are composed at once, and the Channel's
+    // single delivery (ADR 0003) must not be consumed by the outgoing tab's collector.
+    val selectedTabNow by viewModel.selectedTab.collectAsStateWithLifecycle()
+    val isActiveTab = selectedTabNow == tab
+    LaunchedEffect(isActiveTab) {
+        if (isActiveTab) {
+            viewModel.scrollToTopEvent.collect {
+                listState.animateScrollToItem(0)
+            }
         }
     }
     Scaffold(

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -7,7 +7,6 @@
 
 package com.github.barriosnahuel.vossosunboton.ui.home
 import android.content.Context
-import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
@@ -49,22 +48,24 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.ui.NavDisplay
 import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsEvent
 import com.github.barriosnahuel.vossosunboton.commons.android.analytics.AnalyticsSource
@@ -84,8 +85,25 @@ import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.playstore.PlayStoreReferrer
 import com.github.barriosnahuel.vossosunboton.ui.AppIcons
 import com.github.barriosnahuel.vossosunboton.ui.about.AboutScreen
+import com.github.barriosnahuel.vossosunboton.ui.home.navigation.AboutRoute
+import com.github.barriosnahuel.vossosunboton.ui.home.navigation.BottomSheetSceneStrategy
+import com.github.barriosnahuel.vossosunboton.ui.home.navigation.BringFromAppsRoute
+import com.github.barriosnahuel.vossosunboton.ui.home.navigation.ExploreRoute
+import com.github.barriosnahuel.vossosunboton.ui.home.navigation.HomeRoute
+import com.github.barriosnahuel.vossosunboton.ui.home.navigation.ImmersiveListenRoute
+import com.github.barriosnahuel.vossosunboton.ui.home.navigation.ImportHubRoute
+import com.github.barriosnahuel.vossosunboton.ui.home.navigation.LandingNavigator
+import com.github.barriosnahuel.vossosunboton.ui.home.navigation.ManageCollectionsRoute
+import com.github.barriosnahuel.vossosunboton.ui.home.navigation.OnboardingRoute
+import com.github.barriosnahuel.vossosunboton.ui.home.navigation.VaultRoute
+import com.github.barriosnahuel.vossosunboton.ui.home.navigation.instantTabTransitions
+import com.github.barriosnahuel.vossosunboton.ui.home.navigation.rememberLandingNavigationState
+import com.github.barriosnahuel.vossosunboton.ui.home.navigation.toRoute
+import com.github.barriosnahuel.vossosunboton.ui.home.navigation.toTabOrNull
 import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -102,34 +120,36 @@ fun LandingScreen(viewModel: SoundsViewModel) {
     val searchResults by viewModel.searchResults.collectAsState()
     val isSearchPending by viewModel.isSearchPending.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
-    val listState = rememberLazyListState()
-    val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
     val tracker = remember(context) { AnalyticsTrackerProvider.get(context.applicationContext) }
-    val tabBackStack = remember { mutableStateListOf<AppTab>() }
-    // Saveable so a rotation while About / Manage are open does not silently bounce the user back
-    // to the sound list — those screens swap out the Scaffold body via a `when` below, and losing
-    // the flag = losing the screen.
-    var isAboutVisible by rememberSaveable { mutableStateOf(false) }
-    var manageRequest by rememberSaveable(stateSaver = ManageRequest.Saver) {
-        mutableStateOf<ManageRequest?>(null)
-    }
-    // Id of the Vault audio whose immersive listen-mode player is open, or null. Saveable so the
-    // overlay survives an Activity recreate (rotation, theme, system kill); the host re-resolves
-    // the Sound from `library` on the way back.
-    var immersiveListenSoundId by rememberSaveable { mutableStateOf<String?>(null) }
 
-    // Import Hub open state. Saveable so an Activity recreate (rotation, theme, system kill) while
-    // the sheet is open does not silently rewind the user back to the list (§ Stateful Composables).
-    var isHubVisible by rememberSaveable { mutableStateOf(false) }
-    // Onboarding tour: null = closed, 0..2 = open at that step. One nullable Int captures both
-    // "is it open" and the step, so an Activity recreate mid-tour cannot rewind the user to step 0
-    // (§ Stateful Composables). On-demand only — no first-run auto-open, no "seen" flag.
-    var onboardingStep by rememberSaveable { mutableStateOf<Int?>(null) }
-    // The Hub's "bring audios from other apps" single-step guide: true = open. rememberSaveable so an
-    // Activity recreate while it is open doesn't silently dump the user back to My Bomps (§ Stateful
-    // Composables). It reuses the IMPORT onboarding content but is a separate, lighter overlay.
-    var bringGuideVisible by rememberSaveable { mutableStateOf(false) }
+    // Navigation 3 backbone (ADR 0024): one saveable back stack per tab + typed child destinations.
+    // The Navigator keeps SoundsViewModel.selectedTab in sync — the ViewModel still projects the
+    // sounds list off the selected tab.
+    val navState = rememberLandingNavigationState()
+    val navigator = remember(navState) { LandingNavigator(navState) { tab -> viewModel.selectTab(tab) } }
+
+    // ViewModel → graph sync: deep links (LandingActivity.handleDeeplink → selectTab) and any other
+    // programmatic tab change reach the graph through here. Navigator-side changes call selectTab
+    // themselves and StateFlow de-dups equal values, so this cannot loop. selectedTab survives
+    // process death (SavedStateHandle) so this never fights the restored back stack.
+    LaunchedEffect(selectedTab) {
+        if (navState.topLevelRoute.toTabOrNull() != selectedTab) {
+            // Leaving the current stack programmatically: an open immersive listen must not keep
+            // playing headless behind another tab, and the modal Hub sheet must not resurrect on a
+            // later visit — close both. Full-screen destinations stay: they are tab history (D2).
+            when (val visible = navState.visibleRoute) {
+                is ImmersiveListenRoute -> {
+                    viewModel.stopPlayback()
+                    navigator.close(visible)
+                }
+                ImportHubRoute -> navigator.close(visible)
+                else -> Unit
+            }
+            navigator.navigate(selectedTab.toRoute())
+        }
+    }
+
     // System file picker for the Hub's "import audio" path. OpenDocument(arrayOf("audio/*")) opens the
     // full SAF browser filtered to audio (non-audio files are not selectable) — better at surfacing
     // on-device audio across OEMs than GetContent's "Recent" view. We copy the audio at save time, so we
@@ -143,64 +163,34 @@ fun LandingScreen(viewModel: SoundsViewModel) {
         }
 
     // Single import-Hub entry point: logs the funnel's ENTRY with the [source] surface, then opens.
-    // The `!isHubVisible` guard makes the open idempotent so a rapid double-tap on a trigger can't
-    // double-count `import_hub_opened`.
+    // The isVisible guard makes the open idempotent so a rapid double-tap on a trigger can't
+    // double-count `import_hub_opened` (or push the sheet twice).
     val openHub = { source: String ->
-        if (!isHubVisible) {
+        if (!navigator.isVisible(ImportHubRoute)) {
             tracker.log(AnalyticsEvent.ImportHubOpened(source = source))
-            isHubVisible = true
+            navigator.navigate(ImportHubRoute)
         }
     }
 
     // Single onboarding-tour entry point: logs the ENTRY with the [source] surface (empty state, the
-    // welcome footer, or the overflow menu), then opens the tour at step 0. The `onboardingStep == null`
-    // guard mirrors openHub's: it makes the open idempotent so a rapid double-tap on a trigger can't
-    // double-count `onboarding_opened` (the funnel's "started").
+    // welcome footer, or the overflow menu), then opens the tour at step 0. The guard mirrors
+    // openHub's: idempotent open so a rapid double-tap can't double-count `onboarding_opened`.
     val openOnboarding = { source: String ->
-        if (onboardingStep == null) {
+        if (!navigator.isVisible(OnboardingRoute)) {
             tracker.log(AnalyticsEvent.OnboardingOpened(source = source))
-            onboardingStep = 0
+            navigator.navigate(OnboardingRoute)
         }
     }
 
-    // Key on the open/closed boolean, not the raw step: advancing or going back within the tour must
-    // not re-emit screen_view=onboarding (one open = one screen view, like the other overlays).
-    LaunchedEffect(selectedTab, isAboutVisible, manageRequest, isSearchVisible, onboardingStep != null, bringGuideVisible) {
-        val name =
-            when {
-                // The bring-from-apps guide reuses the onboarding IMPORT content but is its own screen, so
-                // it reports a distinct screen_view — keeping the onboarding-tour funnel uncontaminated.
-                bringGuideVisible -> CanonicalScreenName.BRING_GUIDE
-                onboardingStep != null -> CanonicalScreenName.ONBOARDING
-                isSearchVisible -> CanonicalScreenName.SEARCH_SOUND
-                isAboutVisible -> CanonicalScreenName.ABOUT
-                manageRequest != null -> CanonicalScreenName.MANAGE_COLLECTIONS
-                selectedTab == AppTab.MY_SOUNDS -> CanonicalScreenName.MY_SOUNDS
-                selectedTab == AppTab.VAULT -> CanonicalScreenName.VAULT
-                selectedTab == AppTab.EXPLORE_SOUNDS -> CanonicalScreenName.EXPLORE_SOUNDS
-                else -> null
-            }
-        name?.let {
-            AnalyticsTrackerProvider.get(context.applicationContext).logScreen(it)
-        }
-    }
-
-    BackHandler(
-        enabled =
-            !isAboutVisible &&
-                manageRequest == null &&
-                immersiveListenSoundId == null &&
-                onboardingStep == null &&
-                !bringGuideVisible &&
-                tabBackStack.isNotEmpty(),
-    ) {
-        viewModel.selectTab(tabBackStack.removeAt(tabBackStack.lastIndex))
-    }
-
+    // screen_view derives from the visible destination, with the search overlay winning while open.
+    // Routes with no canonical name (Hub sheet, immersive listen) map to null = "keep the previous
+    // screen", and distinctUntilChanged keeps open/close round-trips over them from re-emitting —
+    // the same semantics the pre-Nav3 boolean model had.
     LaunchedEffect(Unit) {
-        viewModel.scrollToTopEvent.collect {
-            listState.animateScrollToItem(0)
-        }
+        snapshotFlow { screenNameFor(navState, isSearchVisible) }
+            .filterNotNull()
+            .distinctUntilChanged()
+            .collect { AnalyticsTrackerProvider.get(context.applicationContext).logScreen(it) }
     }
 
     SnackbarEffects(viewModel = viewModel, snackbarHostState = snackbarHostState)
@@ -211,83 +201,144 @@ fun LandingScreen(viewModel: SoundsViewModel) {
     val collectionsByAudio by viewModel.audioCollectionsIndex.collectAsState()
     val privateCollections = remember(collections) { collections.filter { it.isPrivate } }
 
-    // My Sounds is the always-composed base layer; About / Manage Collections render as opaque
-    // full-screen overlays stacked on top of it (the same layering SearchOverlay uses below).
-    // Keeping the list composed behind is what lets predictiveBackTransition reveal the live
-    // My Sounds as the user swipes those screens away — an exclusive `when` (the prior shape)
-    // exposed the bare window background instead. The overlays' Scaffold Surface is opaque: it
-    // blocks touch propagation and covers the list at rest, so there is no visual or input change
-    // until a back gesture is in progress. When the nav3 migration (backlog 08) lands, About/Manage
-    // become real destinations and this manual layering is removed.
-    //
-    // While a sub-screen is open the occluded list is cleared from the semantics tree, so TalkBack
-    // and UI tests neither reach nor double-match nodes hidden behind the opaque overlay (e.g. a
-    // collection name shown both in the chip row and in the Manage list). Drawing is untouched, so
-    // the gesture still reveals the live list visually.
-    val subScreenOpen =
-        isAboutVisible || manageRequest != null || immersiveListenSoundId != null || onboardingStep != null || bringGuideVisible
-    ScaffoldedLanding(
-        modifier = if (subScreenOpen) Modifier.clearAndSetSemantics {} else Modifier,
-        viewModel = viewModel,
-        sounds = sounds,
-        selectedTab = selectedTab,
-        hasBundledSounds = hasBundledSounds,
-        playbackProgress = playbackProgress,
-        pausedProgress = pausedProgress,
-        soundDurations = soundDurations,
-        snackbarHostState = snackbarHostState,
-        listState = listState,
-        coroutineScope = coroutineScope,
-        context = context,
-        tabBackStack = tabBackStack,
-        collections = collections,
-        activeFilter = activeFilter,
-        publicCollections = publicCollections,
-        collectionsByAudio = collectionsByAudio,
-        privateCollections = privateCollections,
-        onAboutClick = { isAboutVisible = true },
-        onManageCollectionsClick = { manageRequest = ManageRequest.Generic },
-        onActiveFilterEditClick = { collectionId ->
-            manageRequest = ManageRequest.Focused(collectionId)
-        },
-        onImmersivePlay = { sound ->
-            // Vault play opens immersive listen mode and starts a listen session — always from 0 on
-            // the long-form engine (ADR 0022), unless the audio is already mid-session.
-            immersiveListenSoundId = sound.id
-            if (!sound.isPlaying) viewModel.startListenSession(sound)
-        },
-        onCreateClick = openHub,
-        // One source-parameterized entry point (mirrors onCreateClick): each surface binds its own
-        // AnalyticsSource at the leaf call site below, so no per-surface callback has to be threaded.
-        onShowOnboarding = openOnboarding,
-    )
+    val bottomSheetStrategy = remember { BottomSheetSceneStrategy<NavKey>() }
 
-    // Exactly one sub-screen overlays the list at a time (About wins over Manage, preserving the
-    // prior priority); neither branch removes the base layer.
-    when {
-        isAboutVisible -> AboutScreen(onBack = { isAboutVisible = false })
-        manageRequest != null ->
-            com.github.barriosnahuel.vossosunboton.feature.collections.ManageCollectionsScreen(
-                viewModel = viewModel,
-                focusedCollectionId = (manageRequest as? ManageRequest.Focused)?.collectionId,
-                onBack = { manageRequest = null },
-            )
-    }
-
-    // Immersive listen mode for a Vault audio — layers above everything (it covers the top bar, so
-    // About/Manage are unreachable while it is open). Back STOPS playback definitively (sessions have
-    // no cross-open retention — ADR 0022) so no audio keeps playing headless behind the Vault list,
-    // then closes the overlay.
-    immersiveListenSoundId?.let { listeningId ->
-        com.github.barriosnahuel.vossosunboton.feature.vault.ImmersiveListenHost(
+    // The three tab entries share this content; each binds its own constant tab.
+    val tabContent: @Composable (AppTab) -> Unit = { tab ->
+        TabContent(
+            tab = tab,
             viewModel = viewModel,
-            soundId = listeningId,
-            onBack = {
-                viewModel.stopPlayback()
-                immersiveListenSoundId = null
+            sounds = sounds,
+            hasBundledSounds = hasBundledSounds,
+            playbackProgress = playbackProgress,
+            pausedProgress = pausedProgress,
+            soundDurations = soundDurations,
+            snackbarHostState = snackbarHostState,
+            context = context,
+            collections = collections,
+            activeFilter = activeFilter,
+            publicCollections = publicCollections,
+            collectionsByAudio = collectionsByAudio,
+            privateCollections = privateCollections,
+            onTabSelected = { target -> navigator.navigate(target.toRoute()) },
+            // isVisible-style guards mirror openHub's: a rapid double-tap must not push twice.
+            onAboutClick = {
+                if (!navigator.isVisible(AboutRoute)) navigator.navigate(AboutRoute)
             },
+            onManageCollectionsClick = {
+                if (navState.visibleRoute !is ManageCollectionsRoute) {
+                    navigator.navigate(ManageCollectionsRoute())
+                }
+            },
+            onActiveFilterEditClick = { collectionId ->
+                if (navState.visibleRoute !is ManageCollectionsRoute) {
+                    navigator.navigate(ManageCollectionsRoute(collectionId))
+                }
+            },
+            onImmersivePlay = { sound ->
+                // Vault play opens immersive listen mode and starts a listen session — always from 0 on
+                // the long-form engine (ADR 0022), unless the audio is already mid-session. Guarded so a
+                // double-tap can't push the destination twice.
+                if (navState.visibleRoute !is ImmersiveListenRoute) {
+                    navigator.navigate(ImmersiveListenRoute(sound.id))
+                    if (!sound.isPlaying) viewModel.startListenSession(sound)
+                }
+            },
+            onCreateClick = openHub,
+            // One source-parameterized entry point (mirrors onCreateClick): each surface binds its own
+            // AnalyticsSource at the leaf call site below, so no per-surface callback has to be threaded.
+            onShowOnboarding = openOnboarding,
         )
     }
+
+    NavDisplay(
+        entries =
+            navState.toEntries(
+                entryProvider {
+                    entry<HomeRoute>(metadata = instantTabTransitions()) { tabContent(AppTab.MY_SOUNDS) }
+                    entry<VaultRoute>(metadata = instantTabTransitions()) { tabContent(AppTab.VAULT) }
+                    entry<ExploreRoute>(metadata = instantTabTransitions()) { tabContent(AppTab.EXPLORE_SOUNDS) }
+                    entry<AboutRoute> {
+                        AboutScreen(onBack = { navigator.close(AboutRoute) })
+                    }
+                    entry<ManageCollectionsRoute> { key ->
+                        // close(key), not goBack(): Manage's "view collection" action switches tab before
+                        // closing, and a plain pop would hit the new tab's stack (see LandingNavigator.close).
+                        com.github.barriosnahuel.vossosunboton.feature.collections.ManageCollectionsScreen(
+                            viewModel = viewModel,
+                            focusedCollectionId = key.focusedCollectionId,
+                            onBack = { navigator.close(key) },
+                        )
+                    }
+                    entry<ImmersiveListenRoute> { key ->
+                        // Back STOPS playback definitively (sessions have no cross-open retention —
+                        // ADR 0022) so no audio keeps playing headless behind the Vault list.
+                        com.github.barriosnahuel.vossosunboton.feature.vault.ImmersiveListenHost(
+                            viewModel = viewModel,
+                            soundId = key.soundId,
+                            onBack = {
+                                viewModel.stopPlayback()
+                                navigator.close(key)
+                            },
+                        )
+                    }
+                    entry<OnboardingRoute> {
+                        OnboardingHost(
+                            onClose = { navigator.close(OnboardingRoute) },
+                            onFinished = {
+                                navigator.close(OnboardingRoute)
+                                // The tour teaches My Bomps and lands on the Hub to add a first Bomp. When
+                                // opened from the overflow on Vault/Explore, return to My Bomps first so the
+                                // saved Bomp lands on the tab the user is looking at.
+                                if (selectedTab != AppTab.MY_SOUNDS) {
+                                    navigator.navigate(HomeRoute)
+                                }
+                                openHub(AnalyticsSource.ONBOARDING_FINISH)
+                            },
+                        )
+                    }
+                    entry<BringFromAppsRoute> {
+                        com.github.barriosnahuel.vossosunboton.feature.onboarding.BringFromAppsGuide(
+                            onClose = { navigator.close(BringFromAppsRoute) },
+                        )
+                    }
+                    entry<ImportHubRoute>(metadata = BottomSheetSceneStrategy.bottomSheet()) {
+                        ImportHubSheet(
+                            // Guard on visibility so a double-tap on a row (both taps land before the pop
+                            // recomposes the sheet away) fires its action once, not twice.
+                            onImport = {
+                                if (navigator.isVisible(ImportHubRoute)) {
+                                    tracker.log(AnalyticsEvent.ImportHubImportSelected)
+                                    navigator.close(ImportHubRoute)
+                                    importPicker.launch(arrayOf("audio/*"))
+                                }
+                            },
+                            onRecord = {
+                                if (navigator.isVisible(ImportHubRoute)) {
+                                    tracker.log(AnalyticsEvent.ImportHubRecordSelected)
+                                    navigator.close(ImportHubRoute)
+                                    context.startActivity(RecordingActivity.createIntent(context))
+                                }
+                            },
+                            onBringFromApps = {
+                                if (navigator.isVisible(ImportHubRoute)) {
+                                    tracker.log(AnalyticsEvent.ImportHubBringSelected)
+                                    navigator.close(ImportHubRoute)
+                                    navigator.navigate(BringFromAppsRoute)
+                                }
+                            },
+                        )
+                    }
+                },
+            ),
+        onBack = {
+            // Route-aware side effect: popping the immersive listen (gesture or button) must stop
+            // the session, mirroring its explicit onBack above.
+            if (navState.visibleRoute is ImmersiveListenRoute) viewModel.stopPlayback()
+            navigator.goBack()
+        },
+        sceneStrategies = listOf(bottomSheetStrategy),
+    )
 
     com.github.barriosnahuel.vossosunboton.feature.collections
         .CollectionSheetHost(viewModel = viewModel)
@@ -297,69 +348,6 @@ fun LandingScreen(viewModel: SoundsViewModel) {
 
     com.github.barriosnahuel.vossosunboton.feature.collections
         .CollectionDeleteDialog(viewModel = viewModel)
-
-    if (isHubVisible) {
-        ImportHubSheet(
-            // Guard on isHubVisible so a double-tap on the import row (both taps land before the
-            // sheet's hide animation recomposes it away) launches the picker once, not twice.
-            onImport = {
-                if (isHubVisible) {
-                    tracker.log(AnalyticsEvent.ImportHubImportSelected)
-                    isHubVisible = false
-                    importPicker.launch(arrayOf("audio/*"))
-                }
-            },
-            onRecord = {
-                if (isHubVisible) {
-                    tracker.log(AnalyticsEvent.ImportHubRecordSelected)
-                    isHubVisible = false
-                    context.startActivity(RecordingActivity.createIntent(context))
-                }
-            },
-            onBringFromApps = {
-                if (isHubVisible) {
-                    tracker.log(AnalyticsEvent.ImportHubBringSelected)
-                    isHubVisible = false
-                    bringGuideVisible = true
-                }
-            },
-            onDismiss = { isHubVisible = false },
-        )
-    }
-
-    // The Hub's "bring audios from other apps" single-step guide, overlaying everything like the tour.
-    if (bringGuideVisible) {
-        com.github.barriosnahuel.vossosunboton.feature.onboarding.BringFromAppsGuide(
-            onClose = { bringGuideVisible = false },
-        )
-    }
-
-    // On-demand onboarding tour overlaying everything (opened from the Hub or the empty state). The
-    // final "start" CTA lands on the Hub so the user can import right away ("Empezá cae al Hub").
-    onboardingStep?.let { current ->
-        com.github.barriosnahuel.vossosunboton.feature.onboarding.OnboardingTour(
-            step = current,
-            onAdvance = {
-                onboardingStep =
-                    ((onboardingStep ?: 0) + 1)
-                        .coerceAtMost(com.github.barriosnahuel.vossosunboton.feature.onboarding.ONBOARDING_STEP_COUNT - 1)
-            },
-            onStepBack = { onboardingStep = ((onboardingStep ?: 0) - 1).coerceAtLeast(0) },
-            onSkip = { onboardingStep = null },
-            onFinish = {
-                onboardingStep = null
-                // The tour teaches My Bomps and lands on the Hub to add a first Bomp. When it was opened
-                // from the overflow on Vault/Explore, return to My Bomps first so the saved Bomp lands on
-                // the tab the user is looking at — otherwise it goes to the unseen My Bomps list and seems
-                // to vanish.
-                if (selectedTab != AppTab.MY_SOUNDS) {
-                    tabBackStack.add(selectedTab)
-                    viewModel.selectTab(AppTab.MY_SOUNDS)
-                }
-                openHub(AnalyticsSource.ONBOARDING_FINISH)
-            },
-        )
-    }
 
     if (isSearchVisible) {
         SearchOverlayHost(
@@ -372,6 +360,56 @@ fun LandingScreen(viewModel: SoundsViewModel) {
             soundDurations = soundDurations,
         )
     }
+}
+
+/**
+ * Maps the visible destination (+ the search overlay) to its canonical `screen_view` literal.
+ * Routes with no screen of their own (Hub sheet, immersive listen) are transparent: the name
+ * resolves to the entry beneath them in the stack, so opening/closing them never re-emits and a
+ * tab change underneath them still surfaces — the pre-Nav3 semantics.
+ */
+private fun screenNameFor(
+    navState: com.github.barriosnahuel.vossosunboton.ui.home.navigation.LandingNavigationState,
+    isSearchVisible: Boolean,
+): String? =
+    when {
+        isSearchVisible -> CanonicalScreenName.SEARCH_SOUND
+        else -> navState.activeStack.lastOrNull { canonicalNameFor(it) != null }?.let { canonicalNameFor(it) }
+    }
+
+private fun canonicalNameFor(route: NavKey): String? =
+    when (route) {
+        HomeRoute -> CanonicalScreenName.MY_SOUNDS
+        VaultRoute -> CanonicalScreenName.VAULT
+        ExploreRoute -> CanonicalScreenName.EXPLORE_SOUNDS
+        AboutRoute -> CanonicalScreenName.ABOUT
+        is ManageCollectionsRoute -> CanonicalScreenName.MANAGE_COLLECTIONS
+        OnboardingRoute -> CanonicalScreenName.ONBOARDING
+        BringFromAppsRoute -> CanonicalScreenName.BRING_GUIDE
+        else -> null
+    }
+
+/**
+ * Hosts the onboarding tour as a destination. The step lives here as `rememberSaveable` (not a
+ * route argument) so advancing steps never mutates the back stack and an Activity recreate
+ * mid-tour cannot rewind the user to step 0 (§ Stateful Composables); the tour's internal
+ * `BackHandler` keeps owning step-back vs dismiss.
+ */
+@Composable
+private fun OnboardingHost(
+    onClose: () -> Unit,
+    onFinished: () -> Unit,
+) {
+    var step by rememberSaveable { mutableStateOf(0) }
+    com.github.barriosnahuel.vossosunboton.feature.onboarding.OnboardingTour(
+        step = step,
+        onAdvance = {
+            step = (step + 1).coerceAtMost(com.github.barriosnahuel.vossosunboton.feature.onboarding.ONBOARDING_STEP_COUNT - 1)
+        },
+        onStepBack = { step = (step - 1).coerceAtLeast(0) },
+        onSkip = onClose,
+        onFinish = onFinished,
+    )
 }
 
 /**
@@ -445,31 +483,28 @@ private fun SearchOverlayHost(
 }
 
 /**
- * Extracted Scaffold body to keep [LandingScreen] readable now that the top-level swap between
- * Landing / About / Manage Collections lives in a `when`. All the previous Scaffold logic moves
- * here unchanged.
+ * One tab's full screen: the shared chrome (top bar, FAB, bottom bar, snackbar host) plus the
+ * tab's body. Each tab route renders its own instance; hoisted state (list scroll, snackbars)
+ * lives in [LandingScreen] so it behaves exactly as the single pre-Nav3 Scaffold did.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun ScaffoldedLanding(
-    modifier: Modifier = Modifier,
+private fun TabContent(
+    tab: AppTab,
     viewModel: SoundsViewModel,
     sounds: List<Sound>,
-    selectedTab: AppTab,
     hasBundledSounds: Boolean,
     playbackProgress: PlaybackProgress?,
     pausedProgress: Map<String, PlaybackProgress>,
     soundDurations: Map<String, Int>,
     snackbarHostState: SnackbarHostState,
-    listState: LazyListState,
-    coroutineScope: kotlinx.coroutines.CoroutineScope,
     context: Context,
-    tabBackStack: androidx.compose.runtime.snapshots.SnapshotStateList<AppTab>,
     collections: List<com.github.barriosnahuel.vossosunboton.model.Collection>,
     activeFilter: String?,
     publicCollections: List<com.github.barriosnahuel.vossosunboton.model.Collection>,
     collectionsByAudio: Map<String, List<String>>,
     privateCollections: List<com.github.barriosnahuel.vossosunboton.model.Collection>,
+    onTabSelected: (AppTab) -> Unit,
     onAboutClick: () -> Unit,
     onManageCollectionsClick: () -> Unit,
     onActiveFilterEditClick: (String) -> Unit,
@@ -481,8 +516,18 @@ private fun ScaffoldedLanding(
     // state, welcome footer, or overflow). Each leaf surface binds its own constant.
     onShowOnboarding: (String) -> Unit,
 ) {
+    // Per-tab list state: each tab keeps its own scroll position (multi-back-stack state retention,
+    // ADR 0024), and a predictive-back preview composing two tabs at once never shares one
+    // LazyListState between two live lists. The scroll-to-top event only reaches the visible tab —
+    // the others are not composed.
+    val listState = rememberLazyListState()
+    val coroutineScope = rememberCoroutineScope()
+    LaunchedEffect(Unit) {
+        viewModel.scrollToTopEvent.collect {
+            listState.animateScrollToItem(0)
+        }
+    }
     Scaffold(
-        modifier = modifier,
         topBar = {
             AppTopBar(
                 onSearchClick = { viewModel.showSearch() },
@@ -503,7 +548,7 @@ private fun ScaffoldedLanding(
             val showsWelcomeEmpty =
                 sounds.isEmpty() &&
                     !(activeFilter != null && publicCollections.any { it.id == activeFilter })
-            if (selectedTab == AppTab.MY_SOUNDS && !showsWelcomeEmpty) {
+            if (tab == AppTab.MY_SOUNDS && !showsWelcomeEmpty) {
                 FloatingActionButton(
                     onClick = { onCreateClick(AnalyticsSource.FAB) },
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
@@ -520,21 +565,20 @@ private fun ScaffoldedLanding(
             // Vault is always visible (spec § 2.1) — no `hasBundledSounds` gating. The Explore
             // tab keeps its conditional behaviour through `AppBottomBar.hasExplore`.
             AppBottomBar(
-                selectedTab = selectedTab,
+                selectedTab = tab,
                 hasExplore = hasBundledSounds,
-                onTabSelected = { tab ->
-                    if (tab == selectedTab) {
+                onTabSelected = { target ->
+                    if (target == tab) {
                         coroutineScope.launch { listState.animateScrollToItem(0) }
                     } else {
-                        tabBackStack.add(selectedTab)
-                        viewModel.selectTab(tab)
+                        onTabSelected(target)
                     }
                 },
             )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { innerPadding ->
-        when (selectedTab) {
+        when (tab) {
             AppTab.VAULT ->
                 com.github.barriosnahuel.vossosunboton.feature.vault.VaultScreen(
                     privateCollections = privateCollections,
@@ -546,7 +590,7 @@ private fun ScaffoldedLanding(
                 )
             else -> {
                 MySoundsBody(
-                    selectedTab = selectedTab,
+                    selectedTab = tab,
                     sounds = sounds,
                     playbackProgress = playbackProgress,
                     pausedProgress = pausedProgress,
@@ -1157,40 +1201,5 @@ private fun MySoundsFilterEmptyState(collectionName: String) {
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = androidx.compose.ui.text.style.TextAlign.Center,
         )
-    }
-}
-
-/**
- * Top-level navigation request to open [com.github.barriosnahuel.vossosunboton.feature.collections.ManageCollectionsScreen].
- * `Generic` opens it at the top with no row highlight; `Focused` deep-links to a specific
- * collection (scroll + transient tint). Persisted across rotation via [Saver].
- */
-internal sealed class ManageRequest {
-    object Generic : ManageRequest()
-
-    data class Focused(
-        val collectionId: String,
-    ) : ManageRequest()
-
-    companion object {
-        val Saver: androidx.compose.runtime.saveable.Saver<ManageRequest?, Any> =
-            androidx.compose.runtime.saveable.Saver(
-                save = { value ->
-                    when (value) {
-                        null -> ""
-                        Generic -> "generic"
-                        is Focused -> "focused:${value.collectionId}"
-                    }
-                },
-                restore = { raw ->
-                    val s = raw as? String ?: return@Saver null
-                    when {
-                        s.isEmpty() -> null
-                        s == "generic" -> Generic
-                        s.startsWith("focused:") -> Focused(s.removePrefix("focused:"))
-                        else -> null
-                    }
-                },
-            )
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -109,6 +109,10 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LandingScreen(viewModel: SoundsViewModel) {
+    // Read BEFORE any list flow (sounds, vaultAudios): loadSounds() writes lists→flag, so the
+    // mirrored flag→lists read order guarantees a `true` flag is never paired with a stale empty
+    // list. Reordering these reads reintroduces the cold-start empty-state flash.
+    val initialLoadComplete by viewModel.isInitialLoadComplete.collectAsStateWithLifecycle()
     val sounds by viewModel.sounds.collectAsState()
     val selectedTab by viewModel.selectedTab.collectAsState()
     val hasBundledSounds by viewModel.hasBundledSounds.collectAsState()
@@ -209,6 +213,7 @@ fun LandingScreen(viewModel: SoundsViewModel) {
             tab = tab,
             viewModel = viewModel,
             sounds = sounds,
+            initialLoadComplete = initialLoadComplete,
             hasBundledSounds = hasBundledSounds,
             playbackProgress = playbackProgress,
             pausedProgress = pausedProgress,
@@ -493,6 +498,9 @@ private fun TabContent(
     tab: AppTab,
     viewModel: SoundsViewModel,
     sounds: List<Sound>,
+    // Read at the LandingScreen head BEFORE `sounds` (release/acquire pairing with loadSounds) —
+    // don't replace with a local collect, that reintroduces the cold-start empty-state flash.
+    initialLoadComplete: Boolean,
     hasBundledSounds: Boolean,
     playbackProgress: PlaybackProgress?,
     pausedProgress: Map<String, PlaybackProgress>,
@@ -599,6 +607,7 @@ private fun TabContent(
                 MySoundsBody(
                     selectedTab = tab,
                     sounds = sounds,
+                    initialLoadComplete = initialLoadComplete,
                     playbackProgress = playbackProgress,
                     pausedProgress = pausedProgress,
                     soundDurations = soundDurations,
@@ -1069,6 +1078,7 @@ internal fun deletionSnackbarMessage(
 private fun MySoundsBody(
     selectedTab: AppTab,
     sounds: List<Sound>,
+    initialLoadComplete: Boolean,
     playbackProgress: PlaybackProgress?,
     pausedProgress: Map<String, PlaybackProgress>,
     soundDurations: Map<String, Int>,
@@ -1099,7 +1109,9 @@ private fun MySoundsBody(
     }
     val isOnMySounds = selectedTab == AppTab.MY_SOUNDS
     val showFilterEmptyState = isOnMySounds && activeFilterId != null && sounds.isEmpty() && activeCollection != null
-    val showWelcomeEmptyState = sounds.isEmpty() && isOnMySounds && !showFilterEmptyState
+    // Gated on the initial load: on a cold start `sounds` is empty until the first loadSounds
+    // lands, and rendering the inspirational empty state for that window reads as a data flash.
+    val showWelcomeEmptyState = sounds.isEmpty() && isOnMySounds && !showFilterEmptyState && initialLoadComplete
     // Fresh install lands here, not on the ZRP: the welcome audio keeps the list non-empty. Surface a
     // "see how it works" footer under the lone welcome so a new user can reach the tour without first
     // deleting the welcome. Drops away the moment any real Bomp exists.

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -1108,9 +1108,11 @@ private fun MySoundsBody(
         if (pendingDraft != null) draftTracker.log(AnalyticsEvent.RecordingDraftBannerShown)
     }
     val isOnMySounds = selectedTab == AppTab.MY_SOUNDS
-    val showFilterEmptyState = isOnMySounds && activeFilterId != null && sounds.isEmpty() && activeCollection != null
-    // Gated on the initial load: on a cold start `sounds` is empty until the first loadSounds
-    // lands, and rendering the inspirational empty state for that window reads as a data flash.
+    // Both empty states gate on the initial load: on a cold start `sounds` is empty until the
+    // first loadSounds + collections snapshot land, and rendering either empty state for that
+    // window reads as a data flash (the filter variant hits users with a persisted chip).
+    val showFilterEmptyState =
+        isOnMySounds && activeFilterId != null && sounds.isEmpty() && activeCollection != null && initialLoadComplete
     val showWelcomeEmptyState = sounds.isEmpty() && isOnMySounds && !showFilterEmptyState && initialLoadComplete
     // Fresh install lands here, not on the ZRP: the welcome audio keeps the list non-empty. Surface a
     // "see how it works" footer under the lone welcome so a new user can reach the tour without first

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -48,6 +48,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import timber.log.Timber
 
 enum class AppTab { MY_SOUNDS, VAULT, EXPLORE_SOUNDS }
@@ -262,13 +264,35 @@ class SoundsViewModel(
 
     private val mutableInitialLoadComplete = MutableStateFlow(false)
 
+    // Two-input gate for the flag below: the projections loadSounds writes read `_collections`
+    // (chip filters, vault membership), and collections hydrate on an independent coroutine — a
+    // flag opened on loadSounds alone could still front a collections-blind projection. @Volatile:
+    // each input is marked from its own dispatcher thread.
+    @Volatile
+    private var initialSoundsLoaded = false
+
+    @Volatile
+    private var initialCollectionsLoaded = false
+
+    private fun maybeCompleteInitialLoad() {
+        if (initialSoundsLoaded && initialCollectionsLoaded) mutableInitialLoadComplete.value = true
+    }
+
+    // Serializes every loadSounds pass. Concurrent triggers (init, the reactive repo collector,
+    // collections emissions, tab/filter changes) each read-then-write the projections; without
+    // the lock, a pass that read an older snapshot can finish last and clobber a fresher
+    // projection (stale-writer-wins — surfaced as a hidden audio flashing back into My Sounds).
+    private val loadSoundsMutex = Mutex()
+
     /**
-     * Flips to `true` only AFTER the first [loadSounds] call finished writing every list it
-     * projects (`_sounds`, `_vaultAudios`, caches) — on success or failure. That write order is a
-     * contract: UI consumers gate their empty states on this flag and MUST read it BEFORE the list
-     * flows (release/acquire pairing), so a `true` flag is never paired with a stale empty list
-     * during the first composition pass (cold-start ZRP flash). Tests also use it to await the
-     * async DataStore read started in `init` before mutating state via reflection.
+     * Flips to `true` only AFTER both cold-start inputs landed: the first [loadSounds] pass
+     * finished writing every list it projects (`_sounds`, `_vaultAudios`, caches) AND the first
+     * collections snapshot was applied (those projections read `_collections`). Fail-open: an init
+     * failure flips it regardless so empty states are never gated shut forever. That write order
+     * is a contract: UI consumers gate their empty states on this flag and MUST read it BEFORE the
+     * list flows (release/acquire pairing), so a `true` flag is never paired with a stale empty
+     * list during the first composition pass (cold-start ZRP flash). Tests also use it to await
+     * the async DataStore reads started in `init` before mutating state via reflection.
      *
      * Avoids the conventional `_isInitialLoadComplete`/`isInitialLoadComplete` backing-field
      * pair because ktlint's `backing-property-naming` rule requires both to be `private`,
@@ -366,9 +390,10 @@ class SoundsViewModel(
         // init returns, so the first loadSounds always observes a stable
         // `_welcomeStickerVisible` snapshot.
         //
-        // The whole block is wrapped in try/catch so that any failure between `isActive()` and the
-        // `try/finally` inside `loadSounds()` still flips `mutableInitialLoadComplete` — otherwise
-        // tests that await `isInitialLoadComplete.first { it }` would deadlock.
+        // The `finally` marks the gate's sounds input no matter where this block fails — otherwise
+        // tests that await `isInitialLoadComplete.first { it }` would deadlock. Only THIS coroutine
+        // marks it (not loadSounds itself): it is the one sequenced after migrateVisibilityIfNeeded,
+        // so the gate can never open over a pre-migration projection written by a concurrent pass.
         viewModelScope.launch(ioDispatcher) {
             try {
                 // One-time migration from the old "ephemeral, self-destruct on completion" model:
@@ -393,7 +418,11 @@ class SoundsViewModel(
                 @Suppress("TooGenericExceptionCaught") e: Throwable,
             ) {
                 Tracker.track(RuntimeException("SoundsViewModel init failed", e))
+                // Fail-open: a broken init must not gate the empty states shut forever.
                 mutableInitialLoadComplete.value = true
+            } finally {
+                initialSoundsLoaded = true
+                maybeCompleteInitialLoad()
             }
         }
         // Reactive trigger: any change to the persisted sound list (save / rename / pin /
@@ -473,7 +502,16 @@ class SoundsViewModel(
                     }
                     recomputeVaultAudios()
                     syncCollectionsUserProperties(list)
-                    if (!firstEmission) {
+                    if (firstEmission) {
+                        // The init loadSounds may have projected before this snapshot landed
+                        // (chip filters and vault membership read `_collections`): re-project
+                        // synchronously from the cache so the gate never opens over a
+                        // collections-blind list. No-op while the cache is still empty —
+                        // loadSounds hasn't run yet and will project with collections present.
+                        applyTabFilterFromCache(selectedTab.value)
+                        initialCollectionsLoaded = true
+                        maybeCompleteInitialLoad()
+                    } else {
                         loadSounds()
                     }
                     firstEmission = false
@@ -484,6 +522,8 @@ class SoundsViewModel(
                 @Suppress("TooGenericExceptionCaught") e: Throwable,
             ) {
                 Tracker.track(RuntimeException("SoundsViewModel collections observation failed", e))
+                // Fail-open: never hold the empty-state gate shut forever on a dead collector.
+                mutableInitialLoadComplete.value = true
             }
         }
         // React to the Vault unlock/lock session flag. Search results are the only consumer whose
@@ -1450,7 +1490,7 @@ class SoundsViewModel(
     }
 
     private suspend fun loadSounds() {
-        try {
+        loadSoundsMutex.withLock {
             val allSounds = repo.sounds.first().sortedWith(SOUND_ORDER)
             val cachedDurations = repo.durations.first()
             // Read once per loadSounds — pure function over a snapshotted value, easier to test. The
@@ -1513,9 +1553,6 @@ class SoundsViewModel(
                     tracker.log(AnalyticsEvent.MilestoneAudios(threshold))
                 }
             }
-        } finally {
-            // Always flag completion so test waits do not hang on DataStore failures.
-            mutableInitialLoadComplete.value = true
         }
     }
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -8,7 +8,9 @@ package com.github.barriosnahuel.vossosunboton.ui.home
 import android.app.Application
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
@@ -132,6 +134,7 @@ data class PlaybackProgress(
 @Suppress("TooManyFunctions", "LargeClass")
 class SoundsViewModel(
     application: Application,
+    private val savedStateHandle: SavedStateHandle = SavedStateHandle(),
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val searchDebounceMs: Long = 200L,
     private val welcomeStore: WelcomeStickerStore = WelcomeStickerStore(application),
@@ -195,8 +198,10 @@ class SoundsViewModel(
     @Volatile
     private var welcomeHintConsumed = false
 
-    private val _selectedTab = MutableStateFlow(AppTab.MY_SOUNDS)
-    val selectedTab: StateFlow<AppTab> = _selectedTab.asStateFlow()
+    // SavedStateHandle-backed so the selected tab survives process death: the Nav3 back stack
+    // restores itself (rememberNavBackStack) and the VM->graph sync in LandingScreen would
+    // otherwise see the default MY_SOUNDS and snap the restored graph back to Home.
+    val selectedTab: StateFlow<AppTab> = savedStateHandle.getStateFlow(KEY_SELECTED_TAB, AppTab.MY_SOUNDS)
 
     private val _sounds = MutableStateFlow<List<Sound>>(emptyList())
     val sounds: StateFlow<List<Sound>> = _sounds.asStateFlow()
@@ -615,8 +620,8 @@ class SoundsViewModel(
         get() =
             when {
                 _isSearchVisible.value -> CanonicalScreenName.SEARCH_SOUND
-                _selectedTab.value == AppTab.MY_SOUNDS -> CanonicalScreenName.MY_SOUNDS
-                _selectedTab.value == AppTab.VAULT -> CanonicalScreenName.VAULT
+                selectedTab.value == AppTab.MY_SOUNDS -> CanonicalScreenName.MY_SOUNDS
+                selectedTab.value == AppTab.VAULT -> CanonicalScreenName.VAULT
                 else -> CanonicalScreenName.EXPLORE_SOUNDS
             }
 
@@ -680,7 +685,7 @@ class SoundsViewModel(
     }
 
     fun selectTab(tab: AppTab) {
-        _selectedTab.value = tab
+        savedStateHandle[KEY_SELECTED_TAB] = tab
         // Optimistically rebuild `_sounds` from the in-memory caches before kicking off the
         // async loadSounds. Without this, the freshly selected tab renders an empty list (the
         // previous tab's filtered view) until the IO chain settles — the user sees the empty
@@ -700,7 +705,7 @@ class SoundsViewModel(
         if (snapshot.isEmpty()) return
         // Mirrors the byTab branch in loadSounds so the tab swap doesn't flash an empty list.
         _sounds.value =
-            when (_selectedTab.value) {
+            when (selectedTab.value) {
                 AppTab.MY_SOUNDS -> mySoundsProjection(snapshot)
                 AppTab.EXPLORE_SOUNDS -> snapshot.filter { it.isBundled() }
                 AppTab.VAULT -> emptyList()
@@ -812,7 +817,7 @@ class SoundsViewModel(
      */
     private fun mySoundsProjection(library: List<Sound>): List<Sound> {
         val custom = library.filter { !it.isBundled() }
-        val activeChip = _activeMySoundsFilter.value.takeIf { _selectedTab.value == AppTab.MY_SOUNDS }
+        val activeChip = _activeMySoundsFilter.value.takeIf { selectedTab.value == AppTab.MY_SOUNDS }
         return if (activeChip != null) {
             val ids =
                 _collections.value
@@ -979,7 +984,7 @@ class SoundsViewModel(
         // directly in `_sounds`, so mutating that list would push a private-only audio into the
         // My Sounds projection until the next loadSounds wipes it. Keep `_sounds` untouched on
         // Vault and let `recomputeVaultAudios()` do the user-visible work.
-        val shouldUpdateVisibleSounds = isWelcome || _selectedTab.value != AppTab.VAULT
+        val shouldUpdateVisibleSounds = isWelcome || selectedTab.value != AppTab.VAULT
         if (shouldUpdateVisibleSounds) {
             val currentSounds = _sounds.value.toMutableList()
             if (isWelcome) {
@@ -1240,7 +1245,7 @@ class SoundsViewModel(
         // flaky timeout under CI load). Only the unfiltered My Sounds view is visibility-driven: a
         // public chip surfaces members by membership (ADR 0012) and other tabs don't project by
         // visibility, so leave those to the reactive `loadSounds`, which reprojects to the same list.
-        if (_selectedTab.value == AppTab.MY_SOUNDS && _activeMySoundsFilter.value == null) {
+        if (selectedTab.value == AppTab.MY_SOUNDS && _activeMySoundsFilter.value == null) {
             _sounds.update { current -> reprojectVisibilityToggle(current, audioId, visible, allSoundsCache.value, SOUND_ORDER) }
         }
         viewModelScope.launch(ioDispatcher) {
@@ -1359,7 +1364,7 @@ class SoundsViewModel(
         installTs: Long,
     ): List<Sound> {
         val shouldShowWelcome =
-            _selectedTab.value == AppTab.MY_SOUNDS &&
+            selectedTab.value == AppTab.MY_SOUNDS &&
                 _welcomeStickerVisible.value &&
                 !welcomeIsPendingDismissal
         if (!shouldShowWelcome) return filtered
@@ -1473,7 +1478,7 @@ class SoundsViewModel(
             recomputeVaultAudios()
             _sounds.update {
                 val byTab =
-                    when (_selectedTab.value) {
+                    when (selectedTab.value) {
                         // ADR 0012: "Todo" shows audios with isVisibleInMySounds == true; an active
                         // public chip surfaces that collection's members by membership. Both live in
                         // mySoundsProjection. The Vault-privacy hide rule is NOT applied here.
@@ -1653,10 +1658,15 @@ class SoundsViewModel(
                 .thenByDescending { it.dateAdded ?: Long.MIN_VALUE }
                 .thenBy { it.name.lowercase() }
 
+        private const val KEY_SELECTED_TAB = "selected_tab"
+
         val Factory: ViewModelProvider.Factory =
             viewModelFactory {
                 initializer {
-                    SoundsViewModel(application = this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY]!!)
+                    SoundsViewModel(
+                        application = this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY]!!,
+                        savedStateHandle = createSavedStateHandle(),
+                    )
                 }
             }
     }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -6,7 +6,6 @@
 package com.github.barriosnahuel.vossosunboton.ui.home
 
 import android.app.Application
-import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelProvider
@@ -264,18 +263,17 @@ class SoundsViewModel(
     private val mutableInitialLoadComplete = MutableStateFlow(false)
 
     /**
-     * Flips to `true` after the first [loadSounds] call returns (success OR failure).
-     * Tests in this module use it to await the async DataStore read started in `init`
-     * before mutating state via reflection (otherwise the injected value gets overwritten
-     * by the in-flight load). Not part of the production API — `internal` so the wider
-     * codebase cannot accidentally depend on it; `@VisibleForTesting(otherwise = NONE)`
-     * so Lint warns if any non-test caller appears.
+     * Flips to `true` only AFTER the first [loadSounds] call finished writing every list it
+     * projects (`_sounds`, `_vaultAudios`, caches) — on success or failure. That write order is a
+     * contract: UI consumers gate their empty states on this flag and MUST read it BEFORE the list
+     * flows (release/acquire pairing), so a `true` flag is never paired with a stale empty list
+     * during the first composition pass (cold-start ZRP flash). Tests also use it to await the
+     * async DataStore read started in `init` before mutating state via reflection.
      *
      * Avoids the conventional `_isInitialLoadComplete`/`isInitialLoadComplete` backing-field
      * pair because ktlint's `backing-property-naming` rule requires both to be `private`,
-     * which would defeat the test-coordination purpose.
+     * which would defeat the coordination purpose.
      */
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     internal val isInitialLoadComplete: StateFlow<Boolean> = mutableInitialLoadComplete.asStateFlow()
 
     private val allSoundsCache = MutableStateFlow<List<Sound>>(emptyList())
@@ -710,10 +708,11 @@ class SoundsViewModel(
             when (tab) {
                 AppTab.MY_SOUNDS -> mySoundsProjection(snapshot)
                 AppTab.EXPLORE_SOUNDS -> snapshot.filter { it.isBundled() }
-                // Leave the previous projection in place: VaultScreen renders its own list and
-                // never reads `_sounds`, while the OUTGOING tab stays composed during the Nav3
-                // entry transition — emptying here made it flash its empty state mid-swap.
-                AppTab.VAULT -> return
+                // VaultScreen renders its own list and never reads `_sounds`; project the HOME
+                // list here because (a) emptying flashed the outgoing tab's empty state mid-swap
+                // and (b) a predictive-back preview from the Vault base always composes Home
+                // (exit-through-home), which must show its own rows, not the previous tab's.
+                AppTab.VAULT -> mySoundsProjection(snapshot)
             }
     }
 
@@ -1490,10 +1489,10 @@ class SoundsViewModel(
                         AppTab.MY_SOUNDS -> mySoundsProjection(allSounds)
                         AppTab.EXPLORE_SOUNDS -> allSounds.filter { it.isBundled() }
                         // The Vault tab renders its own dedicated list (VaultScreen reads
-                        // `_vaultAudios`, never this projection), so the previous tab's list is
-                        // left untouched: the outgoing tab stays composed during the Nav3 entry
-                        // transition, and emptying it here flashed its empty state mid-swap.
-                        AppTab.VAULT -> it
+                        // `_vaultAudios`, never this projection). Project HOME here: emptying
+                        // flashed the outgoing tab's empty state mid-swap, and the predictive-back
+                        // preview from the Vault base always reveals Home (exit-through-home).
+                        AppTab.VAULT -> mySoundsProjection(allSounds)
                     }.filter { it.id != deletedId }
                 val withWelcome = positionWelcomeIn(byTab, welcomeIsPendingDismissal, welcomeInstallTs)
                 if (playingId == null) {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -689,8 +689,10 @@ class SoundsViewModel(
         // Optimistically rebuild `_sounds` from the in-memory caches before kicking off the
         // async loadSounds. Without this, the freshly selected tab renders an empty list (the
         // previous tab's filtered view) until the IO chain settles — the user sees the empty
-        // state flash for ~150ms on every tab swap.
-        applyTabFilterFromCache()
+        // state flash on every tab swap. The tab is passed explicitly: reading it back through
+        // the SavedStateHandle flow here observed the PREVIOUS value, which re-emptied the list
+        // when leaving the Vault (whose projection is empty by design).
+        applyTabFilterFromCache(tab)
         viewModelScope.launch(ioDispatcher) { loadSounds() }
     }
 
@@ -700,15 +702,18 @@ class SoundsViewModel(
      * keeps the body composable rendering the right list instead of bouncing through the empty
      * state. Returns whatever `applyCollectionFilter` produces for the active tab + chip.
      */
-    private fun applyTabFilterFromCache() {
+    private fun applyTabFilterFromCache(tab: AppTab) {
         val snapshot = allSoundsCache.value
         if (snapshot.isEmpty()) return
         // Mirrors the byTab branch in loadSounds so the tab swap doesn't flash an empty list.
         _sounds.value =
-            when (selectedTab.value) {
+            when (tab) {
                 AppTab.MY_SOUNDS -> mySoundsProjection(snapshot)
                 AppTab.EXPLORE_SOUNDS -> snapshot.filter { it.isBundled() }
-                AppTab.VAULT -> emptyList()
+                // Leave the previous projection in place: VaultScreen renders its own list and
+                // never reads `_sounds`, while the OUTGOING tab stays composed during the Nav3
+                // entry transition — emptying here made it flash its empty state mid-swap.
+                AppTab.VAULT -> return
             }
     }
 
@@ -1484,12 +1489,11 @@ class SoundsViewModel(
                         // mySoundsProjection. The Vault-privacy hide rule is NOT applied here.
                         AppTab.MY_SOUNDS -> mySoundsProjection(allSounds)
                         AppTab.EXPLORE_SOUNDS -> allSounds.filter { it.isBundled() }
-                        // The Vault tab is rendered by its own dedicated screen (VaultScreen) — the
-                        // primary sound list is empty here so the bottom-bar tab swap leaves the
-                        // screen blank while VaultScreen takes over via the overlay path in
-                        // LandingScreen. Returning an empty list also keeps the sound list's empty
-                        // state composable from rendering its "no sounds yet" body for the wrong tab.
-                        AppTab.VAULT -> emptyList()
+                        // The Vault tab renders its own dedicated list (VaultScreen reads
+                        // `_vaultAudios`, never this projection), so the previous tab's list is
+                        // left untouched: the outgoing tab stays composed during the Nav3 entry
+                        // transition, and emptying it here flashed its empty state mid-swap.
+                        AppTab.VAULT -> it
                     }.filter { it.id != deletedId }
                 val withWelcome = positionWelcomeIn(byTab, welcomeIsPendingDismissal, welcomeInstallTs)
                 if (playingId == null) {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/navigation/BottomSheetSceneStrategy.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/navigation/BottomSheetSceneStrategy.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home.navigation
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.ModalBottomSheetProperties
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.rememberLifecycleOwner
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavMetadataKey
+import androidx.navigation3.runtime.get
+import androidx.navigation3.runtime.metadata
+import androidx.navigation3.scene.OverlayScene
+import androidx.navigation3.scene.Scene
+import androidx.navigation3.scene.SceneStrategy
+import androidx.navigation3.scene.SceneStrategyScope
+
+// BottomSheetSceneStrategy is deliberately not part of the Navigation 3 core library; the official
+// migration guide instructs copying it from the nav3-recipes repository. Adapted from
+// https://github.com/android/nav3-recipes (Apache License 2.0, Copyright 2025 The Android Open
+// Source Project); the only local change is the themed container color.
+
+/** An [OverlayScene] that renders an [entry] within a [ModalBottomSheet]. */
+@OptIn(ExperimentalMaterial3Api::class)
+internal data class BottomSheetScene<T : Any>(
+    override val key: T,
+    override val previousEntries: List<NavEntry<T>>,
+    override val overlaidEntries: List<NavEntry<T>>,
+    private val entry: NavEntry<T>,
+    private val modalBottomSheetProperties: ModalBottomSheetProperties,
+    private val onBack: () -> Unit,
+) : OverlayScene<T> {
+    override val entries: List<NavEntry<T>> = listOf(entry)
+
+    override val content: @Composable (() -> Unit) = {
+        val lifecycleOwner = rememberLifecycleOwner()
+        ModalBottomSheet(
+            onDismissRequest = onBack,
+            properties = modalBottomSheetProperties,
+            containerColor = MaterialTheme.colorScheme.surface,
+        ) {
+            CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
+                entry.Content()
+            }
+        }
+    }
+}
+
+/**
+ * A [SceneStrategy] that displays entries carrying [bottomSheet] metadata inside a
+ * [ModalBottomSheet]. Must be listed before any non-overlay scene strategies.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+internal class BottomSheetSceneStrategy<T : Any> : SceneStrategy<T> {
+    override fun SceneStrategyScope<T>.calculateScene(entries: List<NavEntry<T>>): Scene<T>? {
+        val lastEntry = entries.lastOrNull()
+        val bottomSheetProperties = lastEntry?.metadata?.get(BottomSheetKey)
+        return if (lastEntry == null || bottomSheetProperties == null) {
+            null
+        } else {
+            @Suppress("UNCHECKED_CAST")
+            BottomSheetScene(
+                key = lastEntry.contentKey as T,
+                previousEntries = entries.dropLast(1),
+                overlaidEntries = entries.dropLast(1),
+                entry = lastEntry,
+                modalBottomSheetProperties = bottomSheetProperties,
+                onBack = onBack,
+            )
+        }
+    }
+
+    companion object {
+        /** Marks an entry's [NavEntry.metadata] as a modal-bottom-sheet destination. */
+        fun bottomSheet(modalBottomSheetProperties: ModalBottomSheetProperties = ModalBottomSheetProperties()) =
+            metadata {
+                put(BottomSheetKey, modalBottomSheetProperties)
+            }
+
+        object BottomSheetKey : NavMetadataKey<ModalBottomSheetProperties>
+    }
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/navigation/BottomSheetSceneStrategy.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/navigation/BottomSheetSceneStrategy.kt
@@ -43,6 +43,9 @@ internal data class BottomSheetScene<T : Any>(
         val lifecycleOwner = rememberLifecycleOwner()
         ModalBottomSheet(
             onDismissRequest = onBack,
+            // skipPartiallyExpanded: the pre-Nav3 host always opened fully expanded; the default
+            // half-state cuts the last Hub row below the fold on short viewports.
+            sheetState = androidx.compose.material3.rememberModalBottomSheetState(skipPartiallyExpanded = true),
             properties = modalBottomSheetProperties,
             containerColor = MaterialTheme.colorScheme.surface,
         ) {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/navigation/LandingNavigation.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/navigation/LandingNavigation.kt
@@ -205,9 +205,20 @@ internal class LandingNavigator(
      * screen resurrectable on the old one.
      */
     fun close(route: NavKey) {
-        state.backStacks.values.forEach { stack ->
+        // Exactly one instance is removed, preferring the active stack: routes are value-equal
+        // (@Serializable objects/data classes), and a route legitimately duplicated as another
+        // tab's history must survive closing the visible one.
+        val stacks =
+            buildList {
+                add(state.activeStack)
+                state.backStacks.values.forEach { if (it !== state.activeStack) add(it) }
+            }
+        for (stack in stacks) {
             val index = stack.lastIndexOf(route)
-            if (index >= 0) stack.removeAt(index)
+            if (index >= 0) {
+                stack.removeAt(index)
+                return
+            }
         }
     }
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/navigation/LandingNavigation.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/navigation/LandingNavigation.kt
@@ -68,12 +68,19 @@ data object ImportHubRoute : NavKey
  * Tab entries switch instantly (no cross-scaffold animation), matching the pre-Nav3 body swap —
  * the top/bottom bars must read as static chrome while tabs change. Child destinations keep the
  * NavDisplay defaults, which is where the automatic predictive back pays off (ADR 0024).
+ *
+ * The outgoing tab must stay composed beneath until the incoming one has drawn
+ * (`KeepUntilTransitionsFinished`, the official recipe's pattern): `ExitTransition.None` drops it
+ * immediately, exposing the bare window background for however many frames the new tab's first
+ * composition takes — on device that reads as an empty-state flash when entering the Vault.
  */
 internal fun instantTabTransitions() =
     metadata {
-        put(NavDisplay.TransitionKey) { EnterTransition.None togetherWith ExitTransition.None }
-        put(NavDisplay.PopTransitionKey) { EnterTransition.None togetherWith ExitTransition.None }
-        put(NavDisplay.PredictivePopTransitionKey) { EnterTransition.None togetherWith ExitTransition.None }
+        put(NavDisplay.TransitionKey) { EnterTransition.None togetherWith ExitTransition.KeepUntilTransitionsFinished }
+        put(NavDisplay.PopTransitionKey) { EnterTransition.None togetherWith ExitTransition.KeepUntilTransitionsFinished }
+        put(NavDisplay.PredictivePopTransitionKey) {
+            EnterTransition.None togetherWith ExitTransition.KeepUntilTransitionsFinished
+        }
     }
 
 internal fun AppTab.toRoute(): NavKey =

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/navigation/LandingNavigation.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/navigation/LandingNavigation.kt
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home.navigation
+
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.togetherWith
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSerializable
+import androidx.compose.runtime.setValue
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.metadata
+import androidx.navigation3.runtime.rememberDecoratedNavEntries
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.runtime.serialization.NavKeySerializer
+import androidx.navigation3.ui.NavDisplay
+import androidx.savedstate.compose.serialization.serializers.MutableStateSerializer
+import com.github.barriosnahuel.vossosunboton.ui.home.AppTab
+import kotlinx.serialization.Serializable
+
+// Navigation 3 backbone for Landing: typed routes, one back stack per tab, and the Navigator that
+// mutates them. Architecture decision + trade-offs: docs/adr/0024-jetpack-navigation-3.md.
+
+@Serializable
+data object HomeRoute : NavKey
+
+@Serializable
+data object VaultRoute : NavKey
+
+@Serializable
+data object ExploreRoute : NavKey
+
+@Serializable
+data object AboutRoute : NavKey
+
+@Serializable
+data class ManageCollectionsRoute(
+    val focusedCollectionId: String? = null,
+) : NavKey
+
+@Serializable
+data class ImmersiveListenRoute(
+    val soundId: String,
+) : NavKey
+
+/** Tour step progression stays inside the destination (`rememberSaveable`), matching today's semantics. */
+@Serializable
+data object OnboardingRoute : NavKey
+
+@Serializable
+data object BringFromAppsRoute : NavKey
+
+/** Rendered as a modal bottom sheet via [BottomSheetSceneStrategy] metadata. */
+@Serializable
+data object ImportHubRoute : NavKey
+
+/**
+ * Tab entries switch instantly (no cross-scaffold animation), matching the pre-Nav3 body swap —
+ * the top/bottom bars must read as static chrome while tabs change. Child destinations keep the
+ * NavDisplay defaults, which is where the automatic predictive back pays off (ADR 0024).
+ */
+internal fun instantTabTransitions() =
+    metadata {
+        put(NavDisplay.TransitionKey) { EnterTransition.None togetherWith ExitTransition.None }
+        put(NavDisplay.PopTransitionKey) { EnterTransition.None togetherWith ExitTransition.None }
+        put(NavDisplay.PredictivePopTransitionKey) { EnterTransition.None togetherWith ExitTransition.None }
+    }
+
+internal fun AppTab.toRoute(): NavKey =
+    when (this) {
+        AppTab.MY_SOUNDS -> HomeRoute
+        AppTab.VAULT -> VaultRoute
+        AppTab.EXPLORE_SOUNDS -> ExploreRoute
+    }
+
+internal fun NavKey.toTabOrNull(): AppTab? =
+    when (this) {
+        HomeRoute -> AppTab.MY_SOUNDS
+        VaultRoute -> AppTab.VAULT
+        ExploreRoute -> AppTab.EXPLORE_SOUNDS
+        else -> null
+    }
+
+/**
+ * Creates the Landing navigation state: the current top-level route plus one saveable back stack
+ * per tab. Both survive configuration changes and process death (`rememberSerializable` +
+ * `rememberNavBackStack`), which is what lets an open overlay survive rotation without the
+ * hand-written `Saver`s the boolean model needed.
+ */
+@Composable
+internal fun rememberLandingNavigationState(): LandingNavigationState {
+    val topLevelRoute =
+        rememberSerializable(
+            serializer = MutableStateSerializer(NavKeySerializer()),
+        ) {
+            mutableStateOf<NavKey>(HomeRoute)
+        }
+    val backStacks: Map<NavKey, NavBackStack<NavKey>> =
+        mapOf(
+            HomeRoute to rememberNavBackStack(HomeRoute),
+            VaultRoute to rememberNavBackStack(VaultRoute),
+            ExploreRoute to rememberNavBackStack(ExploreRoute),
+        )
+    return remember { LandingNavigationState(topLevelRoute = topLevelRoute, backStacks = backStacks) }
+}
+
+/**
+ * State holder for Landing navigation. Mutated only through [LandingNavigator] (UDF). Follows the
+ * official multiple-back-stacks recipe, including its "exit through home" pattern: the Home stack
+ * is always at the bottom, so the user always leaves the app from My Sounds.
+ */
+internal class LandingNavigationState(
+    topLevelRoute: MutableState<NavKey>,
+    val backStacks: Map<NavKey, NavBackStack<NavKey>>,
+) {
+    var topLevelRoute: NavKey by topLevelRoute
+
+    val startRoute: NavKey = HomeRoute
+
+    /** The route whose entry is currently on top (the visible destination). */
+    val visibleRoute: NavKey
+        get() = activeStack.lastOrNull() ?: topLevelRoute
+
+    val activeStack: NavBackStack<NavKey>
+        get() = backStacks.getValue(topLevelRoute)
+
+    private val stacksInUse: List<NavKey>
+        get() =
+            if (topLevelRoute == startRoute) {
+                listOf(startRoute)
+            } else {
+                listOf(startRoute, topLevelRoute)
+            }
+
+    /** Flattens the in-use stacks into decorated entries for `NavDisplay`. */
+    @Composable
+    fun toEntries(entryProvider: (NavKey) -> NavEntry<NavKey>): List<NavEntry<NavKey>> {
+        val decoratedEntries =
+            backStacks.mapValues { (_, stack) ->
+                val decorators =
+                    listOf(
+                        rememberSaveableStateHolderNavEntryDecorator<NavKey>(),
+                    )
+                rememberDecoratedNavEntries(
+                    backStack = stack,
+                    entryDecorators = decorators,
+                    entryProvider = entryProvider,
+                )
+            }
+        return stacksInUse.flatMap { decoratedEntries[it] ?: emptyList() }
+    }
+}
+
+/**
+ * Handles navigation events by updating [LandingNavigationState], keeping `SoundsViewModel`'s
+ * `selectedTab` in sync through [onTabChange] — the ViewModel still projects the sounds list off
+ * the selected tab, so every tab change (taps, back pops, deep links) must reach it.
+ */
+internal class LandingNavigator(
+    val state: LandingNavigationState,
+    private val onTabChange: (AppTab) -> Unit,
+) {
+    fun navigate(route: NavKey) {
+        val tab = route.toTabOrNull()
+        if (tab != null) {
+            state.topLevelRoute = route
+            onTabChange(tab)
+        } else {
+            state.activeStack.add(route)
+        }
+    }
+
+    fun goBack() {
+        val currentStack = state.activeStack
+        if (currentStack.lastOrNull() == state.topLevelRoute) {
+            // At the base of the current tab: exit through home.
+            state.topLevelRoute = state.startRoute
+            onTabChange(AppTab.MY_SOUNDS)
+        } else {
+            currentStack.removeLastOrNull()
+        }
+    }
+
+    /**
+     * Removes [route] from whichever stack holds it — not necessarily the active one. Needed by
+     * destinations whose actions switch tabs before closing themselves (e.g. Manage Collections'
+     * "view collection"): a plain [goBack] would pop the *new* tab's stack and leave the closed
+     * screen resurrectable on the old one.
+     */
+    fun close(route: NavKey) {
+        state.backStacks.values.forEach { stack ->
+            val index = stack.lastIndexOf(route)
+            if (index >= 0) stack.removeAt(index)
+        }
+    }
+
+    /** True when [route] is the visible destination — the idempotence guard for double-tap opens. */
+    fun isVisible(route: NavKey): Boolean = state.visibleRoute == route
+}

--- a/app/src/main/res/raw/app_third_party_notices.txt
+++ b/app/src/main/res/raw/app_third_party_notices.txt
@@ -5,7 +5,7 @@ This application includes software from third parties. The following notices
 are provided in accordance with each library's license terms.
 
 --------------------------------------------------------------------------------
-Android Jetpack (Activity, Compose, Lifecycle, etc.)
+Android Jetpack (Activity, Compose, Lifecycle, Navigation 3, etc.)
 Copyright (C) The Android Open Source Project
 Apache License, Version 2.0
 https://developer.android.com/jetpack

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/ImportHubSheetTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/ImportHubSheetTest.kt
@@ -92,7 +92,6 @@ internal class ImportHubSheetTest : AbstractRobolectricTest() {
         onImport: () -> Unit = {},
         onRecord: () -> Unit = {},
         onBringFromApps: () -> Unit = {},
-        onDismiss: () -> Unit = {},
     ) {
         composeTestRule.setContent {
             AppTheme {
@@ -100,7 +99,6 @@ internal class ImportHubSheetTest : AbstractRobolectricTest() {
                     onImport = onImport,
                     onRecord = onRecord,
                     onBringFromApps = onBringFromApps,
-                    onDismiss = onDismiss,
                 )
             }
         }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivityTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivityTest.kt
@@ -105,12 +105,99 @@ internal class LandingActivityTest : AbstractRobolectricTest() {
         }
     }
 
+    /** OWASP MASVS-PLATFORM-1 / CWE-939 (deep-link allowlist fallback survives state restoration). */
+    @Test
+    fun `deep link with unknown path still lands on MY_SOUNDS after Activity recreate`() {
+        // Restoration guard: the saveable NavBackStack must not let a restored graph override the
+        // deep-link allowlist fallback — an unknown path lands (and stays) on Home.
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("push-me://open/unknown"))
+        ActivityScenario.launch<LandingActivity>(intent).use { scenario ->
+            composeTestRule.waitForIdle()
+            scenario.recreate()
+            composeTestRule.waitForIdle()
+            scenario.onActivity { activity ->
+                val viewModel = ViewModelProvider(activity, SoundsViewModel.Factory)[SoundsViewModel::class.java]
+                assertThat(viewModel.selectedTab.value).isEqualTo(AppTab.MY_SOUNDS)
+            }
+        }
+    }
+
+    @Test
+    fun `back from a non-home tab returns to My Bomps before exiting`() {
+        // Multi-back-stack "exit through home" (ADR 0024): from the Vault base, back crosses to the
+        // Home tab instead of leaving the app; only the Home base exits.
+        ActivityScenario.launch(LandingActivity::class.java).use { scenario ->
+            composeTestRule.waitForIdle()
+            composeTestRule
+                .onNodeWithText(context.getString(R.string.app_navigation_menu_item_vault))
+                .performClick()
+            composeTestRule.waitForIdle()
+
+            scenario.onActivity { it.onBackPressedDispatcher.onBackPressed() }
+            composeTestRule.waitForIdle()
+
+            scenario.onActivity { activity ->
+                val viewModel = ViewModelProvider(activity, SoundsViewModel.Factory)[SoundsViewModel::class.java]
+                assertThat(viewModel.selectedTab.value).isEqualTo(AppTab.MY_SOUNDS)
+                assertThat(activity.isFinishing).isFalse()
+            }
+        }
+    }
+
+    @Test
+    fun `back sequence from About over Explore walks Explore then My Bomps then exits`() {
+        // The epic's acceptance walk: My Bomps → Explore → About → back closes About, back returns
+        // to My Bomps (exit through home), back leaves the app. Needs bundled audios for Explore.
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        if (PackagedAudios.get(ctx).isEmpty()) {
+            return
+        }
+        ActivityScenario.launch(LandingActivity::class.java).use { scenario ->
+            composeTestRule.waitForIdle()
+            scenario.onActivity { activity ->
+                val viewModel = ViewModelProvider(activity, SoundsViewModel.Factory)[SoundsViewModel::class.java]
+                viewModel.selectTab(AppTab.EXPLORE_SOUNDS)
+            }
+            composeTestRule.waitForIdle()
+            composeTestRule
+                .onNodeWithContentDescription(context.getString(R.string.app_overflow_menu))
+                .performClick()
+            composeTestRule.waitForIdle()
+            composeTestRule.onNodeWithText(context.getString(R.string.app_about)).performClick()
+            composeTestRule.waitForIdle()
+            composeTestRule
+                .onNodeWithContentDescription(context.getString(R.string.app_about_back))
+                .assertIsDisplayed()
+
+            scenario.onActivity { it.onBackPressedDispatcher.onBackPressed() }
+            composeTestRule.waitForIdle()
+            scenario.onActivity { activity ->
+                val viewModel = ViewModelProvider(activity, SoundsViewModel.Factory)[SoundsViewModel::class.java]
+                assertThat(viewModel.selectedTab.value).isEqualTo(AppTab.EXPLORE_SOUNDS)
+            }
+
+            scenario.onActivity { it.onBackPressedDispatcher.onBackPressed() }
+            composeTestRule.waitForIdle()
+            scenario.onActivity { activity ->
+                val viewModel = ViewModelProvider(activity, SoundsViewModel.Factory)[SoundsViewModel::class.java]
+                assertThat(viewModel.selectedTab.value).isEqualTo(AppTab.MY_SOUNDS)
+                assertThat(activity.isFinishing).isFalse()
+            }
+
+            scenario.onActivity { it.onBackPressedDispatcher.onBackPressed() }
+            composeTestRule.waitForIdle()
+            scenario.onActivity { activity ->
+                assertThat(activity.isFinishing).isTrue()
+            }
+        }
+    }
+
     @Test
     fun `About overlay survives Activity recreate so rotation does not bounce the user back to MY_SOUNDS`() {
-        // The About overlay is a full-screen early-return inside LandingScreen — when
-        // `isAboutVisible` flips back to false on recreate, the user silently lands on MY_SOUNDS
-        // without ever asking for it. Recreate has to preserve the flag so the screen stays where
-        // the user left it. The back-arrow content description is unique to the About TopAppBar.
+        // About is a destination on the saveable NavBackStack — if the restored stack dropped it,
+        // the user would silently land on MY_SOUNDS without ever asking for it. Recreate has to
+        // preserve the stack so the screen stays where the user left it. The back-arrow content
+        // description is unique to the About TopAppBar.
         ActivityScenario.launch(LandingActivity::class.java).use { scenario ->
             composeTestRule.waitForIdle()
             composeTestRule

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivityTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivityTest.kt
@@ -145,18 +145,16 @@ internal class LandingActivityTest : AbstractRobolectricTest() {
     }
 
     @Test
-    fun `back sequence from About over Explore walks Explore then My Bomps then exits`() {
-        // The epic's acceptance walk: My Bomps → Explore → About → back closes About, back returns
-        // to My Bomps (exit through home), back leaves the app. Needs bundled audios for Explore.
-        val ctx = ApplicationProvider.getApplicationContext<Context>()
-        if (PackagedAudios.get(ctx).isEmpty()) {
-            return
-        }
+    fun `back sequence from About over the Vault walks the Vault then My Bomps then exits`() {
+        // The epic's acceptance walk: My Bomps → Vault → About → back closes About, back returns
+        // to My Bomps (exit through home), back leaves the app. Driven through the Vault tab so it
+        // runs everywhere — Explore needs bundled audios that CI checkouts lack (the earlier
+        // Explore-based variant silently skipped there, leaving this behavior unguarded).
         ActivityScenario.launch(LandingActivity::class.java).use { scenario ->
             composeTestRule.waitForIdle()
             scenario.onActivity { activity ->
                 val viewModel = ViewModelProvider(activity, SoundsViewModel.Factory)[SoundsViewModel::class.java]
-                viewModel.selectTab(AppTab.EXPLORE_SOUNDS)
+                viewModel.selectTab(AppTab.VAULT)
             }
             composeTestRule.waitForIdle()
             composeTestRule
@@ -173,7 +171,7 @@ internal class LandingActivityTest : AbstractRobolectricTest() {
             composeTestRule.waitForIdle()
             scenario.onActivity { activity ->
                 val viewModel = ViewModelProvider(activity, SoundsViewModel.Factory)[SoundsViewModel::class.java]
-                assertThat(viewModel.selectedTab.value).isEqualTo(AppTab.EXPLORE_SOUNDS)
+                assertThat(viewModel.selectedTab.value).isEqualTo(AppTab.VAULT)
             }
 
             scenario.onActivity { it.onBackPressedDispatcher.onBackPressed() }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingVaultTabTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingVaultTabTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.R
+import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
+import com.github.barriosnahuel.vossosunboton.feature.vault.security.VaultSessionState
+import com.github.barriosnahuel.vossosunboton.model.data.manager.CollectionsRepository
+import com.github.barriosnahuel.vossosunboton.model.data.manager.SoundsRepository
+import com.github.barriosnahuel.vossosunboton.testSound
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Regression guard for the Vault tab under the Nav3 graph: switching My Bomps → Vault must render
+ * the vault content immediately — never flash the ZRP while an async reload settles. The ZRP is
+ * legitimate only when the Vault truly has no audios.
+ */
+internal class LandingVaultTabTest : AbstractRobolectricTest() {
+    @get:Rule
+    val composeTestRule = createEmptyComposeRule()
+
+    private val context get() = ApplicationProvider.getApplicationContext<android.app.Application>()
+
+    @Before
+    fun setUp() {
+        mockkObject(PlayerControllerFactory)
+        every { PlayerControllerFactory.instance.setOnStartStopListener(any()) } answers { nothing }
+        every { PlayerControllerFactory.instance.removeOnStartStopListener(any()) } answers { nothing }
+        runBlocking {
+            SoundsRepository(context).clearForTest()
+            CollectionsRepository(context).clearForTest()
+            val repo = SoundsRepository(context)
+            repo.save(testSound("vaulted-audio", file = "vaulted.mp3"))
+            val collections = CollectionsRepository(context)
+            // Reading the flow once seeds the system Baúl before addAudio (no-op otherwise).
+            collections.collections.first()
+            val vaulted = repo.sounds.first().first { it.name == "vaulted-audio" }
+            collections.addAudio(CollectionsRepository.BAUL_SYSTEM_ID, vaulted.id)
+        }
+        VaultSessionState.markVaultOpen()
+    }
+
+    @After
+    fun tearDown() {
+        VaultSessionState.clearForTest()
+        unmockkAll()
+    }
+
+    @Test
+    fun `switching to the Vault tab shows its audios without flashing the empty state`() {
+        ActivityScenario.launch(LandingActivity::class.java).use {
+            composeTestRule.waitForIdle()
+
+            composeTestRule
+                .onNodeWithText(context.getString(R.string.app_navigation_menu_item_vault))
+                .performClick()
+            composeTestRule.waitForIdle()
+
+            // Immediately after the swap — no awaiting an async reload — the vault audio must be
+            // there and the ZRP must not. A transient empty vaultAudios at composition = the bug.
+            val zrpNodes =
+                composeTestRule
+                    .onAllNodesWithText(context.getString(R.string.app_vault_zrp_headline_lead))
+                    .fetchSemanticsNodes()
+            assertThat(zrpNodes).isEmpty()
+            composeTestRule.onNodeWithText("vaulted-audio").assertIsDisplayed()
+        }
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelCollectionsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelCollectionsTest.kt
@@ -5,6 +5,7 @@
  */
 package com.github.barriosnahuel.vossosunboton.ui.home
 
+import androidx.lifecycle.viewModelScope
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
 import com.github.barriosnahuel.vossosunboton.feature.collections.MySoundsFilterStore
@@ -20,6 +21,7 @@ import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -278,12 +280,12 @@ internal class SoundsViewModelCollectionsTest : AbstractRobolectricTest() {
         val vm = givenAViewModel()
         // Wait until the library is hydrated by the initial loadSounds before asserting on .value.
         runBlocking { vm.library.first { list -> list.any { it.name == "audio-b" } } }
-        // Switch to Vault — vm.sounds collapses to emptyList(), but the library snapshot must keep
-        // the user catalog so ImmersiveListenScreen can resolve collection.audioIds to real Sounds.
+        // Switch to Vault — vm.sounds keeps the previous tab's projection (emptying it flashed the
+        // outgoing tab's empty state mid-transition), and the library snapshot must keep the user
+        // catalog so ImmersiveListenScreen can resolve collection.audioIds to real Sounds.
         vm.selectTab(AppTab.VAULT)
-        runBlocking { vm.sounds.first { it.isEmpty() } }
 
-        assertThat(vm.sounds.value).isEmpty()
+        assertThat(vm.sounds.value.map { it.name }).containsExactly("audio-a", "audio-b")
         val userLibraryNames =
             vm.library.value
                 .filter { it.file != null }
@@ -310,8 +312,8 @@ internal class SoundsViewModelCollectionsTest : AbstractRobolectricTest() {
         val vm = givenAViewModel()
         runBlocking { vm.collections.first { it.size >= 1 } }
         runBlocking { vm.vaultAudios.first { it.size == 1 } }
-        // The user is on the Vault tab when they swipe-to-delete; `_sounds` collapses to empty on
-        // Vault by design (the VaultScreen reads `_vaultAudios` directly).
+        // The user is on the Vault tab when they swipe-to-delete; the main list is empty here only
+        // because the seeded audio is Vault-only (VaultScreen itself reads `_vaultAudios` directly).
         vm.selectTab(AppTab.VAULT)
         runBlocking { vm.sounds.first { it.isEmpty() } }
 
@@ -418,6 +420,71 @@ internal class SoundsViewModelCollectionsTest : AbstractRobolectricTest() {
         assertThat(created.profile.playbackUI).isEqualTo(
             com.github.barriosnahuel.vossosunboton.model.CollectionPlaybackUI.IMMERSIVE,
         )
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `returning from VAULT to MY_SOUNDS repopulates the list synchronously from the cache`() {
+        val context = ApplicationProvider.getApplicationContext<android.app.Application>()
+        runBlocking {
+            val repo = SoundsRepository(context)
+            repo.save(testSound("first", file = "a.mp3"))
+            repo.save(testSound("second", file = "b.mp3"))
+        }
+        // StandardTestDispatcher (not Unconfined): keeps the async loadSounds parked so the
+        // assertion sees exactly what the UI sees between the tab tap and the IO chain landing.
+        val scheduler = kotlinx.coroutines.test.TestCoroutineScheduler()
+        val vm =
+            SoundsViewModel(
+                context,
+                ioDispatcher = kotlinx.coroutines.test.StandardTestDispatcher(scheduler),
+            )
+        // NOT registered in createdViewModels: the shared tearDown's runBlocking join would
+        // deadlock on jobs parked on this test-owned virtual scheduler. Cancelled at the end below.
+        // Pump the parked IO scheduler and the Robolectric main looper together until the initial
+        // load lands — a plain runBlocking await would deadlock the main looper the VM relies on.
+        val mainLooper = org.robolectric.Shadows.shadowOf(android.os.Looper.getMainLooper())
+        // Interleave real time with the virtual pumps: the DataStore reads inside loadSounds run
+        // on their own real executor, and only their continuations land on the parked scheduler.
+        val deadline = System.currentTimeMillis() + 10_000
+        while (vm.sounds.value.size != 2 && System.currentTimeMillis() < deadline) {
+            scheduler.advanceTimeBy(1_000)
+            scheduler.runCurrent()
+            mainLooper.idle()
+            Thread.sleep(10)
+        }
+        com.google.common.truth.Truth
+            .assertWithMessage("initial load")
+            .that(vm.sounds.value.map { it.name })
+            .containsExactly("first", "second")
+
+        vm.selectTab(AppTab.VAULT)
+        scheduler.advanceTimeBy(1_000)
+        scheduler.runCurrent()
+        mainLooper.idle()
+        // The Vault renders its own list; the main projection must stay untouched — the outgoing
+        // tab remains composed during the Nav3 transition and would flash its empty state if this
+        // were emptied (the ZRP-flash regression this test guards).
+        com.google.common.truth.Truth
+            .assertWithMessage("while on VAULT")
+            .that(vm.sounds.value.map { it.name })
+            .containsExactly("first", "second")
+
+        vm.selectTab(AppTab.MY_SOUNDS)
+
+        // No scheduler advance: loadSounds has not run. The synchronous cache projection alone
+        // must repopulate the list — otherwise the tab renders its empty state until IO lands.
+        val namesRightAfterSwitch = vm.sounds.value.map { it.name }
+
+        // Cancel here (not via createdViewModels) and drain the virtual scheduler so no job
+        // outlives the test on a scheduler nobody advances anymore.
+        vm.viewModelScope.cancel()
+        scheduler.advanceUntilIdle()
+
+        com.google.common.truth.Truth
+            .assertWithMessage("right after switching back to MY_SOUNDS")
+            .that(namesRightAfterSwitch)
+            .containsExactly("first", "second")
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
@@ -30,12 +30,16 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.After
 import org.junit.Assume.assumeTrue
@@ -82,25 +86,42 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
     /**
      * Release/acquire contract behind the cold-start empty-state gate: the flag must flip only
      * AFTER `loadSounds` projected `_sounds`, so UI reading flag→lists (LandingScreen/VaultScreen
-     * heads) can never pair a `true` flag with a stale empty list. Guards against a refactor
-     * moving the flag flip before the projection.
+     * heads) can never pair a `true` flag with a stale empty list. The welcome store is gated so
+     * the subscription provably starts BEFORE the init load runs, and `withTimeout` (not
+     * `withTimeoutOrNull`) makes a never-opening gate fail loudly instead of passing vacuously.
      */
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
     fun `isInitialLoadComplete flips only after sounds are projected`() {
         val context = ApplicationProvider.getApplicationContext<android.app.Application>()
         runBlocking { SoundsRepository(context).save(testSound("preloaded", file = "preloaded.mp3")) }
+        // Holds the init coroutine parked before loadSounds until the test has subscribed.
+        val initGate = CompletableDeferred<Unit>()
+        val gatedWelcomeStore =
+            mockk<WelcomeStickerStore>(relaxed = true) {
+                coEvery { migrateToPersistentIfNeeded() } coAnswers { initGate.await() }
+            }
         val viewModel =
             SoundsViewModel(
                 context,
                 ioDispatcher = UnconfinedTestDispatcher(),
+                welcomeStore = gatedWelcomeStore,
                 searchDebounceMs = 0L,
             )
         createdViewModels += viewModel
 
-        runBlocking { withTimeoutOrNull(5_000L) { viewModel.isInitialLoadComplete.first { it } } }
+        val soundNamesWhenFlagFlipped =
+            runBlocking {
+                val awaiter =
+                    async(start = CoroutineStart.UNDISPATCHED) {
+                        withTimeout(5_000L) { viewModel.isInitialLoadComplete.first { it } }
+                        viewModel.sounds.value.map { it.name }
+                    }
+                initGate.complete(Unit)
+                awaiter.await()
+            }
 
-        assertThat(viewModel.sounds.value.map { it.name }).contains("preloaded")
+        assertThat(soundNamesWhenFlagFlipped).contains("preloaded")
     }
 
     @Test

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
@@ -79,6 +79,30 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
         unmockkAll()
     }
 
+    /**
+     * Release/acquire contract behind the cold-start empty-state gate: the flag must flip only
+     * AFTER `loadSounds` projected `_sounds`, so UI reading flag→lists (LandingScreen/VaultScreen
+     * heads) can never pair a `true` flag with a stale empty list. Guards against a refactor
+     * moving the flag flip before the projection.
+     */
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun `isInitialLoadComplete flips only after sounds are projected`() {
+        val context = ApplicationProvider.getApplicationContext<android.app.Application>()
+        runBlocking { SoundsRepository(context).save(testSound("preloaded", file = "preloaded.mp3")) }
+        val viewModel =
+            SoundsViewModel(
+                context,
+                ioDispatcher = UnconfinedTestDispatcher(),
+                searchDebounceMs = 0L,
+            )
+        createdViewModels += viewModel
+
+        runBlocking { withTimeoutOrNull(5_000L) { viewModel.isInitialLoadComplete.first { it } } }
+
+        assertThat(viewModel.sounds.value.map { it.name }).contains("preloaded")
+    }
+
     @Test
     fun `initial tab is MY_SOUNDS`() {
         val viewModel = givenAViewModel()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ tracing                   = "1.2.0"
 media3                    = "1.10.1"
 composeBom                = "2026.06.01"
 lifecycleCompose          = "2.11.0"
+nav3                      = "1.1.4"
 material                  = "1.14.0"
 
 # Firebase
@@ -78,6 +79,8 @@ compose-ui-test-junit4            = { module = "androidx.compose.ui:ui-test-juni
 # ---------- Lifecycle ----------
 lifecycle-viewmodel-compose       = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleCompose" }
 lifecycle-runtime-compose         = { module = "androidx.lifecycle:lifecycle-runtime-compose",   version.ref = "lifecycleCompose" }
+androidx-navigation3-runtime      = { module = "androidx.navigation3:navigation3-runtime", version.ref = "nav3" }
+androidx-navigation3-ui           = { module = "androidx.navigation3:navigation3-ui",      version.ref = "nav3" }
 
 # ---------- Material ----------
 material                          = { module = "com.google.android.material:material", version.ref = "material" }

--- a/scripts/check-security-test-count.sh
+++ b/scripts/check-security-test-count.sh
@@ -20,7 +20,7 @@
 
 set -euo pipefail
 
-EXPECTED_COUNT=33
+EXPECTED_COUNT=34
 
 SCAN_ROOTS=(
   app/src/test


### PR DESCRIPTION
### Summary
Internal — same screens, same flows; the navigation backbone under them is now Jetpack Navigation 3 (ADR 0024). What it unblocks: automatic predictive back between every Landing destination, and the graph the creation-flows PR (003c) and the adaptive work plug into.

Two deliberate behavior deltas (both platform-native, per ADR 0024 D2):
- **Back across tabs** now follows *exit-through-home*: from any tab, back returns to My Bomps, then exits — instead of replaying every visited tab.
- **Each tab keeps its own scroll position** (multi-back-stack state retention); they used to share one.

Plus one user-visible fix that predates this PR but was diagnosed during it: opening the app no longer flashes the inspirational empty state (~1s) while the sound list is still loading on a cold start.

### Technical detail
Landing's boolean lattice + manual `tabBackStack` replaced by a `NavDisplay` with one saveable `NavBackStack` per tab:

- **`ui/home/navigation/`** (new): typed `@Serializable` routes, `LandingNavigationState` + `LandingNavigator` (official multiple-backstacks recipe), vendored `BottomSheetSceneStrategy` (per the migration guide, Apache-2.0 nav3-recipes).
- **`LandingScreen.kt`**: overlays → destinations; ImportHub → bottom-sheet scene; Search stays a non-route overlay; screen_view derives from the visible route (transparent routes resolve to the entry beneath, `distinctUntilChanged` preserves the old emission semantics).
- **`SoundsViewModel`**: `selectedTab` moves into `SavedStateHandle` so process death can't fight the restored back stack; VM stays the tab source of truth (deep links unchanged in `LandingActivity`).
- **ADR 0011 machinery removed** from About/Manage/Immersive (NavDisplay provides predictive back); Search keeps `predictiveBackTransition`.
- **Cold-start empty-state flash fix**: the first composition pass could read a fresh `isInitialLoadComplete=true` with a stale empty `sounds` list (torn initial reads — `collectAsState*` initial values are not snapshot-isolated). UI now reads the flag BEFORE the list flows, mirroring `loadSounds()`'s lists→flag write order (release/acquire), and threads it down as a parameter. Verified 3×/3× repro → 0×/3× on an instrumented emulator cold start, then on the Pixel 8 where it was reported.
- **Review round 3 (self-review of the fix)**: the gate is now two-input — it also waits for the first collections snapshot, since the projections read `_collections` (a chip user could otherwise still flash the ZRP); filter empty states gate on it in both screens; and a `Mutex` serializes concurrent `loadSounds` passes — a pass reading a pre-migration snapshot could finish last and clobber a fresher projection (root cause of `PrivateOnlyAudiosHiddenFromMySoundsTest` failing 2/4 suite runs; 0/33 targeted runs after the fix). The gated-init VM contract test pins flag-after-projection deterministically.
- **Deliberately unchanged**: deep-link allowlist (§ Security), Vault gate (self-gating body), creation Activities (`AddButton`/`Recording` → 003c). Baseline Profile regen deferred to the pre-release cycle (more startup-path changes still landing).

### Code review tips
- `LandingNavigator.close(key)` vs `goBack()`: Manage's "view collection" switches tab before closing — close-by-value removes it from the *origin* stack (round 2 made it remove exactly one instance, preferring the active stack). The VM→graph `LaunchedEffect` also stops an open immersive listen on programmatic tab changes (deep link) so no session plays headless.
- `NavDisplay.onBack` is route-aware (stops immersive playback before popping) — riskiest new line; covered by the new `systemBackFromImmersiveListenModeStopsPlayback…` instrumented test.
- Vendored `BottomSheetSceneStrategy` compiles against nav3 1.1.4 — diff it against the recipe if it ever misbehaves.
- The flag→lists read order in `LandingScreen`/`VaultScreen` heads is a documented invariant — reordering those `collectAsState*` lines silently reintroduces the cold-start flash.
- **Manual verification suggested**: saved-stack restore on a **minified release** build (kotlinx-serialization + R8 is new to this graph), predictive-back gesture feel on device, and a cold start with existing audios on the Pixel 8 (the device where the flash was reported).
- Instrumented triage during development: the `PrivateOnlyAudiosHiddenFromMySoundsTest` repeat failure was diagnosed as a REAL race (stale loadSounds writer) and fixed by the mutex above. Remaining one-time flakes, none ever twice: 2 in untouched `AddButtonCreateFlowTest`, one `ComposeTimeoutException` in `AssignCollectionSheetFlowTest` (same stale-writer symptom, likely also cured), one in `InboundUriValidationFlowTest`, and one documented GC-timing `StrictMode InstanceCountViolation` in `SearchOverlayTest` (known artifact, deferred to the LeakCanary track).

### Already tested
- [x] Local instrumented suite (full, forced, cold-boot AVD): 133 executed, **0 failed**, 2 assumption-skips (cafecito locale, explore-without-bundled) — re-run clean after round 2 + cold-start fix
- [x] `./gradlew test` + `./gradlew check -x test` green local (CI re-runs them)
- [x] Cold-start flash repro on emulator (10 seeded audios, instrumented logging): 3/3 flash before the fix → 0/3 after; confirmed on the Pixel 8 with real data
- [x] Projection race: `PrivateOnlyAudiosHiddenFromMySoundsTest` 1/10 fail isolated before the mutex → 0/25 after (+ 0/8 `AssignCollectionSheetFlowTest`)
