### PR TITLE
docs(exec-report): distinguish 0-in-window from broken instrumentation

### DIFF
--- a/.claude/skills/exec-report/SKILL.md
+++ b/.claude/skills/exec-report/SKILL.md
@@ -149,6 +149,19 @@ Compare the last 7 days vs the previous 7 days whenever there is data.
 
    Prioritize funnels with signal; if a funnel has 0 events, summarize it in one line, don't break it down.
 
+   **0-in-window ≠ broken instrumentation (recency check first).** Before attributing a 0 to an
+   instrumentation gap, verify the event's most recent occurrence (a 30–90 day count / last-seen date). If
+   it fired recently *outside* the current window, the instrumentation is healthy and the 0 is **real
+   usage** — report it as such, never as a "possible gap". Only call it an instrumentation gap when the
+   event never appears at all, or stopped appearing right after a release that touched it. (Lesson: a
+   week with `sound_add`=0 in-window but `sound_add` last-seen 3 weeks ago is a quiet week, not a gap.)
+
+   **Funnel coherence (read steps together, not in isolation).** When an upstream step has signal and its
+   downstream step is 0, that is a **drop-off** to surface — not a contradiction and not a gap. Never frame
+   the same behavior as "activity happened" in one place and "no activity / maybe not instrumented" in
+   another. Canonical: `recording_completed` > 0 with `sound_add` (`source=record`) = 0 → users record but
+   don't save; the finding is the abandonment at the save step, not "no creations recorded".
+
 3. **QUALITY:** crash-free, number and top crashes (Crashlytics), ANRs (Play) — ALWAYS broken down by
    version. These are **counts/rates, not medianable** (no "median of a crash count"): keep raw
    crash-free % and counts, but apply the per-device + min-N + single-device-domination guards from the

--- a/.claude/skills/exec-report/SKILL.md
+++ b/.claude/skills/exec-report/SKILL.md
@@ -149,12 +149,27 @@ Compare the last 7 days vs the previous 7 days whenever there is data.
 
    Prioritize funnels with signal; if a funnel has 0 events, summarize it in one line, don't break it down.
 
-   **0-in-window ≠ broken instrumentation (recency check first).** Before attributing a 0 to an
-   instrumentation gap, verify the event's most recent occurrence (a 30–90 day count / last-seen date). If
-   it fired recently *outside* the current window, the instrumentation is healthy and the 0 is **real
-   usage** — report it as such, never as a "possible gap". Only call it an instrumentation gap when the
-   event never appears at all, or stopped appearing right after a release that touched it. (Lesson: a
-   week with `sound_add`=0 in-window but `sound_add` last-seen 3 weeks ago is a quiet week, not a gap.)
+   **0-in-window ≠ broken instrumentation — but cut by version before deciding.** A 0 has two very
+   different causes (a quiet week vs. a tracker that died); recency alone can't tell them apart, because a
+   fresh regression looks exactly like a quiet week if the event fired fine on the previous version. Work
+   the checks in this order:
+
+   1. **Recency** — get the event's last-seen date / 30–90 day count. Never fired at all → instrumentation
+      gap, stop here.
+   2. **Version** — if it fired historically, cut it by `app_info.version`. Still emitting on the version
+      that dominates the window → instrumentation is healthy and the 0 is **real usage**; report it as such,
+      never as a "possible gap". Alive on older versions and 0 on the current one → suspect a **regression
+      introduced by that release** and say so, *even when nothing in the release obviously "touched" the
+      event* — an R8 rule, a nav refactor, or a screen that quietly stopped calling the tracker all break it
+      without naming it.
+   3. **Corroborate before crying wolf** — a 0 on a new version means nothing if barely anyone is on it, or
+      if the whole surface is idle. Require enough users on that version (same min-N guard as the
+      QUALITY/PERFORMANCE cuts) and check a **sibling event on the same screen**: siblings alive + this one
+      dead = instrumentation; the whole screen dead = real usage.
+
+   (Lesson: `sound_add`=0 in-window, last-seen 3 weeks ago, and the current version still emits it elsewhere
+   → quiet week, not a gap. Same 0 with the event alive on the previous version, dead on the new one, while
+   `recording_completed` keeps firing there → regression, not a quiet week.)
 
    **Funnel coherence (read steps together, not in isolation).** When an upstream step has signal and its
    downstream step is 0, that is a **drop-off** to surface — not a contradiction and not a gap. Never frame


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change.

Hardens the weekly executive report so it stops mis-reading the funnel. In the last run, a week with zero sound creations *in the window* was reported as a "possible instrumentation gap", while the same report said elsewhere that users were recording audio — two contradictory readings of the same funnel, and a false alarm that would have sent us chasing a non-existent analytics bug. The symmetric failure is worse: a release that silently breaks a tracker looks *exactly* like a quiet week, so the report would have shrugged at a real regression.

### Technical detail

Adds two interpretation guardrails to the PRODUCT-FUNNEL step of `.claude/skills/exec-report/SKILL.md`:

- **A 0 in the window is triaged in three ordered checks, not one.** (1) *Recency* — never fired at all → gap, stop. (2) *Version cut* by `app_info.version` — still emitting on the version that dominates the window → healthy, the 0 is **real usage**; alive on older versions and dead on the current one → suspect a **regression introduced by that release**, even when nothing in it obviously "touched" the event (an R8 rule, a nav refactor, a screen that stopped calling the tracker all break it without naming it). (3) *Corroborate* — a 0 on a new version means nothing if barely anyone is on it: require the same min-N guard as the QUALITY/PERFORMANCE cuts, and check a **sibling event on the same screen** (siblings alive + this one dead = instrumentation; whole screen dead = real usage).
- **Funnel coherence — read steps together.** Upstream step with signal + downstream step at `0` is a **drop-off**, not a contradiction. Canonical case spelled out in the skill: `recording_completed` > 0 with `sound_add` (`source=record`) = 0 → users record but don't save; the finding is the abandonment at the save step.
- **Deliberately unchanged:** the queries themselves, the report sections, and the delivery format. This is a reading/interpretation guardrail, not a data-collection change. The version cut reuses the existing min-N guard rather than inventing a second threshold.

### Code review tips

- The skill is the single source of truth for the Friday scheduled report — a wording change here changes what the next automated run says. Worth reading the new block as the report author would, not as a diff.
- The riskiest line is the "healthy → real usage" verdict: it is only safe **because** it is now gated on the version cut. Loosening that ordering re-opens the "new release broke the tracker" blind spot.
- Rules are phrased as positive routing ("cut by version", "surface the drop-off") rather than "don't do X", per skill-authoring guidance.

### Already tested

- [x] Re-read against the last real report run: the rules flip the false "instrumentation gap" finding into the correct "quiet week + save-step abandonment" finding.
- [x] Walked the inverse scenario (new release kills an event that fired fine on the previous one): the version cut + sibling-event check catch it, where the recency check alone would have called it a quiet week.
- [x] No code, resources or build files touched — no test/lint surface. Pre-push guards (ADR invariants, security-test count, analytics wrapper, ktlint/detekt/spotless) pass.
