### PR TITLE
fix(exec-report): read screen_view name from firebase_screen key

### DIFF
--- a/.claude/skills/exec-report/SKILL.md
+++ b/.claude/skills/exec-report/SKILL.md
@@ -115,8 +115,11 @@ Compare the last 7 days vs the previous 7 days whenever there is data.
       `vault_unprotected_warning_shown`; `vault_search_unlock_cta_shown`).
    k) UNMET DEMAND: `search_zero_results` (+ `query_length`).
    l) MONETIZATION: `about_gratitude_cafecito_open` + `about_gratitude_kofi_open`.
-   m) NAVIGATION: `screen_view` by param `screen_name` (my_sounds, explore_sounds, vault, vault_listen,
-      about, search_sound, add_sound, edit_sound, manage_collections, onboarding, record_sound).
+   m) NAVIGATION: `screen_view` broken down by screen. Read the name from `event_params`
+      key `firebase_screen` — the export uses that key, not `screen_name` (Firebase renames
+      the SDK's SCREEN_NAME param). Values (`CanonicalScreenName.kt`): my_sounds,
+      explore_sounds, about, search_sound, add_sound, edit_sound, vault, vault_listen,
+      vault_unlock, collection_create, manage_collections, onboarding, bring_guide, record_sound.
 
    Available user properties (to segment if useful): `current_sounds`, `current_pinned`,
    `current_public_colls`, `current_private_colls`, `current_audios_in_colls`, `current_public_default`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -850,7 +850,7 @@ After enabling the BQ export, the first daily run lands ~24 h later. `bq ls --pr
 | Dataset | Tables |
 |---|---|
 | `firebase_crashlytics` | `com_github_barriosnahuel_vossosunboton_ANDROID` (one row per non-fatal/fatal; `event_timestamp`, `issue_id`, stack trace, sessions when enabled) |
-| `analytics_<GA4_PROPERTY_ID>` | `events_YYYYMMDD` (one row per event, params nested) — property ID is numeric, distinct from project ID, visible only after the first dataset materializes |
+| `analytics_<GA4_PROPERTY_ID>` | `events_YYYYMMDD` (one row per event, params nested) — property ID is numeric, distinct from project ID, visible only after the first dataset materializes. **`screen_view` gotcha:** the screen name is in `event_params` under key `firebase_screen` (class in `firebase_screen_class`), **not** `screen_name` — Firebase renames the reserved `SCREEN_NAME` param in the export, so querying `key='screen_name'` returns NULL for every row. |
 | `firebase_performance` | `com_github_barriosnahuel_vossosunboton_ANDROID` — one row per perf event; `event_type` ∈ {`DURATION_TRACE` (incl. `_app_start`), `SCREEN_TRACE` (`_st_<Activity>`, carries `screen_info.slow_frame_ratio` / `frozen_frame_ratio`), `TRACE_METRIC`, `NETWORK_REQUEST`}; segment by `app_build_version` (versionCode) + `device_name`. No cold/warm/hot dimension. |
 
 ### Sanity-check query


### PR DESCRIPTION
### Summary

Fixes the weekly executive report's **Navigation** axis, which was blind.

1. You run the weekly executive report
2. You look at the Navigation axis (screen breakdown)

**before:** the axis comes back empty / "not breakable down" — you can't see which screens users visit, even though the data is there.
**after:** it breaks down per screen (`my_sounds`, `vault`, `about`, …), reading the value that actually exists in the export.

The app's `screen_view` tracking was never broken — this is a read-side fix in the report query. All past weeks remain queryable retroactively.

### Technical detail

Root cause: the report read the screen name from `event_params` key `screen_name`, but that key doesn't exist in the GA4/BigQuery export.

- **`exec-report/SKILL.md` — Navigation axis:** read the screen name from key `firebase_screen`. Firebase renames the reserved `SCREEN_NAME` param (which the app logs via `FirebaseAnalytics.Param.SCREEN_NAME`) to `firebase_screen` in the export, so `screen_name` returned NULL for every row.
- **`SKILL.md` — screen list:** completed the canonical list against `CanonicalScreenName.kt` — added `vault_unlock`, `collection_create`, `bring_guide` (were missing).
- **`CONTRIBUTING.md` § BigQuery export:** documented the rename on the `analytics_*` dataset row — the string `firebase_screen` previously appeared nowhere in the repo, which is what let the bug slip.
- **Out of scope:** no app/code change — tracking is correct; verified empirically, not touched.

### Code review tips

- Verified against `bomp-prod`: `firebase_screen` resolves the screen (`my_sounds`), `screen_name` returns NULL — so the fix is confirmed at the source, not just theory.
- **Separate latent bug in the same skill, NOT touched here (flagging for a follow-up decision):** the GA4 windowing rule (`SKILL.md` ~L134) compares `event_timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), …)`, but `event_timestamp` is INT64 micros in the export → BigQuery raises a type error (`INT64 >= TIMESTAMP`). It needs `TIMESTAMP_MICROS(event_timestamp)`. Confirmed the type mismatch while verifying this fix. Left out to keep this PR scoped; worth its own PR since it could affect every GA4 query in the report.

### Already tested

- Corrected navigation query run against `bomp-prod.analytics_536876881` (7-day window): breaks down by `firebase_screen`; old `screen_name` key confirmed NULL.
