### PR TITLE
Make the Nav3 back stack the only source of truth for navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog][]. Through v2.3.0 this project used [S
 - Opening a Vault audio's listen screen now always starts it from the beginning — previously a reopened audio silently resumed from where it was left mid-clip
 
 ### Fixed
+- Opening a collection from "Manage collections" now takes you straight to it — the manage screen no longer stays behind, waiting to reappear when you come back to the tab you opened it from
 - Sharing an audio into Bomp from another app now returns you to that app once you save it, even when Bomp was already open in your recent apps — previously it left you inside Bomp, having to go back through its screens to get out
 - Opening the app no longer briefly flashes an empty state — inspirational or a collection filter's "no results" — while your Bomps are still loading; the list now waits for the first load before deciding what to show
 - An audio hidden from My Bomps (Vault-only) can no longer briefly reappear in the list right after opening the app — concurrent list refreshes could land out of order and show a stale view
@@ -33,6 +34,9 @@ The format is based on [Keep a Changelog][]. Through v2.3.0 this project used [S
 - Creation flows are graph destinations (ADR 0024 D4): `RecordingActivity` is gone (now the `RecorderHost` destination) and `AddButtonActivity` is reduced to the share-sheet trampoline, keeping the task-level `excludeFromRecents` + return-to-source contract that a destination cannot honor. Screen-lifetime ViewModels scope per `NavEntry` (`lifecycle-viewmodel-navigation3`), and a grep invariant now fails the build if internal navigation reintroduces `startActivity` on one of our own Activities
 - Release tags, GitHub release titles and CHANGELOG headers move from day-precision CalVer (`vYYYY.MM.DD`) to month + sequential counter (`vYYYY.MM.N`), so the month's milestone can be created up front and assigned to every PR at creation (ADR 0023 amending ADR 0021)
 - Waveform envelope extraction demuxes via Media3's `MediaExtractorCompat` instead of the AEP-prohibited `MediaExtractor` (`MediaCodec` decode unchanged); all sources normalize to per-decode temp files to route around a Media3 1.10.1 truncation bug with fd/content/resource sources — envelope verified bit-comparable (1 of 48 bars off by 0.014)
+
+#### Changed
+- The Nav3 back stack is now the single source of truth for the active tab (ADR 0024, amended): `SoundsViewModel` mirrors it instead of persisting a second copy in `SavedStateHandle`, and programmatic navigation (deep links, "view collection") goes through `LandingNavigator`, landing on the destination tab's root. The ADR's "declarative deep links" wording is corrected — Navigation 3 ships no such API; the Activity-side matcher is the official recipe, and the allowlist + Home-fallback security invariant is unchanged
 
 #### Fixed
 - `screen_view` for the add/edit-Bomp and recorder screens now fires from composition instead of `Activity.onCreate`, where the GA4 SDK silently dropped it — `add_sound`, `edit_sound` and `record_sound` had never reached the analytics export

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,7 +233,7 @@ Canonical implementation: `AddButtonFeature.saveNewButtonAsync`. Any future inbo
 
 ### Deep link path allowlist
 
-`push-me://open<path>` routes against a closed allowlist in `LandingActivity.handleDeeplink`. Today: `/home` → `MY_SOUNDS`, `/explore` → `EXPLORE_SOUNDS`. **Unknown paths fall back to `MY_SOUNDS`** (the safe default) — never silently route to Explore or any other tab. New destinations require an explicit branch in the `when`; the `else` stays `MY_SOUNDS`.
+`push-me://open<path>` routes against a closed allowlist in `LandingActivity.handleDeeplink`. Today: `/home` → `MY_SOUNDS`, `/explore` → `EXPLORE_SOUNDS`. **Unknown paths fall back to `MY_SOUNDS`** (the safe default) — never silently route to Explore or any other tab. New destinations require an explicit branch in the `when`; the `else` stays `MY_SOUNDS`. The resolved tab reaches the graph as a one-shot event that resets that tab to its root.
 
 ### Backup hygiene
 
@@ -326,7 +326,7 @@ Hard rules (calque examples, reserved-term list with ✓/❌, read-aloud detail 
 
 ## Store listing asset generation
 
-Store listing PNGs (icon, feature graphic) render from SVG masters under `store-listing/`. Canonical pipeline: `rsvg-convert` (`brew install librsvg`); brand font Inter must be installed system-wide. Tooling tradeoffs, install command, exact export commands, and screenshot capture all live in `CONTRIBUTING.md` § *Store listing*. For copy in screenshots / feature graphic taglines, see § *Copy & localization*.
+Store listing PNGs (icon, feature graphic) render from SVG masters under `store-listing/` via `rsvg-convert`; brand font Inter must be installed system-wide. Pipeline, install and export commands, screenshot capture: CONTRIBUTING.md § *Store listing*. Copy in screenshots / taglines: § *Copy & localization*.
 
 ## Labels and milestone
 

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/collections/ManageCollectionsScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/feature/collections/ManageCollectionsScreen.kt
@@ -95,6 +95,9 @@ internal fun ManageCollectionsScreen(
     viewModel: SoundsViewModel,
     focusedCollectionId: String?,
     onBack: () -> Unit,
+    // Opening a collection is navigation, not a ViewModel state poke: the caller sends the graph to
+    // that tab's root, which also closes this screen (its entry lives on a stack being reset).
+    onViewCollectionIn: (AppTab) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val collections by viewModel.collections.collectAsState()
@@ -158,11 +161,10 @@ internal fun ManageCollectionsScreen(
                         isHighlighted = highlightedId == collection.id,
                         onViewClick = {
                             viewModel.trackCollectionView(isPublic = true)
-                            // Set tab + filter before closing so LandingScreen re-renders against
-                            // both new values in a single composition pass.
-                            viewModel.selectTab(AppTab.MY_SOUNDS)
+                            // Filter first, then navigate: LandingScreen renders the destination tab
+                            // against the new filter in a single composition pass.
                             viewModel.selectMySoundsFilter(collection.id)
-                            onBack()
+                            onViewCollectionIn(AppTab.MY_SOUNDS)
                         },
                         onRenameClick = { viewModel.requestRenameCollection(collection.id) },
                         onDeleteClick = { viewModel.requestDeleteConfirmation(collection.id) },
@@ -205,9 +207,8 @@ internal fun ManageCollectionsScreen(
                         isHighlighted = highlightedId == collection.id,
                         onViewClick = {
                             viewModel.trackCollectionView(isPublic = false)
-                            viewModel.selectTab(AppTab.VAULT)
                             viewModel.selectVaultFilter(collection.id)
-                            onBack()
+                            onViewCollectionIn(AppTab.VAULT)
                         },
                         onRenameClick = { viewModel.requestRenameCollection(collection.id) },
                         onDeleteClick = { viewModel.requestDeleteConfirmation(collection.id) },

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivity.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivity.kt
@@ -16,6 +16,7 @@ import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.fragment.app.FragmentActivity
 import com.github.barriosnahuel.vossosunboton.CustomBuildTypeApplication
 import com.github.barriosnahuel.vossosunboton.model.data.local.defaultaudios.PackagedAudios
+import com.github.barriosnahuel.vossosunboton.ui.home.navigation.resolveDeepLinkTab
 import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
 
 // FragmentActivity (vs the smaller ComponentActivity) is required so androidx.biometric's
@@ -34,12 +35,21 @@ class LandingActivity : FragmentActivity() {
                 LandingScreen(viewModel = viewModel)
             }
         }
-        handleDeeplink(intent)
+        // Only on a fresh start: the launching Intent survives in `getIntent()` across recreates, so
+        // replaying it on every rotation would re-navigate — and a deep link now resets the tab it
+        // names, which would silently discard whatever the user had opened since (an unsaved take,
+        // a half-typed name). A restored Activity already has its back stack; it needs no link.
+        if (savedInstanceState == null) {
+            handleDeeplink(intent)
+        }
         maybeSeedDebugSounds(intent)
     }
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
+        // Keep getIntent() pointing at the newest Intent, so a later recreate restores from the one
+        // the user actually arrived on rather than the stale launcher Intent.
+        setIntent(intent)
         handleDeeplink(intent)
         maybeSeedDebugSounds(intent)
     }
@@ -53,23 +63,9 @@ class LandingActivity : FragmentActivity() {
 
     private fun handleDeeplink(intent: Intent) {
         val uri = intent.data ?: return
-        // Closed allowlist of known deep-link destinations. Unknown paths fall back to MY_SOUNDS
-        // (the safe default) so we never silently route to a tab the link did not name.
-        val requested =
-            when (uri.path) {
-                "/home" -> AppTab.MY_SOUNDS
-                "/explore" -> AppTab.EXPLORE_SOUNDS
-                else -> AppTab.MY_SOUNDS
-            }
-        // Explore is empty in release builds (no bundled audios) and in any debug build that
-        // hasn't populated model/src/debug/res/raw/. Routing there would land on a blank tab,
-        // so fall back to Home when there's nothing to explore.
-        val resolved =
-            if (requested == AppTab.EXPLORE_SOUNDS && PackagedAudios.get(this).isEmpty()) {
-                AppTab.MY_SOUNDS
-            } else {
-                requested
-            }
-        viewModel.selectTab(resolved)
+        val resolved = resolveDeepLinkTab(uri.path, hasBundledAudios = PackagedAudios.get(this).isNotEmpty())
+        // Handed to the graph as a one-shot event: the link resets the destination tab to its root,
+        // so it lands the user on the tab it names rather than under whatever was left open.
+        viewModel.onDeepLink(resolved)
     }
 }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -116,7 +116,6 @@ fun LandingScreen(viewModel: SoundsViewModel) {
     // list. Reordering these reads reintroduces the cold-start empty-state flash.
     val initialLoadComplete by viewModel.isInitialLoadComplete.collectAsStateWithLifecycle()
     val sounds by viewModel.sounds.collectAsState()
-    val selectedTab by viewModel.selectedTab.collectAsState()
     val hasBundledSounds by viewModel.hasBundledSounds.collectAsState()
     val playbackProgress by viewModel.playbackProgress.collectAsState()
     val pausedProgress by viewModel.pausedProgress.collectAsState()
@@ -130,30 +129,26 @@ fun LandingScreen(viewModel: SoundsViewModel) {
     val tracker = remember(context) { AnalyticsTrackerProvider.get(context.applicationContext) }
 
     // Navigation 3 backbone (ADR 0024): one saveable back stack per tab + typed child destinations.
-    // The Navigator keeps SoundsViewModel.selectedTab in sync — the ViewModel still projects the
-    // sounds list off the selected tab.
+    // The graph is the single source of truth for where the user is (ADR 0024 § Consequences).
     val navState = rememberLandingNavigationState()
-    val navigator = remember(navState) { LandingNavigator(navState) { tab -> viewModel.selectTab(tab) } }
+    val navigator = remember(navState) { LandingNavigator(navState) { viewModel.stopPlayback() } }
+    val selectedTab = navState.topLevelRoute.toTabOrNull() ?: AppTab.MY_SOUNDS
 
-    // ViewModel → graph sync: deep links (LandingActivity.handleDeeplink → selectTab) and any other
-    // programmatic tab change reach the graph through here. Navigator-side changes call selectTab
-    // themselves and StateFlow de-dups equal values, so this cannot loop. selectedTab survives
-    // process death (SavedStateHandle) so this never fights the restored back stack.
-    LaunchedEffect(selectedTab) {
-        if (navState.topLevelRoute.toTabOrNull() != selectedTab) {
-            // Leaving the current stack programmatically: an open immersive listen must not keep
-            // playing headless behind another tab, and the modal Hub sheet must not resurrect on a
-            // later visit — close both. Full-screen destinations stay: they are tab history (D2).
-            when (val visible = navState.visibleRoute) {
-                is ImmersiveListenRoute -> {
-                    viewModel.stopPlayback()
-                    navigator.close(visible)
-                }
-                ImportHubRoute -> navigator.close(visible)
-                else -> Unit
-            }
-            navigator.navigate(selectedTab.toRoute())
-        }
+    // Graph → ViewModel: the VM projects the sounds list off the active tab, so it mirrors whatever
+    // the graph says — taps, back pops, deep links, and a back stack restored after process death
+    // (which is why this reads the graph on first composition rather than trusting a VM default).
+    LaunchedEffect(navState) {
+        snapshotFlow { navState.topLevelRoute.toTabOrNull() }
+            .filterNotNull()
+            .distinctUntilChanged()
+            .collect { viewModel.setActiveTab(it) }
+    }
+
+    // Deep links arrive on the Activity (Intent) and reach the graph as one-shot events (ADR 0003):
+    // the allowlist resolves the URI to a tab, and the graph resets that tab to its root — a link is
+    // "take me here", not "stack this on whatever was open".
+    LaunchedEffect(navigator) {
+        viewModel.deepLinkEvent.collect { tab -> navigator.switchToTabRoot(tab) }
     }
 
     // System file picker for the Hub's "import audio" path. OpenDocument(arrayOf("audio/*")) opens the
@@ -214,6 +209,7 @@ fun LandingScreen(viewModel: SoundsViewModel) {
     val tabContent: @Composable (AppTab) -> Unit = { tab ->
         TabContent(
             tab = tab,
+            activeTab = selectedTab,
             viewModel = viewModel,
             sounds = sounds,
             initialLoadComplete = initialLoadComplete,
@@ -282,12 +278,12 @@ fun LandingScreen(viewModel: SoundsViewModel) {
                         AboutScreen(onBack = { navigator.close(AboutRoute) })
                     }
                     entry<ManageCollectionsRoute> { key ->
-                        // close(key), not goBack(): Manage's "view collection" action switches tab before
-                        // closing, and a plain pop would hit the new tab's stack (see LandingNavigator.close).
                         com.github.barriosnahuel.vossosunboton.feature.collections.ManageCollectionsScreen(
                             viewModel = viewModel,
                             focusedCollectionId = key.focusedCollectionId,
                             onBack = { navigator.close(key) },
+                            // Resetting the destination tab also drops this screen's entry — no explicit close.
+                            onViewCollectionIn = { tab -> navigator.switchToTabRoot(tab) },
                         )
                     }
                     entry<ImmersiveListenRoute> { key ->
@@ -546,6 +542,9 @@ private fun SearchOverlayHost(
 @Composable
 private fun TabContent(
     tab: AppTab,
+    // The tab the graph currently shows. Each TabContent binds its own constant [tab]; comparing the
+    // two is how a composed-but-outgoing tab knows it is not the active one.
+    activeTab: AppTab,
     viewModel: SoundsViewModel,
     sounds: List<Sound>,
     // Read at the LandingScreen head BEFORE `sounds` (release/acquire pairing with loadSounds) —
@@ -586,9 +585,10 @@ private fun TabContent(
     val coroutineScope = rememberCoroutineScope()
     // Only the ACTIVE tab collects the one-shot scroll event: during a tab transition (or a
     // predictive-back preview) two TabContent instances are composed at once, and the Channel's
-    // single delivery (ADR 0003) must not be consumed by the outgoing tab's collector.
-    val selectedTabNow by viewModel.selectedTab.collectAsStateWithLifecycle()
-    val isActiveTab = selectedTabNow == tab
+    // single delivery (ADR 0003) must not be consumed by the outgoing tab's collector. Read from
+    // the graph, not the ViewModel's mirror of it: the mirror lands a dispatch later, which would
+    // leave the outgoing tab owning the collector for that window.
+    val isActiveTab = activeTab == tab
     LaunchedEffect(isActiveTab) {
         if (isActiveTab) {
             viewModel.scrollToTopEvent.collect {

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModel.kt
@@ -7,9 +7,7 @@ package com.github.barriosnahuel.vossosunboton.ui.home
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
@@ -135,7 +133,6 @@ data class PlaybackProgress(
 @Suppress("TooManyFunctions", "LargeClass")
 class SoundsViewModel(
     application: Application,
-    private val savedStateHandle: SavedStateHandle = SavedStateHandle(),
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val searchDebounceMs: Long = 200L,
     private val welcomeStore: WelcomeStickerStore = WelcomeStickerStore(application),
@@ -199,10 +196,12 @@ class SoundsViewModel(
     @Volatile
     private var welcomeHintConsumed = false
 
-    // SavedStateHandle-backed so the selected tab survives process death: the Nav3 back stack
-    // restores itself (rememberNavBackStack) and the VM->graph sync in LandingScreen would
-    // otherwise see the default MY_SOUNDS and snap the restored graph back to Home.
-    val selectedTab: StateFlow<AppTab> = savedStateHandle.getStateFlow(KEY_SELECTED_TAB, AppTab.MY_SOUNDS)
+    // Mirror of the graph's active tab, NOT a second source of truth: the Nav3 back stack is what
+    // says where the user is, and it restores itself across process death (rememberNavBackStack).
+    // The VM only needs the tab to project the sounds list — LandingScreen pushes it in via
+    // [setActiveTab] on every graph change, including the first composition after a restore.
+    private val _selectedTab = MutableStateFlow(AppTab.MY_SOUNDS)
+    val selectedTab: StateFlow<AppTab> = _selectedTab.asStateFlow()
 
     private val _sounds = MutableStateFlow<List<Sound>>(emptyList())
     val sounds: StateFlow<List<Sound>> = _sounds.asStateFlow()
@@ -347,6 +346,12 @@ class SoundsViewModel(
 
     private val _scrollToTopEvent = Channel<Unit>(Channel.BUFFERED)
     val scrollToTopEvent: Flow<Unit> = _scrollToTopEvent.receiveAsFlow()
+
+    // CONFLATED, not BUFFERED: the Activity resolves the deep link in onCreate, before LandingScreen
+    // composes and starts collecting, so the event has to wait — and if a second link arrives first,
+    // only the latest destination is worth honouring.
+    private val _deepLinkEvent = Channel<AppTab>(Channel.CONFLATED)
+    val deepLinkEvent: Flow<AppTab> = _deepLinkEvent.receiveAsFlow()
 
     // One-shot informative snackbar shown the first time the welcome audio plays to completion —
     // "it's yours, delete it whenever". Replaces the old self-destruct-on-completion flow (ADR 0003
@@ -722,16 +727,24 @@ class SoundsViewModel(
         }
     }
 
-    fun selectTab(tab: AppTab) {
-        savedStateHandle[KEY_SELECTED_TAB] = tab
+    /**
+     * Mirrors the graph's active tab into the projection state. Called by `LandingScreen` on every
+     * `topLevelRoute` change — never to *perform* navigation, which belongs to `LandingNavigator`.
+     */
+    fun setActiveTab(tab: AppTab) {
+        if (_selectedTab.value == tab) return
+        _selectedTab.value = tab
         // Optimistically rebuild `_sounds` from the in-memory caches before kicking off the
         // async loadSounds. Without this, the freshly selected tab renders an empty list (the
         // previous tab's filtered view) until the IO chain settles — the user sees the empty
-        // state flash on every tab swap. The tab is passed explicitly: reading it back through
-        // the SavedStateHandle flow here observed the PREVIOUS value, which re-emptied the list
-        // when leaving the Vault (whose projection is empty by design).
+        // state flash on every tab swap.
         applyTabFilterFromCache(tab)
         viewModelScope.launch(ioDispatcher) { loadSounds() }
+    }
+
+    /** Resolved deep-link destination, handed to the graph as a one-shot event (ADR 0003). */
+    fun onDeepLink(tab: AppTab) {
+        _deepLinkEvent.trySend(tab)
     }
 
     /**
@@ -1698,14 +1711,11 @@ class SoundsViewModel(
                 .thenByDescending { it.dateAdded ?: Long.MIN_VALUE }
                 .thenBy { it.name.lowercase() }
 
-        private const val KEY_SELECTED_TAB = "selected_tab"
-
         val Factory: ViewModelProvider.Factory =
             viewModelFactory {
                 initializer {
                     SoundsViewModel(
                         application = this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY]!!,
-                        savedStateHandle = createSavedStateHandle(),
                     )
                 }
             }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/navigation/DeepLinkResolver.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/navigation/DeepLinkResolver.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home.navigation
+
+import com.github.barriosnahuel.vossosunboton.ui.home.AppTab
+
+/**
+ * Resolves a `push-me://open<path>` deep link to the tab it may open.
+ *
+ * The closed allowlist and its **unknown-path → My Sounds** fallback are the security boundary
+ * (CLAUDE.md § *Deep link path allowlist*): an inbound Intent is untrusted input, and no path may
+ * route anywhere the allowlist does not name. Navigation 3 has no declarative deep-link API — the
+ * matcher lives here, on the Activity side, per the official recipe (ADR 0024 § *Deep links*).
+ *
+ * Pure so the boundary is testable without an Activity, and without a checkout that happens to ship
+ * bundled audios: [hasBundledAudios] is passed in rather than read from the packaged catalogue.
+ */
+internal fun resolveDeepLinkTab(
+    path: String?,
+    hasBundledAudios: Boolean,
+): AppTab {
+    val requested =
+        when (path) {
+            "/home" -> AppTab.MY_SOUNDS
+            "/explore" -> AppTab.EXPLORE_SOUNDS
+            else -> AppTab.MY_SOUNDS
+        }
+    // Explore is empty in release builds (no bundled audios) and in any debug build that hasn't
+    // populated model/src/debug/res/raw/. Routing there would land on a blank tab.
+    return if (requested == AppTab.EXPLORE_SOUNDS && !hasBundledAudios) AppTab.MY_SOUNDS else requested
+}

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/navigation/LandingNavigation.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/navigation/LandingNavigation.kt
@@ -205,22 +205,46 @@ internal class LandingNavigationState(
 }
 
 /**
- * Handles navigation events by updating [LandingNavigationState], keeping `SoundsViewModel`'s
- * `selectedTab` in sync through [onTabChange] — the ViewModel still projects the sounds list off
- * the selected tab, so every tab change (taps, back pops, deep links) must reach it.
+ * Handles navigation events by updating [LandingNavigationState]. The graph is the single source of
+ * truth for where the user is: `SoundsViewModel` mirrors the active tab (it projects the sounds list
+ * off it) by observing [LandingNavigationState.topLevelRoute], never by driving it.
+ *
+ * [onStopPlayback] is the one effect the navigator cannot own: leaving a tab with an immersive
+ * listen open must silence it, and playback lives in the ViewModel.
  */
 internal class LandingNavigator(
     val state: LandingNavigationState,
-    private val onTabChange: (AppTab) -> Unit,
+    private val onStopPlayback: () -> Unit,
 ) {
+    /**
+     * Tab taps and destination pushes. A tab tap *keeps* that tab's history (D2 multiple back
+     * stacks): the user who left About open on Home expects it there when they come back.
+     */
     fun navigate(route: NavKey) {
         val tab = route.toTabOrNull()
         if (tab != null) {
             state.topLevelRoute = route
-            onTabChange(tab)
         } else {
             state.activeStack.add(route)
         }
+    }
+
+    /**
+     * Programmatic navigation to a tab — a deep link, or Manage Collections' "view collection".
+     * Unlike a tab tap it lands on the tab's *root*: the caller named a destination, so leaving the
+     * user under whatever screen happened to be open (or under another tab's leftover history, which
+     * "exit through home" would surface later) would ignore what was asked for.
+     *
+     * Every stack is reset, not just the destination's: the leftovers are only reachable *because*
+     * of history the user didn't choose to keep, and Home's stack is always below the active tab.
+     */
+    fun switchToTabRoot(tab: AppTab) {
+        // An immersive listen being left behind must not keep playing headless under the new tab.
+        if (state.visibleRoute is ImmersiveListenRoute) onStopPlayback()
+        state.backStacks.values.forEach { stack ->
+            while (stack.size > 1) stack.removeAt(stack.lastIndex)
+        }
+        state.topLevelRoute = tab.toRoute()
     }
 
     fun goBack() {
@@ -228,34 +252,16 @@ internal class LandingNavigator(
         if (currentStack.lastOrNull() == state.topLevelRoute) {
             // At the base of the current tab: exit through home.
             state.topLevelRoute = state.startRoute
-            onTabChange(AppTab.MY_SOUNDS)
         } else {
             currentStack.removeLastOrNull()
         }
     }
 
-    /**
-     * Removes [route] from whichever stack holds it — not necessarily the active one. Needed by
-     * destinations whose actions switch tabs before closing themselves (e.g. Manage Collections'
-     * "view collection"): a plain [goBack] would pop the *new* tab's stack and leave the closed
-     * screen resurrectable on the old one.
-     */
+    /** Removes [route] from the active stack — the only stack a visible destination can live on. */
     fun close(route: NavKey) {
-        // Exactly one instance is removed, preferring the active stack: routes are value-equal
-        // (@Serializable objects/data classes), and a route legitimately duplicated as another
-        // tab's history must survive closing the visible one.
-        val stacks =
-            buildList {
-                add(state.activeStack)
-                state.backStacks.values.forEach { if (it !== state.activeStack) add(it) }
-            }
-        for (stack in stacks) {
-            val index = stack.lastIndexOf(route)
-            if (index >= 0) {
-                stack.removeAt(index)
-                return
-            }
-        }
+        val stack = state.activeStack
+        val index = stack.lastIndexOf(route)
+        if (index >= 0) stack.removeAt(index)
     }
 
     /**

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivityTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingActivityTest.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.ViewModelProvider
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
@@ -35,6 +34,8 @@ internal class LandingActivityTest : AbstractRobolectricTest() {
     val composeTestRule = createEmptyComposeRule()
 
     private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    private fun assertOnTab(tab: AppTab) = composeTestRule.assertOnTab(tab)
 
     @Before
     fun setUp() {
@@ -58,11 +59,9 @@ internal class LandingActivityTest : AbstractRobolectricTest() {
     @Test
     fun `deep link with home path opens MY_SOUNDS tab`() {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse("push-me://open/home"))
-        ActivityScenario.launch<LandingActivity>(intent).use { scenario ->
-            scenario.onActivity { activity ->
-                val viewModel = ViewModelProvider(activity, SoundsViewModel.Factory)[SoundsViewModel::class.java]
-                assertThat(viewModel.selectedTab.value).isEqualTo(AppTab.MY_SOUNDS)
-            }
+        ActivityScenario.launch<LandingActivity>(intent).use {
+            composeTestRule.waitForIdle()
+            assertOnTab(AppTab.MY_SOUNDS)
         }
     }
 
@@ -75,33 +74,28 @@ internal class LandingActivityTest : AbstractRobolectricTest() {
             return
         }
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse("push-me://open/explore"))
-        ActivityScenario.launch<LandingActivity>(intent).use { scenario ->
-            scenario.onActivity { activity ->
-                val viewModel = ViewModelProvider(activity, SoundsViewModel.Factory)[SoundsViewModel::class.java]
-                assertThat(viewModel.selectedTab.value).isEqualTo(AppTab.EXPLORE_SOUNDS)
-            }
+        ActivityScenario.launch<LandingActivity>(intent).use {
+            composeTestRule.waitForIdle()
+            assertOnTab(AppTab.EXPLORE_SOUNDS)
         }
     }
 
+    /** OWASP MASVS-PLATFORM-1 / CWE-939 (deep-link allowlist: unknown path never routes off Home). */
     @Test
     fun `deep link with unknown path falls back to MY_SOUNDS tab`() {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse("push-me://open/unknown"))
-        ActivityScenario.launch<LandingActivity>(intent).use { scenario ->
-            scenario.onActivity { activity ->
-                val viewModel = ViewModelProvider(activity, SoundsViewModel.Factory)[SoundsViewModel::class.java]
-                assertThat(viewModel.selectedTab.value).isEqualTo(AppTab.MY_SOUNDS)
-            }
+        ActivityScenario.launch<LandingActivity>(intent).use {
+            composeTestRule.waitForIdle()
+            assertOnTab(AppTab.MY_SOUNDS)
         }
     }
 
     @Test
     fun `deep link with no path falls back to MY_SOUNDS tab`() {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse("push-me://open"))
-        ActivityScenario.launch<LandingActivity>(intent).use { scenario ->
-            scenario.onActivity { activity ->
-                val viewModel = ViewModelProvider(activity, SoundsViewModel.Factory)[SoundsViewModel::class.java]
-                assertThat(viewModel.selectedTab.value).isEqualTo(AppTab.MY_SOUNDS)
-            }
+        ActivityScenario.launch<LandingActivity>(intent).use {
+            composeTestRule.waitForIdle()
+            assertOnTab(AppTab.MY_SOUNDS)
         }
     }
 
@@ -115,10 +109,26 @@ internal class LandingActivityTest : AbstractRobolectricTest() {
             composeTestRule.waitForIdle()
             scenario.recreate()
             composeTestRule.waitForIdle()
-            scenario.onActivity { activity ->
-                val viewModel = ViewModelProvider(activity, SoundsViewModel.Factory)[SoundsViewModel::class.java]
-                assertThat(viewModel.selectedTab.value).isEqualTo(AppTab.MY_SOUNDS)
-            }
+            assertOnTab(AppTab.MY_SOUNDS)
+        }
+    }
+
+    @Test
+    fun `rotating after arriving on a deep link does not replay it over what the user opened since`() {
+        // The launching Intent survives in getIntent() across recreates. Replaying it would re-run
+        // the link — which resets the tab to its root — so a rotation would silently throw away
+        // whatever the user opened after arriving (here About; in the wild, an unsaved recording).
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("push-me://open/home"))
+        ActivityScenario.launch<LandingActivity>(intent).use { scenario ->
+            composeTestRule.waitForIdle()
+            openAboutFromOverflow()
+
+            scenario.recreate()
+            composeTestRule.waitForIdle()
+
+            composeTestRule
+                .onNodeWithContentDescription(context.getString(R.string.app_about_back))
+                .assertIsDisplayed()
         }
     }
 
@@ -128,19 +138,13 @@ internal class LandingActivityTest : AbstractRobolectricTest() {
         // Home tab instead of leaving the app; only the Home base exits.
         ActivityScenario.launch(LandingActivity::class.java).use { scenario ->
             composeTestRule.waitForIdle()
-            composeTestRule
-                .onNodeWithText(context.getString(R.string.app_navigation_menu_item_vault))
-                .performClick()
-            composeTestRule.waitForIdle()
+            composeTestRule.selectTab(AppTab.VAULT)
 
             scenario.onActivity { it.onBackPressedDispatcher.onBackPressed() }
             composeTestRule.waitForIdle()
 
-            scenario.onActivity { activity ->
-                val viewModel = ViewModelProvider(activity, SoundsViewModel.Factory)[SoundsViewModel::class.java]
-                assertThat(viewModel.selectedTab.value).isEqualTo(AppTab.MY_SOUNDS)
-                assertThat(activity.isFinishing).isFalse()
-            }
+            assertOnTab(AppTab.MY_SOUNDS)
+            scenario.onActivity { activity -> assertThat(activity.isFinishing).isFalse() }
         }
     }
 
@@ -152,35 +156,20 @@ internal class LandingActivityTest : AbstractRobolectricTest() {
         // Explore-based variant silently skipped there, leaving this behavior unguarded).
         ActivityScenario.launch(LandingActivity::class.java).use { scenario ->
             composeTestRule.waitForIdle()
-            scenario.onActivity { activity ->
-                val viewModel = ViewModelProvider(activity, SoundsViewModel.Factory)[SoundsViewModel::class.java]
-                viewModel.selectTab(AppTab.VAULT)
-            }
-            composeTestRule.waitForIdle()
-            composeTestRule
-                .onNodeWithContentDescription(context.getString(R.string.app_overflow_menu))
-                .performClick()
-            composeTestRule.waitForIdle()
-            composeTestRule.onNodeWithText(context.getString(R.string.app_about)).performClick()
-            composeTestRule.waitForIdle()
+            composeTestRule.selectTab(AppTab.VAULT)
+            openAboutFromOverflow()
             composeTestRule
                 .onNodeWithContentDescription(context.getString(R.string.app_about_back))
                 .assertIsDisplayed()
 
             scenario.onActivity { it.onBackPressedDispatcher.onBackPressed() }
             composeTestRule.waitForIdle()
-            scenario.onActivity { activity ->
-                val viewModel = ViewModelProvider(activity, SoundsViewModel.Factory)[SoundsViewModel::class.java]
-                assertThat(viewModel.selectedTab.value).isEqualTo(AppTab.VAULT)
-            }
+            assertOnTab(AppTab.VAULT)
 
             scenario.onActivity { it.onBackPressedDispatcher.onBackPressed() }
             composeTestRule.waitForIdle()
-            scenario.onActivity { activity ->
-                val viewModel = ViewModelProvider(activity, SoundsViewModel.Factory)[SoundsViewModel::class.java]
-                assertThat(viewModel.selectedTab.value).isEqualTo(AppTab.MY_SOUNDS)
-                assertThat(activity.isFinishing).isFalse()
-            }
+            assertOnTab(AppTab.MY_SOUNDS)
+            scenario.onActivity { activity -> assertThat(activity.isFinishing).isFalse() }
 
             scenario.onActivity { it.onBackPressedDispatcher.onBackPressed() }
             composeTestRule.waitForIdle()
@@ -188,6 +177,15 @@ internal class LandingActivityTest : AbstractRobolectricTest() {
                 assertThat(activity.isFinishing).isTrue()
             }
         }
+    }
+
+    private fun openAboutFromOverflow() {
+        composeTestRule
+            .onNodeWithContentDescription(context.getString(R.string.app_overflow_menu))
+            .performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText(context.getString(R.string.app_about)).performClick()
+        composeTestRule.waitForIdle()
     }
 
     @Test

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenAnalyticsTest.kt
@@ -92,8 +92,10 @@ internal class LandingScreenAnalyticsTest : AbstractRobolectricTest() {
 
         composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
         composeTestRule.waitForIdle()
-        viewModel.selectTab(AppTab.EXPLORE_SOUNDS)
+        // The Explore tab only exists in the bar when there are bundled audios to explore.
+        viewModel.injectHasBundledSounds(true)
         composeTestRule.waitForIdle()
+        composeTestRule.selectTab(AppTab.EXPLORE_SOUNDS)
 
         fake.assertScreenView(CanonicalScreenName.EXPLORE_SOUNDS)
     }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenOnboardingTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenOnboardingTest.kt
@@ -199,8 +199,7 @@ internal class LandingScreenOnboardingTest : AbstractRobolectricTest() {
         composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
         composeTestRule.waitForIdle()
         // Open the tour from the overflow (reachable on every tab) while standing on the Vault tab.
-        viewModel.selectTab(AppTab.VAULT)
-        composeTestRule.waitForIdle()
+        composeTestRule.selectTab(AppTab.VAULT)
 
         composeTestRule.onNodeWithContentDescription(OVERFLOW_LABEL).performClick()
         composeTestRule.waitForIdle()

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreenTest.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.test.core.app.ApplicationProvider
 import com.github.barriosnahuel.vossosunboton.AbstractRobolectricTest
+import com.github.barriosnahuel.vossosunboton.R
 import com.github.barriosnahuel.vossosunboton.feature.playback.PlayerControllerFactory
 import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.ui.theme.AppTheme
@@ -152,8 +153,7 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
 
         composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
         composeTestRule.waitForIdle()
-        viewModel.selectTab(AppTab.VAULT)
-        composeTestRule.waitForIdle()
+        composeTestRule.selectTab(AppTab.VAULT)
 
         // Vault's job is to listen — it stays FAB-less (design "regla por tab").
         composeTestRule.onNodeWithContentDescription("Add a Bomp").assertDoesNotExist()
@@ -167,11 +167,49 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
         composeTestRule.waitForIdle()
         viewModel.injectHasBundledSounds(true)
         composeTestRule.waitForIdle()
-        viewModel.selectTab(AppTab.EXPLORE_SOUNDS)
-        composeTestRule.waitForIdle()
+        composeTestRule.selectTab(AppTab.EXPLORE_SOUNDS)
 
         // Explore is a consumption surface — no create affordance there.
         composeTestRule.onNodeWithContentDescription("Add a Bomp").assertDoesNotExist()
+    }
+
+    @Test
+    fun `tapping a tab tells the ViewModel which list to project`() {
+        // The graph owns the active tab; the ViewModel mirrors it to project the sounds list. Drop
+        // that mirror and nothing else breaks visibly — the bar and the FAB read the graph directly
+        // — while the list silently keeps projecting the tab the user left.
+        val viewModel = givenAViewModel()
+
+        composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
+        composeTestRule.waitForIdle()
+        composeTestRule.selectTab(AppTab.VAULT)
+
+        assertThat(viewModel.selectedTab.value).isEqualTo(AppTab.VAULT)
+    }
+
+    @Test
+    fun `a deep link arriving while About is open lands on the tab it names`() {
+        // A link is "take me here", not "stack this under whatever was open": arriving while About
+        // is up must leave the user on the sounds list, not still reading About.
+        val viewModel = givenAViewModel()
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+        composeTestRule.setContent { AppTheme { LandingScreen(viewModel) } }
+        composeTestRule.waitForIdle()
+        composeTestRule
+            .onNodeWithContentDescription(context.getString(R.string.app_overflow_menu))
+            .performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText(context.getString(R.string.app_about)).performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithContentDescription(context.getString(R.string.app_about_back)).assertIsDisplayed()
+
+        // What LandingActivity.handleDeeplink emits once the allowlist has resolved the URI.
+        viewModel.onDeepLink(AppTab.MY_SOUNDS)
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithContentDescription(context.getString(R.string.app_about_back)).assertDoesNotExist()
+        composeTestRule.assertOnTab(AppTab.MY_SOUNDS)
     }
 
     @Test
@@ -262,15 +300,6 @@ internal class LandingScreenTest : AbstractRobolectricTest() {
         // races with the in-flight load and gets overwritten.
         runBlocking { vm.isInitialLoadComplete.first { it } }
         return vm
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun SoundsViewModel.injectHasBundledSounds(value: Boolean) {
-        SoundsViewModel::class.java
-            .getDeclaredField("_hasBundledSounds")
-            .also { it.isAccessible = true }
-            // Safe: _hasBundledSounds is always MutableStateFlow<Boolean> — type parameter erased at runtime
-            .let { (it.get(this) as MutableStateFlow<Boolean>).value = value }
     }
 
     // Drives the global library (allSoundsCache) to a known value. The debug build's loadSounds

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelAnalyticsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelAnalyticsTest.kt
@@ -137,7 +137,7 @@ internal class SoundsViewModelAnalyticsTest : AbstractRobolectricTest() {
     @Test
     fun `playOrStop emits sound_play with surface = explore_sounds when explore tab is active`() {
         val viewModel = givenAViewModel()
-        viewModel.selectTab(AppTab.EXPLORE_SOUNDS)
+        viewModel.setActiveTab(AppTab.EXPLORE_SOUNDS)
         val sound = testSound("test", null, 0, isPlaying = false)
 
         viewModel.playOrStop(sound)

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelCollectionsTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelCollectionsTest.kt
@@ -283,7 +283,7 @@ internal class SoundsViewModelCollectionsTest : AbstractRobolectricTest() {
         // Switch to Vault — vm.sounds keeps the previous tab's projection (emptying it flashed the
         // outgoing tab's empty state mid-transition), and the library snapshot must keep the user
         // catalog so ImmersiveListenScreen can resolve collection.audioIds to real Sounds.
-        vm.selectTab(AppTab.VAULT)
+        vm.setActiveTab(AppTab.VAULT)
 
         assertThat(vm.sounds.value.map { it.name }).containsExactly("audio-a", "audio-b")
         val userLibraryNames =
@@ -314,7 +314,7 @@ internal class SoundsViewModelCollectionsTest : AbstractRobolectricTest() {
         runBlocking { vm.vaultAudios.first { it.size == 1 } }
         // The user is on the Vault tab when they swipe-to-delete; the main list is empty here only
         // because the seeded audio is Vault-only (VaultScreen itself reads `_vaultAudios` directly).
-        vm.selectTab(AppTab.VAULT)
+        vm.setActiveTab(AppTab.VAULT)
         runBlocking { vm.sounds.first { it.isEmpty() } }
 
         val target = vm.vaultAudios.value.single()
@@ -345,7 +345,7 @@ internal class SoundsViewModelCollectionsTest : AbstractRobolectricTest() {
         val vm = givenAViewModel()
         runBlocking { vm.collections.first { it.isNotEmpty() } }
         runBlocking { vm.vaultAudios.first { it.size == 1 } }
-        vm.selectTab(AppTab.VAULT)
+        vm.setActiveTab(AppTab.VAULT)
         runBlocking { vm.sounds.first { it.isEmpty() } }
 
         val target = vm.vaultAudios.value.single()
@@ -458,7 +458,7 @@ internal class SoundsViewModelCollectionsTest : AbstractRobolectricTest() {
             .that(vm.sounds.value.map { it.name })
             .containsExactly("first", "second")
 
-        vm.selectTab(AppTab.VAULT)
+        vm.setActiveTab(AppTab.VAULT)
         scheduler.advanceTimeBy(1_000)
         scheduler.runCurrent()
         mainLooper.idle()
@@ -470,7 +470,7 @@ internal class SoundsViewModelCollectionsTest : AbstractRobolectricTest() {
             .that(vm.sounds.value.map { it.name })
             .containsExactly("first", "second")
 
-        vm.selectTab(AppTab.MY_SOUNDS)
+        vm.setActiveTab(AppTab.MY_SOUNDS)
 
         // No scheduler advance: loadSounds has not run. The synchronous cache projection alone
         // must repopulate the list — otherwise the tab renders its empty state until IO lands.

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTest.kt
@@ -135,7 +135,7 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
     fun `selectTab updates the selected tab`() {
         val viewModel = givenAViewModel()
 
-        viewModel.selectTab(AppTab.MY_SOUNDS)
+        viewModel.setActiveTab(AppTab.MY_SOUNDS)
 
         assertThat(viewModel.selectedTab.value).isEqualTo(AppTab.MY_SOUNDS)
     }
@@ -516,8 +516,8 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
         val sound = viewModel.sounds.value.first()
 
         viewModel.deleteSound(sound)
-        viewModel.selectTab(AppTab.EXPLORE_SOUNDS)
-        viewModel.selectTab(AppTab.MY_SOUNDS)
+        viewModel.setActiveTab(AppTab.EXPLORE_SOUNDS)
+        viewModel.setActiveTab(AppTab.MY_SOUNDS)
 
         assertThat(viewModel.sounds.value.none { it.name == sound.name }).isTrue()
     }
@@ -619,8 +619,8 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
             val playingSound = viewModel.sounds.value.single { it.name == "custom" }
 
             viewModel.onPlayerStart(playingSound, durationMs = 1000)
-            viewModel.selectTab(AppTab.EXPLORE_SOUNDS)
-            viewModel.selectTab(AppTab.MY_SOUNDS)
+            viewModel.setActiveTab(AppTab.EXPLORE_SOUNDS)
+            viewModel.setActiveTab(AppTab.MY_SOUNDS)
 
             assertThat(
                 viewModel.sounds.value
@@ -852,7 +852,7 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
                 .getApplicationContext<android.content.Context>()
                 .getString(R.string.app_welcome_sticker_title)
 
-        viewModel.selectTab(AppTab.EXPLORE_SOUNDS)
+        viewModel.setActiveTab(AppTab.EXPLORE_SOUNDS)
         // selectTab launches loadSounds asynchronously on ioDispatcher. Wait for the welcome to
         // drop out of _sounds before asserting — isInitialLoadComplete already flipped on the first
         // load and is no longer a useful sync signal.
@@ -1085,7 +1085,7 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
             val shareFeature = mockShareFeatureReturning(CanonicalScreenName.MY_SOUNDS)
             val viewModel = givenAViewModel(shareFeature = shareFeature)
             val sound = testSound("s", file = "s.mp3")
-            viewModel.selectTab(AppTab.MY_SOUNDS)
+            viewModel.setActiveTab(AppTab.MY_SOUNDS)
 
             viewModel.share(sound)
             withTimeoutOrNull(1000) { viewModel.shareIntentEvent.first() }
@@ -1099,7 +1099,7 @@ internal class SoundsViewModelTest : AbstractRobolectricTest() {
             val shareFeature = mockShareFeatureReturning(CanonicalScreenName.EXPLORE_SOUNDS)
             val viewModel = givenAViewModel(shareFeature = shareFeature)
             val sound = testSound("s", file = "s.mp3")
-            viewModel.selectTab(AppTab.EXPLORE_SOUNDS)
+            viewModel.setActiveTab(AppTab.EXPLORE_SOUNDS)
 
             viewModel.share(sound)
             withTimeoutOrNull(1000) { viewModel.shareIntentEvent.first() }

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTestInjection.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundsViewModelTestInjection.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home
+
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * Forces the "there are bundled audios" state, which is what makes the Explore tab exist in the
+ * bottom bar. Reflection because the flag is derived from the packaged catalogue, and a CI checkout
+ * has no `model/src/debug/res/raw/` to derive it from.
+ */
+@Suppress("UNCHECKED_CAST")
+internal fun SoundsViewModel.injectHasBundledSounds(value: Boolean) {
+    SoundsViewModel::class.java
+        .getDeclaredField("_hasBundledSounds")
+        .also { it.isAccessible = true }
+        // Safe: _hasBundledSounds is always MutableStateFlow<Boolean> — type parameter erased at runtime
+        .let { (it.get(this) as MutableStateFlow<Boolean>).value = value }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/TabNavigationTestExtensions.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/TabNavigationTestExtensions.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home
+
+import android.content.Context
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.github.barriosnahuel.vossosunboton.R
+
+/**
+ * Tab navigation for tests, through the bottom bar the user actually taps. The graph owns the active
+ * tab (ADR 0024), so a test that pokes the ViewModel to "be on the Vault" asserts against a state no
+ * user can produce — it would keep passing with the graph left on the wrong tab.
+ */
+internal fun ComposeTestRule.selectTab(tab: AppTab) {
+    tabNode(tab).performClick()
+    waitForIdle()
+}
+
+/** Where the user is, as rendered: the bar reflects the graph's active tab. */
+internal fun ComposeTestRule.assertOnTab(tab: AppTab) {
+    tabNode(tab).assertIsSelected()
+}
+
+// Matched by role, not by text alone: a tab's label is also the title of the screen it opens
+// (e.g. "Vault"), so a text-only matcher hits two nodes as soon as that tab is the active one.
+private fun ComposeTestRule.tabNode(tab: AppTab): SemanticsNodeInteraction =
+    onNode(hasText(tabLabel(tab)) and SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Tab))
+
+internal fun tabLabel(tab: AppTab): String {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    return context.getString(
+        when (tab) {
+            AppTab.MY_SOUNDS -> R.string.app_navigation_menu_item_my_sounds
+            AppTab.VAULT -> R.string.app_navigation_menu_item_vault
+            AppTab.EXPLORE_SOUNDS -> R.string.app_navigation_menu_item_explore_sounds
+        },
+    )
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/navigation/DeepLinkResolverTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/navigation/DeepLinkResolverTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home.navigation
+
+import com.github.barriosnahuel.vossosunboton.ui.home.AppTab
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * The deep-link allowlist is a security boundary: an inbound Intent is untrusted input
+ * (CLAUDE.md § *Deep link path allowlist*). Asserted here rather than through the Activity because
+ * every Activity-level assertion lands on My Sounds — which is also the default state, so those
+ * tests cannot distinguish "the allowlist rejected the path" from "nothing happened at all".
+ */
+class DeepLinkResolverTest {
+    /** OWASP MASVS-PLATFORM-1 / CWE-939 (deep-link allowlist — only named paths route). */
+    @Test
+    fun `the home path opens My Sounds`() {
+        assertThat(resolveDeepLinkTab("/home", hasBundledAudios = true)).isEqualTo(AppTab.MY_SOUNDS)
+    }
+
+    /** OWASP MASVS-PLATFORM-1 / CWE-939 (deep-link allowlist — only named paths route). */
+    @Test
+    fun `the explore path opens Explore when there are bundled audios`() {
+        assertThat(resolveDeepLinkTab("/explore", hasBundledAudios = true)).isEqualTo(AppTab.EXPLORE_SOUNDS)
+    }
+
+    /** OWASP MASVS-PLATFORM-1 / CWE-939 (deep-link allowlist — unknown paths never route off Home). */
+    @Test
+    fun `an unknown path falls back to My Sounds`() {
+        assertThat(resolveDeepLinkTab("/unknown", hasBundledAudios = true)).isEqualTo(AppTab.MY_SOUNDS)
+    }
+
+    /** OWASP MASVS-PLATFORM-1 / CWE-939 (deep-link allowlist — no path is not a wildcard). */
+    @Test
+    fun `a link with no path falls back to My Sounds`() {
+        assertThat(resolveDeepLinkTab(null, hasBundledAudios = true)).isEqualTo(AppTab.MY_SOUNDS)
+    }
+
+    /** OWASP MASVS-PLATFORM-1 / CWE-939 (deep-link allowlist — exact match only, no traversal or casing tricks). */
+    @Test
+    fun `paths that merely resemble an allowed one do not route to it`() {
+        // Exact-match `when`, so none of these reach Explore: the allowlist is not a prefix, a
+        // suffix, or a case-insensitive match, and a traversal segment buys nothing.
+        val lookalikes = listOf("/explore/", "/EXPLORE", "/explore/../explore", "//explore", "/explore?x=1", "explore")
+        lookalikes.forEach { path ->
+            assertThat(resolveDeepLinkTab(path, hasBundledAudios = true)).isEqualTo(AppTab.MY_SOUNDS)
+        }
+    }
+
+    @Test
+    fun `the explore path falls back to My Sounds when there is nothing bundled to explore`() {
+        // Release builds ship no bundled audios — routing there would land the user on a blank tab.
+        assertThat(resolveDeepLinkTab("/explore", hasBundledAudios = false)).isEqualTo(AppTab.MY_SOUNDS)
+    }
+}

--- a/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/navigation/LandingNavigatorTest.kt
+++ b/app/src/test/java/com/github/barriosnahuel/vossosunboton/ui/home/navigation/LandingNavigatorTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.home.navigation
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import com.github.barriosnahuel.vossosunboton.ui.home.AppTab
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Back-stack semantics of programmatic tab switches (deep links, "view collection"). The graph owns
+ * navigation: switching to a tab must land on that tab's root, not on whatever history was left
+ * behind — see docs/adr/0024-jetpack-navigation-3.md.
+ */
+class LandingNavigatorTest {
+    private var stoppedPlayback = 0
+
+    private fun navigator(
+        homeStack: List<NavKey> = listOf(HomeRoute),
+        vaultStack: List<NavKey> = listOf(VaultRoute),
+        exploreStack: List<NavKey> = listOf(ExploreRoute),
+        startOn: NavKey = HomeRoute,
+    ): LandingNavigator {
+        val state =
+            LandingNavigationState(
+                topLevelRoute = mutableStateOf(startOn),
+                backStacks =
+                    mapOf(
+                        HomeRoute to NavBackStack(*homeStack.toTypedArray()),
+                        VaultRoute to NavBackStack(*vaultStack.toTypedArray()),
+                        ExploreRoute to NavBackStack(*exploreStack.toTypedArray()),
+                    ),
+            )
+        return LandingNavigator(state = state, onStopPlayback = { stoppedPlayback++ })
+    }
+
+    @Test
+    fun `switching tabs drops destinations left open on the tab being left`() {
+        val navigator = navigator(homeStack = listOf(HomeRoute, AboutRoute))
+
+        navigator.switchToTabRoot(AppTab.EXPLORE_SOUNDS)
+
+        assertThat(navigator.state.visibleRoute).isEqualTo(ExploreRoute)
+        // Back from Explore's root exits through home — which must be the sounds list, not the
+        // About screen the user left behind before the deep link arrived.
+        navigator.goBack()
+        assertThat(navigator.state.visibleRoute).isEqualTo(HomeRoute)
+    }
+
+    @Test
+    fun `switching to the tab already showing an overlay returns to the tab root`() {
+        val navigator = navigator(homeStack = listOf(HomeRoute, AboutRoute))
+
+        navigator.switchToTabRoot(AppTab.MY_SOUNDS)
+
+        assertThat(navigator.state.visibleRoute).isEqualTo(HomeRoute)
+    }
+
+    @Test
+    fun `switching to a tab that has its own history lands on the tab root`() {
+        val navigator =
+            navigator(
+                exploreStack = listOf(ExploreRoute, AboutRoute),
+                startOn = HomeRoute,
+            )
+
+        navigator.switchToTabRoot(AppTab.EXPLORE_SOUNDS)
+
+        assertThat(navigator.state.visibleRoute).isEqualTo(ExploreRoute)
+    }
+
+    @Test
+    fun `switching tabs stops an immersive listen playing on the tab being left`() {
+        val navigator = navigator(homeStack = listOf(HomeRoute, ImmersiveListenRoute(soundId = "s1")))
+
+        navigator.switchToTabRoot(AppTab.VAULT)
+
+        assertThat(stoppedPlayback).isEqualTo(1)
+        assertThat(navigator.state.backStacks.getValue(HomeRoute)).containsExactly(HomeRoute)
+    }
+
+    @Test
+    fun `switching tabs leaves no import hub sheet to resurrect on the next visit`() {
+        val navigator = navigator(homeStack = listOf(HomeRoute, ImportHubRoute))
+
+        navigator.switchToTabRoot(AppTab.VAULT)
+        navigator.switchToTabRoot(AppTab.MY_SOUNDS)
+
+        assertThat(navigator.state.visibleRoute).isEqualTo(HomeRoute)
+    }
+
+    @Test
+    fun `an unsaved recording is not silently kept alive under a tab switch`() {
+        val navigator = navigator(homeStack = listOf(HomeRoute, RecorderRoute(resumeDraft = false)))
+
+        navigator.switchToTabRoot(AppTab.EXPLORE_SOUNDS)
+        navigator.goBack()
+
+        assertThat(navigator.state.visibleRoute).isEqualTo(HomeRoute)
+    }
+}

--- a/docs/adr/0024-jetpack-navigation-3.md
+++ b/docs/adr/0024-jetpack-navigation-3.md
@@ -2,6 +2,9 @@
 
 - **Status:** Accepted
 - **Date:** 2026-07-05
+- **Amended:** 2026-07-12 — § *Deep links* rewritten (Navigation 3 ships no declarative deep-link
+  API; the original wording described a capability the library does not have) and § *Consequences*
+  corrected on the Vault, which ships self-gating rather than as conditional navigation.
 - **Supersedes:** Amends [ADR 0011](0011-predictive-back-navigation.md) (its revisit
   criterion — "when the Navigation 3 migration lands" — fires with this epic: the manual
   `predictiveBackTransition` machinery is simplified or removed for every surface that becomes a
@@ -81,12 +84,23 @@ contract; keeping full Activities for internal flows was rejected because it for
 user-visible payoff. Inbound-URI validation (CLAUDE.md § *Security boundaries*) is untouched —
 the same validator runs regardless of who invokes it.
 
-### Deep links: declarative, same allowlist
+### Deep links: resolved in the Activity, applied to the back stack
 
-The `push-me://open` allowlist moves into the graph as declarative mappings (`/home` → Home,
-`/explore` → Explore) with the **unknown-path → Home fallback preserved as the `else`** — the
-security invariant of CLAUDE.md § *Deep link path allowlist* survives the API change verbatim,
-including the extra "Explore without bundled audios → Home" guard.
+**Navigation 3 has no declarative deep-link API** — there is no `navDeepLink { uriPattern }`
+equivalent, and the official recipe (`deeplinks-basic`) parses the `Intent` in the Activity against
+a hand-written matcher, resolves it to a `NavKey`, and applies it to the back stack. `DeepLinkPattern`
+in that recipe belongs to the sample, not to `androidx.navigation3`. This ADR originally promised
+"declarative mappings in the graph"; that capability does not exist, so the `when (uri.path)` in
+`LandingActivity.handleDeeplink` **is** the prescribed shape, not a leftover of the old model.
+
+What the migration owes is therefore not the *form* but the *destination*: the resolved tab is handed
+to the graph as a one-shot event (ADR 0003) and **resets that tab to its root** — a link names a
+place, so it must not leave the user under whatever screen happened to be open, nor under history
+that "exit through home" would surface on the way back.
+
+**The security invariant is unchanged and is the part that matters**: a closed allowlist (`/home`,
+`/explore`), **unknown paths → Home** as the `else`, plus the "Explore without bundled audios → Home"
+guard (CLAUDE.md § *Deep link path allowlist*).
 
 ### Execution: three PRs
 
@@ -123,8 +137,20 @@ radius (share-sheet contract, back semantics). Rationale lives in the master spe
 - Overlay payloads currently carried by hand-written `Saver`s (e.g. the `ManageRequest` sealed
   class) become typed route arguments; the back stack itself is saveable/restorable across
   process death (`rememberNavBackStack` + `@Serializable` keys).
-- `VaultSessionState` keeps its process-scoped, non-persisted semantics: Vault access is modeled
-  as conditional navigation, and a restored back stack must re-request biometrics.
+- `VaultSessionState` keeps its process-scoped, non-persisted semantics: a restored back stack
+  re-requests biometrics. **The Vault ships self-gating, not as conditional navigation** (the
+  `conditional` recipe): the gate lives in `VaultScreen`'s body, which already had to render a
+  locked state — the same tab is a legitimate destination both locked and unlocked, so routing it
+  through the graph would add a second place that decides Vault access without removing the first.
+  Revisit when the Vault gains destinations *below* it (a private collection detail, an immersive
+  listen reachable by link): a gate that must protect a sub-graph rather than one screen belongs in
+  the graph, where every entry into that sub-graph passes it.
+- **The graph is the single source of truth for where the user is.** The ViewModel mirrors the
+  active tab (it projects the sounds list off it) but never drives it: programmatic navigation
+  (deep links, Manage Collections' "view collection") goes through `LandingNavigator`. A second
+  persisted copy of the current tab in `SavedStateHandle` was the original shape and is what let
+  the graph and the ViewModel disagree — the reconciliation it needed silently skipped the back
+  stacks, so a programmatic tab change left destinations stranded on the tab it left.
 - Once internal navigation goes through the graph, `startActivity` stops being a legitimate
   internal-navigation mechanism; a grep invariant for it is added to
   `scripts/check-adr-invariants.sh` by `003b`/`003c` (where the code changes), not by this PR.

--- a/scripts/check-security-test-count.sh
+++ b/scripts/check-security-test-count.sh
@@ -20,7 +20,7 @@
 
 set -euo pipefail
 
-EXPECTED_COUNT=34
+EXPECTED_COUNT=40
 
 SCAN_ROOTS=(
   app/src/test


### PR DESCRIPTION
### Summary

1. User opens "Manage collections" from the Vault
2. Taps "view" on a public collection → lands on My Bomps, filtered

**before:** the manage screen stays alive on the tab it was opened from — come back to that tab later and it reappears, as if the user had never left it.
**after:** opening a collection takes the user there and closes what they left behind.

Same fix, same root cause, for deep links: `push-me://open/home` arriving while another screen is open used to leave the user under it.

### Technical detail

Navigation had **two persisted sources of truth** — `SoundsViewModel.selectedTab` (`SavedStateHandle`) and the graph (`topLevelRoute` + a saveable `NavBackStack` per tab) — reconciled by a `LaunchedEffect` where the ViewModel won and **the back stacks were never touched**. Every programmatic tab change therefore stranded destinations on the tab it left.

- **`LandingNavigator`** — new `switchToTabRoot(tab)`: resets the stacks and lands on the tab's root. Used by deep links and Manage Collections' "view collection". Tab *taps* still keep that tab's history (D2 multi-back-stack) — the two are deliberately different.
- **`SoundsViewModel`** — mirrors the active tab (`setActiveTab`) to project the sounds list; no longer drives navigation, and `SavedStateHandle` is gone (the graph already persists).
- **Deep links** — resolved in the Activity (Nav3 has no declarative deep-link API; the Activity-side matcher *is* the official recipe) and handed to the graph as a one-shot `Channel` event (ADR 0003). The allowlist moves to a pure `resolveDeepLinkTab`, so the security boundary is testable without an Activity or bundled audios.
- **`LandingNavigator.close`** — the "prefer the active stack" patch from #1274's round 2 is **removed**: it existed only because "view collection" switched tabs before closing itself. No caller closes a route on a non-active stack any more.
- **ADR 0024 amended** — the "declarative deep links" promise described a capability Nav3 does not ship; and the Vault is documented as self-gating (not conditional navigation), with revisit criteria.
- **Unchanged on purpose:** the share-sheet trampoline (`AddButtonActivity`, `excludeFromRecents`, return-to-source), inbound-URI validation, and `screen_view` (still derived from the graph).

```mermaid
flowchart LR
  subgraph before
    DL1[deep link] --> VM1[ViewModel.selectTab] -.LaunchedEffect.-> G1[graph: tab only]
    G1 -.->|stacks untouched| L1[About still stacked]
  end
  subgraph after
    DL2[deep link] --> C[Channel event] --> N[switchToTabRoot] --> G2[graph: tab root]
    G2 --> VM2[ViewModel mirrors tab]
  end
```

### Security — the deep-link allowlist and why the test count moves 34 → 40

The boundary itself is **unchanged**: closed allowlist (`/home`, `/explore`), unknown paths → Home, "Explore with no bundled audios" → Home. What changes is that it is now actually *verified*.

- **The allowlist tests could not fail.** All four in `LandingActivityTest` assert the user ends on `MY_SOUNDS` — which is also the app's default state. A deep link regressed to a complete no-op would have kept them green. Worse, the one discriminating case (`/explore` → a *different* tab) early-returns on any checkout without bundled audios, i.e. always on CI.
- **Fix: `resolveDeepLinkTab`,** a pure function taking `hasBundledAudios` as a parameter. The path→tab decision is now assertable without an Activity and without bundled audio, so the discriminating case runs on CI.
- **+6 markers, none removed.** Five are genuinely new tests in `DeepLinkResolverTest` — including one pinning that the match is exact, not a prefix / case-insensitive / traversal match (`/EXPLORE`, `/explore/`, `//explore`, `/explore/../explore`, `/explore?x=1`, `explore`). The sixth is a KDoc tag on an *existing* `LandingActivityTest` case that guards the fallback and was never counted.
- **New attack surface: none.** The graph receives an `AppTab` (closed enum), never a URI or a route, so nothing downstream of the resolver can be steered by an inbound Intent. The share-sheet trampoline and its inbound-URI validation are untouched.

### Code review tips

- **`switchToTabRoot` resets *every* stack, not just the destination's.** Deliberate: leftovers on the origin tab resurface later through "exit through home". Consequence: a deep link arriving over an in-progress creation flow discards it (the recording survives as a persisted draft; a half-typed name does not). Pinned by `LandingNavigatorTest`.
- **`LandingActivity` now only applies the deep link when `savedInstanceState == null`** (+ `setIntent` in `onNewIntent`). Without it, `getIntent()` replays the link on every recreate — and since a link now resets the tab, a rotation would silently discard whatever the user had opened since. Found in self-review; guarded by a test.
- **Process-death restore on Explore** (debug-only: release ships no bundled audios): the VM's `init` load runs against the default tab before the graph's tab arrives on first composition, so the first paint can project My Bomps under Explore. Called out rather than fixed — worth a look if Explore ever ships.
- **CLAUDE.md was 3 bytes under the 40K CI limit on `develop`.** To fit the deep-link correction I compressed § *Store listing* (already a pointer to CONTRIBUTING); the navigation override lives in ADR 0024 instead. The file wants a `/claude-md-audit`.

### Already tested

- unit: 656 green (`./gradlew test`), incl. the three back-semantics bugs — each verified red against the old behaviour before the fix
- `./gradlew check -x test` green; `check-adr-invariants` / `check-security-test-count` / `check-analytics-wrapper` / `check-test-assertions` green
- instrumented: green, but **covered in two runs, not one**. A full cold-boot run reached 122/134 with **0 failures** and then hung as the AVD degraded (ADR 0001's documented "never completes" mode, not a test failure). The tail it never reached — `SearchOverlayTest`, `WelcomeIsolationGuardTest`, `WelcomeStickerFlowTest`, `RecorderDraftBannerFlowTest` — was then run on a fresh cold boot: **16/16 green in 53 s**. Every test in the suite is accounted for; none failed.
