### PR TITLE
fix(exec-report): cast GA4 event_timestamp to TIMESTAMP in windowing

### DIFF
--- a/.claude/skills/exec-report/SKILL.md
+++ b/.claude/skills/exec-report/SKILL.md
@@ -128,20 +128,22 @@ Compare the last 7 days vs the previous 7 days whenever there is data.
    `lifetime_coll_assigns`, `lifetime_vault_unlocks`.
 
    **GA4 windowing (use this WHERE in every GA4 query — it fixes three traps):** filter precisely on
-   `event_timestamp` for an exact N×24h window (so it matches the sessions axis, not 8 days), and prune
+   `event_timestamp` (INT64 microseconds in the GA4 export — wrap in `TIMESTAMP_MICROS` to compare with a
+   `TIMESTAMP`, else BigQuery raises a type error) for an exact N×24h window (so it matches the sessions
+   axis, not 8 days), and prune
    tables with a regex that matches BOTH finalized `events_YYYYMMDD` AND `events_intraday_YYYYMMDD`
    (otherwise the most recent 1-3 days — which lag finalization, and the intraday table — are silently
    dropped right after a release):
 
    ```
-   WHERE event_timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 7 DAY)
+   WHERE TIMESTAMP_MICROS(event_timestamp) >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 7 DAY)
      AND REGEXP_EXTRACT(_TABLE_SUFFIX, r'[0-9]{8}$') >= FORMAT_DATE('%Y%m%d', DATE_SUB(CURRENT_DATE(), INTERVAL 8 DAY))
    ```
    (For 7d-vs-prev-7d, widen both bounds to 14 days and split on `event_timestamp`.)
 
    GA4 reference query (event counts, windowed per the rule above): `SELECT event_name, COUNT(*) n,
    COUNT(DISTINCT user_pseudo_id) usuarios FROM `bomp-prod.analytics_XXX.events_*` WHERE
-   event_timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(),INTERVAL 7 DAY) AND
+   TIMESTAMP_MICROS(event_timestamp) >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(),INTERVAL 7 DAY) AND
    REGEXP_EXTRACT(_TABLE_SUFFIX, r'[0-9]{8}$') >= FORMAT_DATE('%Y%m%d',DATE_SUB(CURRENT_DATE(),INTERVAL 8 DAY))
    GROUP BY event_name ORDER BY n DESC`.
 
@@ -202,7 +204,7 @@ Compare the last 7 days vs the previous 7 days whenever there is data.
     SELECT user_pseudo_id,
       ARRAY_AGG(app_info.version ORDER BY event_timestamp DESC LIMIT 1)[OFFSET(0)] ver
     FROM `bomp-prod.analytics_XXX.events_*`
-    WHERE event_timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(),INTERVAL 7 DAY)
+    WHERE TIMESTAMP_MICROS(event_timestamp) >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(),INTERVAL 7 DAY)
       AND REGEXP_EXTRACT(_TABLE_SUFFIX, r'[0-9]{8}$') >= FORMAT_DATE('%Y%m%d',DATE_SUB(CURRENT_DATE(),INTERVAL 8 DAY))
     GROUP BY user_pseudo_id
   ) GROUP BY ver ORDER BY usuarios DESC;`


### PR DESCRIPTION
### Summary

Fixes a second, separate defect in the weekly report's GA4 queries (surfaced while fixing the navigation axis in #1276).

1. The scheduled report runs its GA4 (product/funnel) queries
2. Each one applies the "GA4 windowing rule" to scope the last 7 days

**before:** the rule compares `event_timestamp >= TIMESTAMP_SUB(…)`, but in the GA4 export `event_timestamp` is INT64 microseconds — so BigQuery rejects it with a type error (`INT64 >= TIMESTAMP`). Every GA4 query as written throws; the report only worked because the runtime agent patched the query on the fly.
**after:** the rule runs as written — the whole product/funnel axis no longer depends on improvisation.

Internal tooling — no app behavior change.

### Technical detail

- **`exec-report/SKILL.md` — 3 GA4 blocks** now wrap the column as `TIMESTAMP_MICROS(event_timestamp)`: the canonical windowing rule, the event-count reference query, and the version-share query.
- **Windowing-rule prose:** added one clause naming *why* the cast exists (INT64 micros in the export) so it isn't "cleaned up" later.
- **`firebase_sessions` engagement query — deliberately untouched:** `event_timestamp` is a real `TIMESTAMP` in that dataset (verified via `INFORMATION_SCHEMA`), so its direct comparison is correct. The `ORDER BY event_timestamp` in the version-share subquery also stays — INT64 sorts chronologically.

### Code review tips

- The fix hinges on a per-dataset type difference: GA4 `analytics_*` = INT64 micros; `firebase_sessions` = TIMESTAMP. Both confirmed against `bomp-prod` before editing — the cast is applied to GA4 blocks only, not blanket.
- Verified end-to-end: the corrected GA4 reference query runs against `bomp-prod.analytics_536876881` and returns event counts (previously a hard type error).

### Already tested

- Corrected GA4 reference query run against `bomp-prod.analytics_536876881` (7-day window): runs clean, returns `user_engagement` / `session_start` / `screen_view` counts.
- Confirmed the `firebase_sessions` engagement query is untouched and its column is genuinely `TIMESTAMP`.
