### PR TITLE
fix(share): keep the share trampoline out of Bomp's task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog][]. Through v2.3.0 this project used [S
 - Opening a Vault audio's listen screen now always starts it from the beginning — previously a reopened audio silently resumed from where it was left mid-clip
 
 ### Fixed
+- Sharing an audio into Bomp from another app now returns you to that app once you save it, even when Bomp was already open in your recent apps — previously it left you inside Bomp, having to go back through its screens to get out
 - Opening the app no longer briefly flashes an empty state — inspirational or a collection filter's "no results" — while your Bomps are still loading; the list now waits for the first load before deciding what to show
 - An audio hidden from My Bomps (Vault-only) can no longer briefly reappear in the list right after opening the app — concurrent list refreshes could land out of order and show a stale view
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -76,13 +76,30 @@
 
         </activity>
 
+        <!--
+            Share-sheet entry point. The task attributes ARE the product contract: saving an audio the
+            user shared from another app must return them to that app, leaving whatever they had open in
+            Bomp untouched.
+
+            singleTop, not singleTask: singleTask "locates the activity on an existing task with the same
+            affinity", so once Bomp was in Recents the share landed inside Bomp's own task and pulled it
+            to the foreground — finishing then dropped the user into Bomp's history instead of back into
+            the app they shared from. singleTop is "launched into the task that called startActivity()",
+            which is exactly the wanted behavior, and still routes a re-share to the live instance
+            through onNewIntent.
+
+            Empty taskAffinity so a caller sharing with FLAG_ACTIVITY_NEW_TASK cannot pull it into Bomp's
+            task on affinity alone; excludeFromRecents then keeps that fallback task out of Recents. No
+            parentActivityName: Landing is not this screen's Up parent — the way out is finish(), back to
+            the sharing app.
+        -->
         <activity
             android:name=".feature.addbutton.AddButtonActivity"
             android:exported="true"
             android:label="@string/app_addbutton_activity_label"
             android:excludeFromRecents="true"
-            android:launchMode="singleTask"
-            android:parentActivityName=".ui.home.LandingActivity"
+            android:launchMode="singleTop"
+            android:taskAffinity=""
             tools:ignore="Instantiatable">
 
             <intent-filter>

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/ShareTrampolineTaskTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/feature/addbutton/ShareTrampolineTaskTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.feature.addbutton
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.ActivityInfo
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * The share-sheet contract, asserted where it actually lives: the manifest. Sharing an audio into Bomp
+ * must not drag the user into Bomp — saving (or backing out) returns them to the app they shared from,
+ * with whatever they had open in Bomp left untouched.
+ *
+ * That is a task-level guarantee, so it is spelled in task-level attributes and can only regress there;
+ * no UI test can see it, because the failure needs a *second* task (Bomp already in Recents) to exist.
+ */
+internal class ShareTrampolineTaskTest : AbstractRobolectricTest() {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val trampoline: ActivityInfo
+        get() =
+            context.packageManager.getActivityInfo(
+                ComponentName(context, AddButtonActivity::class.java),
+                0,
+            )
+
+    @Test
+    fun `the share trampoline is launched into the task of the app that shared the audio`() {
+        // singleTask would instead "locate the activity on an existing task with the same affinity"
+        // (developer.android.com/guide/components/activities/tasks-and-back-stack): with Bomp already in
+        // Recents, the share lands inside Bomp's own task and pulls the whole thing to the foreground —
+        // so finishing drops the user into Bomp's history rather than back into WhatsApp.
+        assertThat(trampoline.launchMode).isEqualTo(ActivityInfo.LAUNCH_SINGLE_TOP)
+    }
+
+    @Test
+    fun `the share trampoline has no affinity with Bomp's own task`() {
+        // A caller that shares with FLAG_ACTIVITY_NEW_TASK would otherwise route the trampoline into
+        // Bomp's task on affinity alone, re-creating the same bug from the other direction.
+        assertThat(trampoline.taskAffinity).isNotEqualTo(context.applicationInfo.taskAffinity)
+    }
+
+    @Test
+    fun `the share trampoline never leaves a ghost entry in Recents`() {
+        // Only meaningful while the trampoline is the root of its own task, which is the fallback path
+        // when the sharing app hands it a task of its own.
+        assertThat(trampoline.flags and ActivityInfo.FLAG_EXCLUDE_FROM_RECENTS).isNotEqualTo(0)
+    }
+}


### PR DESCRIPTION
### Summary

1. User opens Bomp, browses around, leaves it open in Recents
2. Switches to WhatsApp, long-presses a voice note, shares it into Bomp
3. Names it and taps Save

**before:** Save drops the user *inside Bomp* — on whatever screen they had left open — and getting back to WhatsApp means backing out through Bomp's whole history. Sharing an audio quietly hijacked the task they were in. (Only reproducible with Bomp already in Recents; from a cold Bomp it behaved correctly, which is why it slipped through.)
**after:** Save (or Back) returns straight to WhatsApp. Whatever the user had open in Bomp is left untouched, exactly where it was.

### Technical detail

The share-sheet entry point's task attributes in `AndroidManifest.xml` — the contract lives there, not in code.

- **`launchMode`: `singleTask` → `singleTop`.** `singleTask` "locates the activity on an existing task with the same affinity" ([tasks and back stack](https://developer.android.com/guide/components/activities/tasks-and-back-stack)), so once Bomp had a task, the share was routed *into it* and pulled it foreground. `singleTop` is launched into the task that called `startActivity()` — the sharing app's — and still funnels a re-share to the live instance via `onNewIntent`.
- **`taskAffinity=""`.** Kills the affinity match itself, so a caller sharing with `FLAG_ACTIVITY_NEW_TASK` can't route the trampoline into Bomp's task through the back door.
- **`excludeFromRecents="true"`.** Covers that fallback: if the trampoline does end up rooting its own task, it doesn't leave a ghost Bomp card in Recents.
- **`parentActivityName` removed.** Landing was never this screen's Up parent — the way out is `finish()`, back to the sharing app.
- **`ShareTrampolineTaskTest`** asserts the three attributes off the real `ActivityInfo` resolved through `PackageManager`, so a manifest regression fails a unit test.

### Code review tips

- **No UI test can see this.** The bug needs a *second* task to exist (Bomp in Recents); instrumentation runs in one. That's why the guard is a manifest assertion, not a Compose test — reproduce by hand: open Bomp, home, share an audio from another app, save.
- `singleTop` (not `standard`) is load-bearing: a user sharing twice in a row must reuse the live instance through `onNewIntent`, which `AddButtonActivity` already handles.
- The activity is `exported="true"` — the change widens *who can launch it into their own task*, not *what it accepts*. Inbound URI validation (scheme allowlist, `audio/` MIME, 50 MB cap) is untouched.

### Already tested

- unit: `./gradlew test` green, incl. the 3 new `ShareTrampolineTaskTest` cases (2 of them red before the fix)
- instrumented: run locally via `./scripts/run-instrumented-tests.sh`, 131/131 green (2 skipped)
- manual on a Pixel 8: share from WhatsApp with Bomp already in Recents → Save returns to WhatsApp, Bomp's open screen preserved
