### PR TITLE
chore(release): cut v2026.07.1 (versionCode 9, CalVer 2026.07)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog][]. Through v2.3.0 this project used [S
 ## \[v2026.07.1] - 2026-07-13
 
 ### Added
-- Long listens now show up in your system media controls — playing an audio from the Vault's listen screen (or reviewing a recording) surfaces a media notification with lock-screen controls, and headset/media keys pause and resume it; quick soundboard taps stay notification-free
+- Your Vault audios now keep playing in the background — start one from the Vault's listen screen (or review a recording) and it plays on with the screen off, with lock-screen controls and headset/media keys to pause and resume; quick soundboard taps stay notification-free
 
 ### Changed
 - Recording, importing and editing a Bomp now happen inside the app's own screen flow: the back gesture is continuous and step-by-step (from naming you go back to your recording, not out of the whole flow), and saving returns you to the tab you started from. Sharing an audio into Bomp from another app still takes you straight back to that app
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog][]. Through v2.3.0 this project used [S
 - In-app navigation runs on Jetpack Navigation 3 (`NavBackStack` per tab + typed destinations, ADR 0024): predictive back between screens is now automatic, tab history follows the platform's multi-back-stack semantics, and the manual per-overlay back wiring is gone
 - Creation flows are graph destinations (ADR 0024 D4): `RecordingActivity` is gone (now the `RecorderHost` destination) and `AddButtonActivity` is reduced to the share-sheet trampoline, keeping the task-level `excludeFromRecents` + return-to-source contract that a destination cannot honor. Screen-lifetime ViewModels scope per `NavEntry` (`lifecycle-viewmodel-navigation3`), and a grep invariant now fails the build if internal navigation reintroduces `startActivity` on one of our own Activities
 - Release tags, GitHub release titles and CHANGELOG headers move from day-precision CalVer (`vYYYY.MM.DD`) to month + sequential counter (`vYYYY.MM.N`), so the month's milestone can be created up front and assigned to every PR at creation (ADR 0023 amending ADR 0021)
+- The `versionName` now carries the monthly counter too (`YYYY.MM.N`, e.g. `2026.07.1`) instead of just the month, so the string in Play / "Acerca de" matches the release tag, title and CHANGELOG header 1:1 (ADR 0025 amending ADR 0021)
 - Waveform envelope extraction demuxes via Media3's `MediaExtractorCompat` instead of the AEP-prohibited `MediaExtractor` (`MediaCodec` decode unchanged); all sources normalize to per-decode temp files to route around a Media3 1.10.1 truncation bug with fd/content/resource sources — envelope verified bit-comparable (1 of 48 bars off by 0.014)
 - The Nav3 back stack is now the single source of truth for the active tab (ADR 0024, amended): `SoundsViewModel` mirrors it instead of persisting a second copy in `SavedStateHandle`, and programmatic navigation (deep links, "view collection") goes through `LandingNavigator`, landing on the destination tab's root. The ADR's "declarative deep links" wording is corrected — Navigation 3 ships no such API; the Activity-side matcher is the official recipe, and the allowlist + Home-fallback security invariant is unchanged
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog][]. Through v2.3.0 this project used [S
 
 ## \[unreleased]
 
+## \[v2026.07.1] - 2026-07-13
+
 ### Added
 - Long listens now show up in your system media controls — playing an audio from the Vault's listen screen (or reviewing a recording) surfaces a media notification with lock-screen controls, and headset/media keys pause and resume it; quick soundboard taps stay notification-free
 
@@ -34,8 +36,6 @@ The format is based on [Keep a Changelog][]. Through v2.3.0 this project used [S
 - Creation flows are graph destinations (ADR 0024 D4): `RecordingActivity` is gone (now the `RecorderHost` destination) and `AddButtonActivity` is reduced to the share-sheet trampoline, keeping the task-level `excludeFromRecents` + return-to-source contract that a destination cannot honor. Screen-lifetime ViewModels scope per `NavEntry` (`lifecycle-viewmodel-navigation3`), and a grep invariant now fails the build if internal navigation reintroduces `startActivity` on one of our own Activities
 - Release tags, GitHub release titles and CHANGELOG headers move from day-precision CalVer (`vYYYY.MM.DD`) to month + sequential counter (`vYYYY.MM.N`), so the month's milestone can be created up front and assigned to every PR at creation (ADR 0023 amending ADR 0021)
 - Waveform envelope extraction demuxes via Media3's `MediaExtractorCompat` instead of the AEP-prohibited `MediaExtractor` (`MediaCodec` decode unchanged); all sources normalize to per-decode temp files to route around a Media3 1.10.1 truncation bug with fd/content/resource sources — envelope verified bit-comparable (1 of 48 bars off by 0.014)
-
-#### Changed
 - The Nav3 back stack is now the single source of truth for the active tab (ADR 0024, amended): `SoundsViewModel` mirrors it instead of persisting a second copy in `SavedStateHandle`, and programmatic navigation (deep links, "view collection") goes through `LandingNavigator`, landing on the destination tab's root. The ADR's "declarative deep links" wording is corrected — Navigation 3 ships no such API; the Activity-side matcher is the official recipe, and the allowlist + Home-fallback security invariant is unchanged
 
 #### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,10 +347,11 @@ Full "when to use" per label + worked combinations: CONTRIBUTING.md § *Labels &
 
 `CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/); released headers are CalVer `## [vYYYY.MM.N]` (CONTRIBUTING § *Versioning*):
 - Sections `Added` / `Changed` / `Fixed` / `Removed` under `## [unreleased]`. Each entry: single sentence, capital, no trailing period.
-- Dependency bumps → one line for the overall bump (`"Bumped all dependencies to latest stable"`), not one per library.
-- Update `[unreleased]` per commit when the change is user-visible or architecturally significant.
+- Dependency bumps → one line (`"Bumped all dependencies to latest stable"`), not one per library.
+- Update `[unreleased]` per commit for user-visible or architecturally significant changes.
 - Don't add `Fixed` for a bug introduced in the same `[unreleased]` cycle — git history is the traceability.
-- **User-facing first; technical under "For nerds":** user-facing → `### Added/Changed/Fixed/Removed`. Technical (build/CI, deps, refactors, test infra, docs, analytics) → `### For nerds 🤓` with `#### Added/Changed/Fixed/Removed` sub-headings (omit empty). `[unreleased]` only; released versions stay as written.
+- **User-facing first, technical under "For nerds":** user-facing → `### Added/Changed/Fixed/Removed`; technical (build/CI, deps, refactors, tests, docs, analytics) → `### For nerds 🤓` `#### …` sub-headings (omit empty). `[unreleased]` only; released stay as written.
+- Store *What's New* is marketing, not this file: CONTRIBUTING § *Copy guide*.
 
 ## Handoff notes & issue tracking
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -570,9 +570,9 @@ Release-only Gradle commands (need the signing files above in the project root):
 
 ### Versioning
 
-**Calendar Versioning**, at two granularities — the user-facing version reads as a month, the GitHub tag adds a sequential counter:
+**Calendar Versioning** — the user-facing version and the GitHub tag are the same string (bar the `v` prefix): cut month plus a monthly counter.
 
-- **`versionName`** (what the Bomper sees in Play / "Acerca de") is **`YYYY.MM`** — year + month of the cut (e.g. `2026.07`). The date *is* the version: it tells the Bomper how fresh the app is. No SemVer `MAJOR.MINOR.PATCH`, **no sequential counter**. Two releases in the same month share a `versionName` — Play allows it; they stay distinct by `versionCode`.
+- **`versionName`** (what the Bomper sees in Play / "Acerca de") is **`YYYY.MM.N`** — cut month + a 1-based counter within the month (e.g. `2026.07.1`; a second July release is `2026.07.2`). The date *is* the version: it tells the Bomper how fresh the app is, and the `.N` matches the release tag / title / CHANGELOG header 1:1, so an "Acerca de" string maps straight to a GitHub release. No SemVer `MAJOR.MINOR.PATCH`. Two same-month releases differ by `.N` (and by `versionCode`). Rationale for carrying the counter here (not just on the tag): [ADR 0025](docs/adr/0025-versionname-carries-monthly-counter.md).
 - **`versionCode`** stays a **monotonic integer**, bumped +1 per release, independent of `versionName` (Play Store requirement). It is the true build identity.
 - **GitHub tags + release titles + `CHANGELOG.md` headers** are **`vYYYY.MM.N`** — the `v`-prefixed cut month plus a 1-based counter within the month (e.g. `v2026.07.1`; a second July release is `v2026.07.2`). The counter keeps tags unique at any cadence, and — unlike a cut *date* — the name is knowable from the start of the month, which is what lets the month's **milestone** exist while PRs are still being opened (CLAUDE.md § *Labels and milestone*); git already records the cut date on the tag. Rationale + trade-off vs the earlier day-precision scheme: [ADR 0023](docs/adr/0023-monthly-sequential-release-tags.md).
 - **Forward-only frontier:** releases through `v2.3.0` were SemVer and stay as-is in tags / CHANGELOG / history. CalVer governs from the first cut after this change onward.
@@ -584,7 +584,7 @@ A **seed** — expand it as the release process is formalized (store rollout ste
 - [ ] **Regenerate the Baseline Profile** — `./scripts/generate-baseline-profile.sh`, then validate on a **real device** (`StartupBenchmark.startupBaselineProfile` near `DEFAULT`, well under `None`). It's a frozen snapshot of the cold-start path (§ *Baseline Profile*); refresh it so accumulated startup changes are precompiled.
 - [ ] **Run the tap-to-sound latency gate** — `TapLatencyBenchmark` on a **real device** (§ *Performance → What it measures*): median must stay ≤ 100 ms and in line with the last row of `macrobenchmark/RESULTS.md`; **append this run's row** there (that file is the versioned before/today series — there is no automatic threshold).
 - [ ] **Finalize `CHANGELOG.md`** — stamp `## [unreleased]` as `## [vYYYY.MM.N] - YYYY-MM-DD`, the cut month + the month's next counter (`.1` for the month's first release), keeping the Keep-a-Changelog cut-date suffix (§ CLAUDE.md *Changelog*). The tag must match the month's open milestone — if the milestone was carried over from an earlier no-release month, rename it to the cut month first.
-- [ ] **Bump `versionCode` + `versionName`** in `app/build.gradle` — `versionCode` +1; `versionName` to the CalVer `YYYY.MM` cut month (§ *Versioning*).
+- [ ] **Bump `versionCode` + `versionName`** in `app/build.gradle` — `versionCode` +1; `versionName` to the CalVer `YYYY.MM.N` cut month + monthly counter, the same string as the tag / CHANGELOG header without the `v` (§ *Versioning*).
 - [ ] **Release lint gate** — `./gradlew app:lintVitalRelease` green.
 - [ ] **Build the AAB** — `./gradlew app:bundle`.
 - [ ] **Write the store change notes** — `store-listing/{en-US,es-AR}/changelog-<versionCode>.txt`; the GitHub release notes are sourced from the en-US file (§ *Creating the GitHub release*).
@@ -700,6 +700,16 @@ ls -lh store-listing/<locale>/images/*.png # confirms weight (Play caps icon at 
 ## Copy guide ✍️
 
 Hard rules and brand-DNA invariants for user-facing copy live in `CLAUDE.md` § *Copy & localization*. This section collects the **pedagogical examples** — concrete calques we hit (and fixed) during real listings — so contributors writing or reviewing copy can recognise the failure modes without re-deriving them.
+
+### Store "What's New" voice
+
+The store *What's New* (`store-listing/{en-US,es-AR}/changelog-<versionCode>.txt`) is **marketing copy, not a `CHANGELOG.md` mirror**. `CHANGELOG.md` is a factual ledger (Keep a Changelog, one flat sentence per entry); the store note is the pitch the Bomper reads *before* updating. Don't paste the CHANGELOG bullets in — rewrite them:
+
+- **Lead with the benefit / what it unlocks, not the mechanism.** The reader cares what they can now *do*, not how it's wired. A media-notification feature isn't "a notification appears for immersive playback" (the plumbing) — it's "your treasured Vault audios come with you: background playback, screen off, on the go" (the payoff). Name the trigger only as much as the benefit needs. This is the exact miss that shipped once as a duration framing ("Long listens…") when the real hook was portability of the audios you treasure.
+- **Fixes can be a playful before/after.** For corrections, an exaggerated "before X — who wants that? — now Y" reads warmer and more human than a flat "Fixed Z". Use it where it fits; keep each to a line so the note stays scannable.
+- **Native voice per locale** (§ above): en-US → contractions, concrete nouns; es-AR → voseo + warmth. es-AR is *not* a translation of en-US — write it native.
+- **500-character hard cap per locale, counted *with* the trailing newline** (Play truncates over it). es-AR runs longer than en-US, so it's the binding constraint — count it (`python3 -c "print(len(open('path').read()))"`), don't eyeball. If four benefit-led + before/after bullets don't fit, compress the before/after to one-liners or drop the lowest-value bullet — never ship a truncated note.
+- All brand-DNA invariants, reserved-term and policy-contradiction checks in `CLAUDE.md` § *Copy & localization* still apply.
 
 ### Calque examples (en-US listing post-mortem)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Bomp is your personal collection of the voices that matter. Save them, keep them
 [<img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" height="80"/>](https://play.google.com/store/apps/details?id=com.github.barriosnahuel.vossosunboton)
 
 ## Project status 📖
-[![version](https://img.shields.io/badge/version-2026.07-brightgreen.svg)](https://github.com/barriosnahuel/bomp/releases)
+[![version](https://img.shields.io/badge/version-2026.07.1-brightgreen.svg)](https://github.com/barriosnahuel/bomp/releases)
 [![CalVer](https://img.shields.io/badge/versioning-CalVer-green.svg)](https://calver.org/)
 [![stable](https://img.shields.io/badge/stability-experimental-green.svg)](https://nodejs.org/api/documentation.html#documentation_stability_index)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Bomp is your personal collection of the voices that matter. Save them, keep them
 [<img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" height="80"/>](https://play.google.com/store/apps/details?id=com.github.barriosnahuel.vossosunboton)
 
 ## Project status 📖
-[![version](https://img.shields.io/badge/version-2.3.0-brightgreen.svg)](https://github.com/barriosnahuel/bomp/releases)
+[![version](https://img.shields.io/badge/version-2026.07-brightgreen.svg)](https://github.com/barriosnahuel/bomp/releases)
 [![CalVer](https://img.shields.io/badge/versioning-CalVer-green.svg)](https://calver.org/)
 [![stable](https://img.shields.io/badge/stability-experimental-green.svg)](https://nodejs.org/api/documentation.html#documentation_stability_index)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,8 @@ android {
         applicationId "com.github.barriosnahuel.vossosunboton"
         minSdkVersion 23
         targetSdkVersion 37
-        versionCode 8
-        versionName '2.3.0' // last SemVer release; CalVer from the next cut (CONTRIBUTING § Versioning)
+        versionCode 9
+        versionName '2026.07' // CalVer: year + month of the cut (CONTRIBUTING § Versioning)
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         // Keep capture/utility drivers out of the default suite (connectedDebugAndroidTest /
         // run-instrumented-tests.sh). The store-screenshot driver still runs via

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 37
         versionCode 9
-        versionName '2026.07' // CalVer: year + month of the cut (CONTRIBUTING § Versioning)
+        versionName '2026.07.1' // CalVer: cut month + monthly counter, matches the release tag (CONTRIBUTING § Versioning)
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         // Keep capture/utility drivers out of the default suite (connectedDebugAndroidTest /
         // run-instrumented-tests.sh). The store-screenshot driver still runs via

--- a/docs/adr/0021-calver-versioning.md
+++ b/docs/adr/0021-calver-versioning.md
@@ -1,6 +1,6 @@
 # ADR 0021 — Calendar Versioning for the app + GitHub releases
 
-- **Status:** Accepted (the tag / release-title / CHANGELOG-header scheme `vYYYY.MM.DD` amended to `vYYYY.MM.N` by [ADR 0023](0023-monthly-sequential-release-tags.md); everything else stands)
+- **Status:** Accepted (the tag / release-title / CHANGELOG-header scheme `vYYYY.MM.DD` amended to `vYYYY.MM.N` by [ADR 0023](0023-monthly-sequential-release-tags.md); the `versionName` = `YYYY.MM` scheme amended to `YYYY.MM.N` by [ADR 0025](0025-versionname-carries-monthly-counter.md); the CalVer rationale, `versionCode` and SemVer frontier stand)
 - **Date:** 2026-07-04
 - **Supersedes:** the implicit Semantic Versioning convention used through v2.3.0 (never recorded as an ADR)
 

--- a/docs/adr/0023-monthly-sequential-release-tags.md
+++ b/docs/adr/0023-monthly-sequential-release-tags.md
@@ -1,6 +1,6 @@
 # ADR 0023 — Monthly-sequential release tags (`vYYYY.MM.N`)
 
-- **Status:** Accepted
+- **Status:** Accepted (the § *Trade-off accepted* aside that `versionName` keeps ADR 0021's no-counter rationale is amended by [ADR 0025](0025-versionname-carries-monthly-counter.md) — `versionName` now also carries the counter, `YYYY.MM.N`)
 - **Date:** 2026-07-05
 - **Amends:** [ADR 0021](0021-calver-versioning.md) — only the tag / release-title / CHANGELOG-header scheme (`vYYYY.MM.DD` → `vYYYY.MM.N`). The rest of ADR 0021 — `versionName` = `YYYY.MM`, small monotonic `versionCode`, the forward-only SemVer frontier — stands unchanged.
 

--- a/docs/adr/0025-versionname-carries-monthly-counter.md
+++ b/docs/adr/0025-versionname-carries-monthly-counter.md
@@ -1,0 +1,32 @@
+# ADR 0025 — `versionName` carries the monthly counter (`YYYY.MM.N`)
+
+- **Status:** Accepted
+- **Date:** 2026-07-15
+- **Amends:** [ADR 0021](0021-calver-versioning.md) — only the `versionName` scheme (`YYYY.MM` → `YYYY.MM.N`). The rest of ADR 0021 — the CalVer rationale, the small monotonic `versionCode`, the forward-only SemVer frontier — stands. Also amends the aside in [ADR 0023](0023-monthly-sequential-release-tags.md) § *Trade-off accepted* that the user-facing `versionName` "keeps ADR 0021's no-counter rationale intact".
+
+## Context
+
+ADR 0021 set `versionName` = `YYYY.MM` (no counter), while [ADR 0023](0023-monthly-sequential-release-tags.md) later gave the tag / release-title / CHANGELOG-header a monthly counter (`vYYYY.MM.N`). That left **two different version strings for one release**: the tag, title, milestone and CHANGELOG header all read `v2026.07.1`, but the string the Bomper sees in Play / "Acerca de" read only `2026.07`.
+
+The split was chosen for false-precision reasons (ADR 0021 driver #2), but it actively misleads. It surfaced at the very first CalVer cut: `v2026.07.1` shipped with `versionName '2026.07'`, and the mismatch read as a mistake rather than a decision — the maintainer flagged it as one. If the split confuses the person who wrote the ADRs, it will confuse a reader correlating an "Acerca de" string with a GitHub release.
+
+## Decision drivers
+
+1. **One release, one version string.** The Bomper reading `2026.07.1` in "Acerca de" can match it 1:1 to the GitHub release, tag, milestone and CHANGELOG header. No mental mapping.
+2. **The counter already exists and is already hand-managed.** ADR 0023 introduced `N` and manages it at cut; carrying the same value into `versionName` is ~zero marginal cost — no new ceremony ADR 0021's driver #2 was trying to avoid.
+3. **Freshness still reads.** `2026.07.1` still tells the Bomper how fresh the app is (the whole point of CalVer); the `.N` only disambiguates same-month cuts, exactly as it does on the tag.
+
+## Decision
+
+- **`versionName` = `YYYY.MM.N`** — the same cut month + 1-based monthly counter as the tag / release title / CHANGELOG header (e.g. `2026.07.1`; a second July release is `2026.07.2`). It now matches the release identity string everywhere except the `v` prefix (tags keep the `v`, `versionName` cannot — Play rejects a leading non-digit).
+- **`versionCode`** is unchanged — the small monotonic integer, +1 per release, Play's true build identity (ADR 0021).
+- **The two same-month releases no longer share a `versionName`** — they differ by `.N`, matching how they already differ by tag and `versionCode`. This reverses ADR 0021's "two same-month releases share a `versionName`" clause.
+
+## Enforcement
+
+Same as ADR 0021 / ADR 0023: `CONTRIBUTING.md` § *Versioning* is canonical, human-checked at cut via the pre-release checklist. No grep guard — the scheme is low-frequency, and `versionName` now derives trivially from the tag the cut already picks.
+
+## Revisit criteria
+
+- If `versionName` and the tag ever need to diverge (e.g. a hotfix that re-uses a tag but ships a distinct build) → reconsider; today they are 1:1 by construction.
+- Anything that revisits ADR 0021's CalVer decision wholesale (a real compatibility contract appears) supersedes this too.

--- a/store-listing/en-US/changelog-9.txt
+++ b/store-listing/en-US/changelog-9.txt
@@ -1,0 +1,8 @@
+What's new in this version.
+
+▸ Long listens now reach your media controls: play from the Vault and you get a lock-screen notification, with headset keys to pause and resume.
+▸ Recording, importing and editing happen inside the app — back moves one step at a time, and saving returns you where you started.
+▸ Reopening a Vault audio starts it from the beginning, not mid-clip.
+▸ Opening the app no longer flashes an empty screen while your Bomps load.
+
+Thanks for bomping.

--- a/store-listing/en-US/changelog-9.txt
+++ b/store-listing/en-US/changelog-9.txt
@@ -1,8 +1,8 @@
 What's new in this version.
 
-▸ Long listens now reach your media controls: play from the Vault and you get a lock-screen notification, with headset keys to pause and resume.
-▸ Recording, importing and editing happen inside the app — back moves one step at a time, and saving returns you where you started.
-▸ Reopening a Vault audio starts it from the beginning, not mid-clip.
-▸ Opening the app no longer flashes an empty screen while your Bomps load.
+▸ Your treasured Vault audios come with you — background playback, screen off, on the go. The voices that matter, always with you.
+▸ Back used to throw you out of the whole creation flow. Now it steps back one screen at a time; saving lands you where you started.
+▸ Reopening a Vault audio used to pick up mid-clip. Who wants that? Now it starts from the top.
+▸ Opening the app used to flash an empty screen. Now it waits for your Bomps first.
 
 Thanks for bomping.

--- a/store-listing/es-AR/changelog-9.txt
+++ b/store-listing/es-AR/changelog-9.txt
@@ -1,0 +1,8 @@
+Novedades de esta versión.
+
+▸ Las escuchas largas llegan a tus controles multimedia: reproducí desde el Baúl y tenés notificación en la pantalla bloqueada, con el auricular para pausar y seguir.
+▸ Grabar, importar y editar pasan a ser parte de la app: el atrás va paso a paso y, al guardar, volvés a donde arrancaste.
+▸ Al reabrir un audio del Baúl, empieza del principio y no por la mitad.
+▸ Abrir la app ya no muestra un destello de pantalla vacía mientras cargan tus Bomps.
+
+Gracias por bompear.

--- a/store-listing/es-AR/changelog-9.txt
+++ b/store-listing/es-AR/changelog-9.txt
@@ -1,8 +1,8 @@
 Novedades de esta versión.
 
-▸ Las escuchas largas llegan a tus controles multimedia: reproducí desde el Baúl y tenés notificación en la pantalla bloqueada, con el auricular para pausar y seguir.
-▸ Grabar, importar y editar pasan a ser parte de la app: el atrás va paso a paso y, al guardar, volvés a donde arrancaste.
-▸ Al reabrir un audio del Baúl, empieza del principio y no por la mitad.
-▸ Abrir la app ya no muestra un destello de pantalla vacía mientras cargan tus Bomps.
+▸ Tus audios atesorados del Baúl ahora te acompañan — en segundo plano, pantalla apagada, donde vayas. Las voces que importan, siempre con vos.
+▸ Atrás te sacaba de todo el flujo de creación. Ahora va pantalla por pantalla; al guardar, volvés donde arrancaste.
+▸ Reabrir un audio del Baúl arrancaba por la mitad. ¿Quién quiere eso? Ahora empieza del principio.
+▸ Abrir la app mostraba un destello vacío. Ahora espera a tus Bomps primero.
 
 Gracias por bompear.


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change beyond the version stamp and store copy. This is the version cut itself: it names the release and writes what the Bomper reads in the store.

Prepares the **v2026.07.1** release (the first CalVer cut, per ADR 0021 / 0023 / 0025). What ships in it — background playback for Vault audios via system media controls, in-app creation flows, Nav3 — already landed; this PR only names the version and writes the store notes.

## Corrections since the original cut

Applied after review of the first pass:

1. **`versionName` is now `2026.07.1`, not `2026.07`.** The string the Bomper sees in Play / "Acerca de" now matches the release tag, title and CHANGELOG header 1:1, instead of dropping the counter and reading as a different version. This reverses ADR 0021's "no counter on `versionName`" driver, recorded in new **[ADR 0025](docs/adr/0025-versionname-carries-monthly-counter.md)** (amends ADR 0021); ADR 0021/0023 status lines + `CONTRIBUTING` § *Versioning* updated. README badge bumped too.
2. **Media-controls note reframed from duration to benefit.** It read as "Long listens" — a duration hook — but the feature isn't triggered by length; it's background playback for the immersive **Vault** listen sessions (recorder review too). The store note + `CHANGELOG` now lead with the payoff: *your treasured Vault audios come with you — background, screen off, on the go* ("the voices that matter, always with you"); the lock-screen/headset controls are the consequence, not the headline.
3. **The other three store bullets now use a playful before/after voice** ("used to X — who wants that? — now Y") — a warmer register for fixes than a flat list.
4. **New store "What's New" voice guidance** so the miss doesn't recur: full section in `CONTRIBUTING` § *Copy guide*, terse pointer in `CLAUDE.md` § *Changelog*.

## ⚠️ Rebuild before uploading

The AAB verified on the first pass was built at `versionName 2026.07`. Since it changed to `2026.07.1`, **rebuild + re-sign the AAB** (`./gradlew app:bundle`) and re-run `./gradlew app:lintVitalRelease` before uploading. `versionCode` is unchanged (9), so Play still treats it as the same build identity.

## ⚠️ Two checklist items are still open — they need a human/device

**This PR is not a green light to cut the release.**

1. **`TapLatencyBenchmark` (tap-to-sound ≤100 ms gate) — NOT RUN.** It currently fails before it can measure anything. Root cause is now understood and is **a test-harness problem, not a product bug** (details below). The row in `macrobenchmark/RESULTS.md` is therefore also missing.
2. **Manual analytics smoke in Firebase DebugView — NOT DONE.** Not automatable; aggregated Reports lag 24–48 h.

### Why the benchmark fails (root cause found — harness, not product)

`TapLatencyBenchmark` dies with `Playable seeded sound (Benchmark sound 0) didn't render within 15000 ms`.

**The seeding works.** Verified on a physical Pixel 8: launching with `benchmark_seed_count=1` moves the list counter to `All sounds · 14`, and with `50` to `All sounds · 63` — against a baseline of **13** real audios on that device. The corpus is written and does persist. A JVM test asserting that `replaceSyntheticCorpus` writes and reads back also passes, so **`SoundsRepository` is sound** — no persistence bug, and the `loadSounds` / initial-load-gate changes are not implicated.

**What actually breaks:** the benchmark locates the row with `By.text("Benchmark sound 0")`. In a `LazyColumn`, off-screen items are not composed and therefore do not exist in the accessibility tree. On a device that already holds real audios, the seeded row is pushed below the fold, so UiAutomator never sees it and the 15 s wait expires. The benchmark implicitly assumes an empty list; it only passed before because the device held fewer audios.

**Still open (minor):** the file-less synthetic rows (1..49) do render once scrolled to, but row `0` — the only one backed by a real audio file — was not observed rendering even after scrolling, despite being counted. Worth a look when fixing the harness.

**Fixing the harness is deliberately out of scope here** — a release cut should not carry a benchmark change.

## Technical detail

- **`app/build.gradle`** — `versionCode 8 → 9` (monotonic), `versionName '2.3.0' → '2026.07.1'` (CalVer `YYYY.MM.N`, matching the tag; ADR 0025).
- **`docs/adr/0025-versionname-carries-monthly-counter.md`** — new ADR: `versionName` carries the monthly counter. **ADR 0021 / ADR 0023** status lines note the amendment; **`CONTRIBUTING` § *Versioning*** rewritten to the `YYYY.MM.N` scheme.
- **`CHANGELOG.md`** — `[unreleased]` stamped `[v2026.07.1] - 2026-07-13`; the media-controls `### Added` reframed to the background-playback benefit; a *For nerds* line records the `versionName`-scheme change. (First pass also folded a duplicated `#### Changed` heading into one section.)
- **`store-listing/{en-US,es-AR}/changelog-9.txt`** — reworked: benefit-led media-controls bullet + before/after voice on the rest. en-US is the master; es-AR is native voseo, not translated. Both under Play's 500-char cap (**en-US 494, es-AR 488**).
- **`CONTRIBUTING.md` / `CLAUDE.md`** — store *What's New* voice guidance (correction 4). `CLAUDE.md` kept under the 40 K byte budget (39 992).
- **`README.md`** — version badge `2.3.0 → 2026.07.1`.

## Code review tips

- **The es-AR notes say "Baúl", not "Vault"** — the Spanish UI calls it *Baúl* (`app_vault_screen_title`), so store copy saying "Vault" would send Bompers looking for something that does not exist in their app. The English notes legitimately keep "Vault".
- **Both store files are under Play's 500-char cap** (en-US 494, es-AR 488, counted with the trailing newline). If you edit the copy, re-count or Play truncates it.
- **The AAB must be rebuilt** (see *Rebuild before uploading* above) — the first-pass signed AAB is stale on `versionName`.
- **Brand-DNA cross-check was partial** — the sibling `../push-me-backlog/docs/brand-dna.md` was not present in this environment, so the copy was checked against in-repo authoritative sources (the "always with you" repo tagline, `app_vault_screen_title`, existing strings) rather than the canonical brand doc. Worth a glance against brand-dna on a machine that has it.
- Nothing in `SoundsRepository`, the benchmark seeder or `:macrobenchmark` was touched.

## Already tested

The gates below were green on the **first pass** (`versionName 2026.07`). The corrections in this revision are version-string / CHANGELOG / store-copy / docs only — no Kotlin changed — so the instrumented suite stays exempt (CLAUDE.md). Re-run the release gates after the `versionName` bump (see *Rebuild before uploading*).

- ADR invariants: `./scripts/check-adr-invariants.sh` — re-run green after this revision.
- Store-note char counts + `CLAUDE.md` size budget — re-verified (en-US 494, es-AR 488; CLAUDE.md 39 992 ≤ 40 000).
- Release lint gate `app:lintVitalRelease`, AAB `app:bundle`, `./gradlew test`, `./gradlew check -x test` — green on the first pass; **re-run** after the `versionName` change.
- Instrumented suite: **not run** (version/CHANGELOG/copy/docs only, which CLAUDE.md exempts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)