### PR TITLE
feat(share): reword app-share menu action to "Share app"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog][]. Through v2.3.0 this project used [S
 - Long listens now show up in your system media controls — playing an audio from the Vault's listen screen (or reviewing a recording) surfaces a media notification with lock-screen controls, and headset/media keys pause and resume it; quick soundboard taps stay notification-free
 
 ### Changed
+- The "⋮" menu's invite action is now labelled "Share app" ("Compartí la app" in Spanish) instead of "Share Bomp", so it reads as sharing the app rather than a single audio
 - Opening a Vault audio's listen screen now always starts it from the beginning — previously a reopened audio silently resumed from where it was left mid-clip
 
 ### For nerds 🤓

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -3,7 +3,7 @@
 
     <string name="app_share_chooser_title">Compartir vía</string>
     <string name="app_share_caption_invite">Tenelo a un toque cuando quieras escucharlo.\nTu colección de voces, en Bomp 👉 %1$s</string>
-    <string name="app_share_app_menu_item">Compartí Bomp</string>
+    <string name="app_share_app_menu_item">Compartí la app</string>
     <string name="app_share_app_invite">Mis voces favoritas, siempre a un toque. Esto es Bomp 👉 %1$s</string>
     <string name="app_share_feedback_unshareable">No se pudo compartir este Bomp. Nahu ya se enteró y lo va a investigar.</string>
     <string name="app_share_feedback_no_app_for_audio">No tenés una app para compartir audios. Probá instalando una.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
 
     <string name="app_share_chooser_title">Share vía</string>
     <string name="app_share_caption_invite">Have it one tap away whenever you want to hear it.\nYour collection of voices, on Bomp 👉 %1$s</string>
-    <string name="app_share_app_menu_item">Share Bomp</string>
+    <string name="app_share_app_menu_item">Share app</string>
     <string name="app_share_app_invite">My favorite voices, always one tap away. This is Bomp 👉 %1$s</string>
     <string name="app_share_feedback_unshareable">Couldn\'t share this Bomp. Nahu\'s already on it.</string>
     <string name="app_share_feedback_no_app_for_audio">No app on your device can share audio. Try installing one.</string>

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
@@ -116,7 +116,7 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
         // its stable tag rather than the ambiguous text; the other three labels are unique.
         val help = composeTestRule.onNodeWithTag(OVERFLOW_SEE_HOW_IT_WORKS_TAG)
         val collections = composeTestRule.onNodeWithText("Manage collections")
-        val share = composeTestRule.onNodeWithText("Share Bomp")
+        val share = composeTestRule.onNodeWithText("Share app")
         val about = composeTestRule.onNodeWithText("About")
 
         // Each item is actually on screen (not merely composed) — guards the AGPLv3-required About entry


### PR DESCRIPTION
### Summary

1. User opens the "⋮" menu in the top bar
2. Looks at the action that shares the app (a Play Store invite)

**before:** it reads "Share Bomp" / "Compartí Bomp" — ambiguous, it looks like it shares one audio.
**after:** it reads "Share app" / "Compartí la app" — clearly names sharing the app itself. The invite message the recipient gets is unchanged.

### Technical detail

- **`app_share_app_menu_item`** relabelled in both locales: `values/strings.xml` (EN master) and `values-es/strings.xml`. Only the overflow-menu invite label; the share intent, invite text (`app_share_app_invite`) and chooser title are untouched.
- **`LandingScreenTest`** — the overflow-order assertion now matches on `"Share app"`; still enforces `collections < share < about` ordering.

### Code review tips

- Copy-only. The item's only runtime consumer is `LandingScreen.kt:751`; `onClick` fires `ShareAppIntent.launch(…CONTENT_MENU)`, fully decoupled from the label — no behaviour change to the shared message or Play referrer.
- Pre-existing gap (not introduced here): the ordering test hardcodes the English label, so the Spanish string has no test coverage — same as before the rename.
- Interpretation: exact wording was user-dictated. It intentionally drops the "Bomp" proper noun from this label; the invite body still carries the brand.

### Already tested

Copy-only change — instrumented suite is exempt per CLAUDE.md ("Cosmetic-only changes (copy) are exempt"). Unit + lint run in CI.