### PR TITLE
test(benchmark): pin the tapped synthetic row so the latency gate can run

### DIFF
--- a/app/src/benchmark/java/com/github/barriosnahuel/vossosunboton/CustomBuildTypeApplication.kt
+++ b/app/src/benchmark/java/com/github/barriosnahuel/vossosunboton/CustomBuildTypeApplication.kt
@@ -51,6 +51,11 @@ internal abstract class CustomBuildTypeApplication : Application() {
         val sounds =
             (0 until count).map { index ->
                 Sound("$SYNTHETIC_ID_PREFIX$index", "$SYNTHETIC_NAME_PREFIX $index", "$SYNTHETIC_FILE_PREFIX$index.dat")
+                    // Sound 0 is the row TapLatencyBenchmark taps, and `By.text` only matches composed
+                    // nodes: on a device that already holds audios, an unpinned synthetic row falls below
+                    // the fold and the LazyColumn never composes it. Pinning sorts it first (SOUND_ORDER),
+                    // so the row is on screen whatever the device already holds. Playback path is unchanged.
+                    .copy(isPinned = index == PLAYABLE_INDEX)
             }
         runBlocking {
             SoundsRepository(this@CustomBuildTypeApplication)
@@ -66,7 +71,7 @@ internal abstract class CustomBuildTypeApplication : Application() {
      * playback fidelity only needs the one tapped row. Idempotent; still synchronous in `onCreate`.
      */
     private fun seedPlayableAudioFile() {
-        val playableFile = getFile(this, "${SYNTHETIC_FILE_PREFIX}0.dat")
+        val playableFile = getFile(this, "$SYNTHETIC_FILE_PREFIX$PLAYABLE_INDEX.dat")
         if (playableFile.exists()) {
             return
         }
@@ -83,6 +88,9 @@ const val SEED_COUNT_EXTRA = "benchmark_seed_count"
 const val SYNTHETIC_NAME_PREFIX = "Benchmark sound"
 
 private const val SYNTHETIC_ID_PREFIX = "benchmark:"
+
+/** The one synthetic row backed by real audio bytes — the row `TapLatencyBenchmark` taps. */
+private const val PLAYABLE_INDEX = 0
 
 /**
  * File-name prefix for synthetic rows. Deliberately NOT the id prefix: a `:` is rejected by the

--- a/macrobenchmark/RESULTS.md
+++ b/macrobenchmark/RESULTS.md
@@ -9,4 +9,10 @@ validated (§ *Performance → What it measures*).
 | Date | Device | Branch / context | Benchmark | Min (ms) | Median (ms) | Max (ms) | Iterations |
 |---|---|---|---|---|---|---|---|
 | 2026-07-04 | Pixel 8 (API 16/36) | `test/tap-latency-guardrail` — baseline pre-Media3, MediaPlayer engine | TapLatencyBenchmark.tapToSoundFirstTap | 31.3 | 53.5 | 80.9 | 5 |
-| 2026-07-13 | Pixel 8 (API 16/36) | `test/tap-latency-seed-pinned` — v2026.07.1 pre-release gate, post-Media3 (tap path still MediaPlayer, ADR 0022) | TapLatencyBenchmark.tapToSoundFirstTap | 51.8 | 56.5 | 235.1 | 5 |
+| 2026-07-13 | Pixel 8 (API 16/36) | `test/tap-latency-seed-pinned` — v2026.07.1 pre-release gate, post-Media3 (tap path still MediaPlayer, ADR 0022) | TapLatencyBenchmark.tapToSoundFirstTap | 38.6 | 49.0 | 140.1 | 15 |
+
+**Reading the `Max` column:** `StartupMode.COLD` makes **iteration 1 a warmup outlier** — it is the
+`Max` in every run so far. A 30-iteration run on the same build measured **263.4 ms on the first sample
+and 35–64 ms on the other 29** (p95 = 63.5 ms; the only sample over 100 ms was the first). Its median,
+49.9 ms, matches the 15-iteration median above (49.0 ms) — which is why `DEFAULT_ITERATIONS` is 15.
+**Read the median.** A high `Max` here is warmup, not a latency regression.

--- a/macrobenchmark/RESULTS.md
+++ b/macrobenchmark/RESULTS.md
@@ -9,3 +9,4 @@ validated (§ *Performance → What it measures*).
 | Date | Device | Branch / context | Benchmark | Min (ms) | Median (ms) | Max (ms) | Iterations |
 |---|---|---|---|---|---|---|---|
 | 2026-07-04 | Pixel 8 (API 16/36) | `test/tap-latency-guardrail` — baseline pre-Media3, MediaPlayer engine | TapLatencyBenchmark.tapToSoundFirstTap | 31.3 | 53.5 | 80.9 | 5 |
+| 2026-07-13 | Pixel 8 (API 16/36) | `test/tap-latency-seed-pinned` — v2026.07.1 pre-release gate, post-Media3 (tap path still MediaPlayer, ADR 0022) | TapLatencyBenchmark.tapToSoundFirstTap | 51.8 | 56.5 | 235.1 | 5 |

--- a/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/BenchmarkTargets.kt
+++ b/macrobenchmark/src/main/java/com/github/barriosnahuel/vossosunboton/macrobenchmark/BenchmarkTargets.kt
@@ -13,8 +13,14 @@ package com.github.barriosnahuel.vossosunboton.macrobenchmark
  */
 internal const val TARGET_PACKAGE = "com.github.barriosnahuel.vossosunboton.debug"
 
-/** Iterations per benchmark. Kept modest so a full local run stays under a few minutes. */
-internal const val DEFAULT_ITERATIONS = 5
+/**
+ * Iterations per benchmark. `StartupMode.COLD` makes the **first** iteration a warmup outlier — a
+ * 30-iteration TapLatency run measured 263 ms on iteration 1 and 35–64 ms on the other 29 — so the
+ * count has to be high enough that one such sample doesn't swing the median the gates are read from.
+ * At 5 the median moved 13% run-to-run (56.5 vs 49.9 ms); 15 keeps it stable while a full local run
+ * still takes a few minutes.
+ */
+internal const val DEFAULT_ITERATIONS = 15
 
 /** Number of fling gestures per scroll-benchmark iteration. */
 internal const val SCROLL_GESTURES = 3


### PR DESCRIPTION
### Summary

Internal — no user-visible behavior change. Test-harness only; the seeder it touches exists solely in the `benchmark` build type and never reaches release or debug.

Unblocks the **tap-to-sound latency gate**, which had stopped running. The regression it guards is very much user-facing: the Media3 migration must not make a Bomp take longer to start playing after you tap it. With the benchmark broken, the v2026.07.1 cut had no way to check that budget.

**Gate result on a physical Pixel 8: median 49.0 ms, against the ≤100 ms budget** — in line with the 53.5 ms pre-Media3 baseline. The tap path did not regress.

### Technical detail

`TapLatencyBenchmark` failed with `Playable seeded sound (Benchmark sound 0) didn't render within 15000 ms` — it never reached the measurement.

- **Root cause: the harness, not the product.** The benchmark locates its row with `By.text("Benchmark sound 0")`, and `By.text` only matches **composed** nodes. In a `LazyColumn`, rows below the fold are never composed, so they do not exist in the accessibility tree. On a device that already holds real audios, the seeded row is pushed off screen and the 15 s wait expires. The benchmark implicitly assumed an empty list; it passed before only because the device held fewer audios.
- **`CustomBuildTypeApplication` (benchmark source set)** — the one synthetic row backed by real audio bytes is now seeded **pinned**. `SOUND_ORDER` sorts pinned first, so the row is on screen whatever the device already holds. The `0` literal, previously duplicated between the corpus and the audio-file seeding, is now the named `PLAYABLE_INDEX`.
- **`macrobenchmark/RESULTS.md`** — appends the v2026.07.1 gate run, plus a note on how to read the `Max` column (see below).
- **`DEFAULT_ITERATIONS` 5 → 15.** `StartupMode.COLD` makes **iteration 1 a warmup outlier** — it is the `Max` in every run. A 30-iteration run measured **263 ms on the first sample and 35–64 ms on the other 29** (p95 63.5 ms; the only sample over 100 ms was the first). The median is robust to that, but at 5 samples it swung 13% run-to-run (56.5 vs 49.9 ms) — too noisy for a number a release decision is read from. At 15 it lands on 49.0 ms, matching the 30-iteration median (49.9 ms). Applies to all three benchmarks; a full local run still takes a few minutes.
- **Explicitly ruled out — persistence.** The seed always worked: launching with `benchmark_seed_count=1` moves the counter to `All sounds · 14` and `50` to `All sounds · 63`, against a baseline of 13 real audios on that device. A JVM test writing via `replaceSyntheticCorpus` and reading back through `repo.sounds` passes. `SoundsRepository` is sound and the `loadSounds` / initial-load-gate changes are not implicated.

### Code review tips

- **Pinning changes what the benchmark measures, slightly:** the tapped row is now a pinned row. Playback goes through the same `PlayerController` path either way, so the number stays comparable to the 2026-07-04 baseline (49.0 vs 53.5 ms confirms it) — but it is a deliberate change to the fixture, worth a conscious ack.
- **The high `Max` is warmup, and now proven so** — across both a 30- and a 15-iteration run it was *always* the first sample. `RESULTS.md` now says this explicitly so the next reader does not mistake it for a regression.
- The alternative fixes considered were scrolling to the row (fragile — breaks again as the device accumulates audios) and clearing the list before seeding (runs against a personal phone holding real Bomps). Pinning was chosen as the minimal, deterministic one.
- **Known leftover, not addressed here:** the file-less synthetic rows (`1..49`) render once scrolled to, but row `0` was not observed rendering *unpinned* even after scrolling, despite being counted by the list. Pinning sidesteps it; the underlying question stands.

### Already tested

- `TapLatencyBenchmark` on a physical Pixel 8 — passes, median **49.0 ms** (min 38.6, max 140.1 = warmup, 15 iterations). Recorded in `RESULTS.md`.
- Also run at **30 iterations** to characterise the distribution: median 49.9 ms, p95 63.5 ms, 1/30 over 100 ms (the warmup sample).
- Unit tests: `./gradlew test` — green.
- Lint / static analysis: `./gradlew check -x test` — green.
- ADR invariants: `./scripts/check-adr-invariants.sh` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
