### PR TITLE
feat(motion): physics-based transitions via centralized spring specs

### DIFF
--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/LandingScreen.kt
@@ -11,9 +11,13 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Box
@@ -102,7 +106,10 @@ import com.github.barriosnahuel.vossosunboton.ui.home.navigation.instantTabTrans
 import com.github.barriosnahuel.vossosunboton.ui.home.navigation.rememberLandingNavigationState
 import com.github.barriosnahuel.vossosunboton.ui.home.navigation.toRoute
 import com.github.barriosnahuel.vossosunboton.ui.home.navigation.toTabOrNull
+import com.github.barriosnahuel.vossosunboton.ui.rememberReduceMotionEnabled
 import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
+import com.github.barriosnahuel.vossosunboton.ui.theme.bompEffectsSpec
+import com.github.barriosnahuel.vossosunboton.ui.theme.bompSpatialSpec
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
@@ -127,6 +134,7 @@ fun LandingScreen(viewModel: SoundsViewModel) {
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
     val tracker = remember(context) { AnalyticsTrackerProvider.get(context.applicationContext) }
+    val reduceMotion = rememberReduceMotionEnabled()
 
     // Navigation 3 backbone (ADR 0024): one saveable back stack per tab + typed child destinations.
     // The graph is the single source of truth for where the user is (ADR 0024 § Consequences).
@@ -396,7 +404,20 @@ fun LandingScreen(viewModel: SoundsViewModel) {
     com.github.barriosnahuel.vossosunboton.feature.collections
         .CollectionDeleteDialog(viewModel = viewModel)
 
-    if (isSearchVisible) {
+    // Only the entry animates here: the overlay's dismissal is already gesture-driven by
+    // `predictiveBackTransition` inside SearchOverlay, so `ExitTransition.None` leaves that path
+    // untouched. Reduce-motion collapses the entry to an instant fade (WCAG 2.3.3).
+    AnimatedVisibility(
+        visible = isSearchVisible,
+        enter =
+            if (reduceMotion) {
+                fadeIn(snap())
+            } else {
+                fadeIn(bompEffectsSpec()) + scaleIn(initialScale = SEARCH_OVERLAY_INITIAL_SCALE, animationSpec = bompSpatialSpec())
+            },
+        exit = ExitTransition.None,
+        label = "search_overlay",
+    ) {
         SearchOverlayHost(
             viewModel = viewModel,
             query = searchQuery,
@@ -954,6 +975,7 @@ private fun AppBottomBar(
 }
 
 private const val DELETE_ANIMATION_DURATION_MS = 300
+private const val SEARCH_OVERLAY_INITIAL_SCALE = 0.96f
 private val WELCOME_BORDER_WIDTH = 1.5.dp
 
 // Reserve room below the last card on My Bomps so it scrolls clear of the + FAB (56dp FAB + margin).
@@ -1032,6 +1054,12 @@ internal fun SoundsList(
                             fadeOutSpec = null,
                             placementSpec = spring(),
                         ),
+                    // No entry animation on purpose: AnimatedVisibility's enter fires for every item
+                    // added to the dataset (filter changes, Vault unlock) — not just an undo — so
+                    // animating it would burst-scale unrelated items on a filter toggle. The list's
+                    // placementSpec already springs the reflow. The exit stays a fixed 300ms tween,
+                    // coupled to the `delay(DELETE_ANIMATION_DURATION_MS)` below that commits the
+                    // removal; a non-deterministic spring there would desync visual from data drop.
                     enter = EnterTransition.None,
                     exit =
                         scaleOut(

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/home/SoundItem.kt
@@ -4,8 +4,9 @@
  * See LICENSE in the project root for full license information.
  */
 package com.github.barriosnahuel.vossosunboton.ui.home
-import android.provider.Settings
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -50,7 +51,6 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -69,10 +69,12 @@ import com.github.barriosnahuel.vossosunboton.model.Sound
 import com.github.barriosnahuel.vossosunboton.ui.AppIcons
 import com.github.barriosnahuel.vossosunboton.ui.haptics.performConfirmHaptic
 import com.github.barriosnahuel.vossosunboton.ui.haptics.performRejectHaptic
+import com.github.barriosnahuel.vossosunboton.ui.rememberReduceMotionEnabled
 import com.github.barriosnahuel.vossosunboton.ui.theme.DISABLED_TRACK_ALPHA
 import com.github.barriosnahuel.vossosunboton.ui.theme.MUTED_TEXT_ALPHA
 import com.github.barriosnahuel.vossosunboton.ui.theme.PLAYING_TINT_ALPHA
 import com.github.barriosnahuel.vossosunboton.ui.theme.Spacing
+import com.github.barriosnahuel.vossosunboton.ui.theme.bompEffectsSpec
 import kotlinx.coroutines.CancellationException
 import kotlin.math.roundToInt
 
@@ -147,21 +149,15 @@ fun SoundItem(
         val hintOffsetX = remember { Animatable(0f) }
         val density = LocalDensity.current
         val peekPx = remember(density) { with(density) { WELCOME_HINT_PEEK.toPx() } }
-        val hintContext = LocalView.current.context
+        val reduceMotion = rememberReduceMotionEnabled()
         val currentOnHintShown by rememberUpdatedState(onSwipeHintShown)
         LaunchedEffect(showSwipeHint) {
             if (!showSwipeHint) return@LaunchedEffect
             // Wait for the first frame so the node is laid out before animating, mirroring the
             // FocusRequester incantation documented in CLAUDE.md.
             withFrameNanos { }
-            val animationsEnabled =
-                Settings.Global.getFloat(
-                    hintContext.contentResolver,
-                    Settings.Global.ANIMATOR_DURATION_SCALE,
-                    1f,
-                ) != 0f
             try {
-                if (animationsEnabled) {
+                if (!reduceMotion) {
                     hintOffsetX.animateTo(-peekPx, tween(WELCOME_HINT_OUT_MS))
                     hintOffsetX.animateTo(0f, tween(WELCOME_HINT_BACK_MS))
                 }
@@ -456,15 +452,27 @@ private fun SoundCard(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.Top,
             ) {
+                val reduceMotion = rememberReduceMotionEnabled()
                 val playContainerColor = MaterialTheme.colorScheme.primaryContainer
+                // Tint fades with an effects spring (no bounce on colour); reduce-motion snaps it.
+                val playTint by animateColorAsState(
+                    // Fade to the same hue at alpha 0 (not Color.Transparent): interpolating toward
+                    // transparent black would dip the tint dark in sRGB while the alpha drops.
+                    targetValue =
+                        if (sound.isPlaying) {
+                            playContainerColor.copy(alpha = PLAYING_TINT_ALPHA)
+                        } else {
+                            playContainerColor.copy(alpha = 0f) // alpha-ok
+                        },
+                    animationSpec = if (reduceMotion) snap() else bompEffectsSpec(),
+                    label = "play_tint",
+                )
                 Box(
                     contentAlignment = Alignment.Center,
                     modifier =
                         Modifier
-                            .background(
-                                color = if (sound.isPlaying) playContainerColor.copy(alpha = PLAYING_TINT_ALPHA) else Color.Transparent,
-                                shape = CircleShape,
-                            ).padding(6.dp),
+                            .background(color = playTint, shape = CircleShape)
+                            .padding(6.dp),
                 ) {
                     FilledIconButton(
                         onClick = onPlayClick,
@@ -588,6 +596,14 @@ private fun SoundCardHeader(
     onDeleteClick: (() -> Unit)?,
     shareEnabled: Boolean = true,
 ) {
+    val reduceMotion = rememberReduceMotionEnabled()
+    // Pin/unpin tint crossfades with an effects spring (no bounce on colour); reduce-motion snaps it.
+    val pinTint by animateColorAsState(
+        targetValue =
+            if (sound.isPinned) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+        animationSpec = if (reduceMotion) snap() else bompEffectsSpec(),
+        label = "pin_tint",
+    )
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
@@ -611,7 +627,7 @@ private fun SoundCardHeader(
                 Icon(
                     imageVector = if (sound.isPinned) AppIcons.PushPin else AppIcons.PushPinOutlined,
                     contentDescription = stringResource(if (sound.isPinned) R.string.app_unpin else R.string.app_pin),
-                    tint = if (sound.isPinned) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                    tint = pinTint,
                 )
             }
         }

--- a/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/theme/Motion.kt
+++ b/app/src/main/java/com/github/barriosnahuel/vossosunboton/ui/theme/Motion.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2016-2026 Nahuel Barrios. All rights reserved.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * See LICENSE in the project root for full license information.
+ */
+package com.github.barriosnahuel.vossosunboton.ui.theme
+
+import androidx.compose.animation.core.FiniteAnimationSpec
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+
+/*
+ * Bomp's spring vocabulary — the project's motion specs while Material 3's MotionScheme is still
+ * internal in material3 1.4.0 (not consumable from app code; migration is a follow-up). Two flavours,
+ * following the same spatial-vs-effects split the scheme uses internally:
+ *  - spatial: things that move (enter/exit, size, position) — a touch of bounce is Bomp's character.
+ *  - effects: things that change colour/alpha — no bounce; a bouncing colour reads as a glitch.
+ * Centralised so "the Bomp spring" lives in one place: the future migration to the public
+ * MotionScheme becomes a one-file change. Rationale: ../push-me-backlog/backlog/004-physics-based-motion.md.
+ */
+
+/** Spatial spring for entrances, exits and layout — carries a subtle bounce (Bomp character). */
+internal fun <T> bompSpatialSpec(): FiniteAnimationSpec<T> =
+    spring(dampingRatio = Spring.DampingRatioLowBouncy, stiffness = Spring.StiffnessMediumLow)
+
+/** Effects spring for colour/alpha changes — no bounce. */
+internal fun <T> bompEffectsSpec(): FiniteAnimationSpec<T> =
+    spring(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessMedium)


### PR DESCRIPTION
### Summary

Two spots that used to change with a hard cut now move with physics.

1. User opens search from the top bar
2. User taps play on an audio
3. User pins an audio

**before:** search snapped open in one frame, and the play/pin tints flipped instantly — the app read "digital".
**after:** search enters with a fade + subtle scale, and the play/pin tints ease between states. Every transition is an interruptible spring, and all of it collapses to instant when the system "Remove animations" setting is on.

### Technical detail

Adopts a small, centralized spring vocabulary instead of Material 3's `MotionScheme` — that API is still `internal` in material3 1.4.0 (not consumable from app code), so `spring()` is used directly with the same spatial-vs-effects split the scheme uses internally. Rationale + follow-up: `../push-me-backlog/backlog/004-physics-based-motion.md`.

- **`ui/theme/Motion.kt`** (new): `bompSpatialSpec()` (bouncy — for things that move) and `bompEffectsSpec()` (no bounce — for colour/alpha). One place defines "the Bomp spring"; the future migration to the public `MotionScheme` becomes a one-file change.
- **`LandingScreen.kt`** — the search overlay's raw `if (isSearchVisible)` is wrapped in `AnimatedVisibility` with a fade + scale entry; `exit = ExitTransition.None` leaves the existing gesture-driven predictive-back dismissal untouched.
- **`SoundItem.kt`** — play tint and pin tint move to `animateColorAsState` (effects spring); the reduce-motion read is unified onto `rememberReduceMotionEnabled()`, dropping the inline `Settings.Global` probe.
- **Tab-switch motion: evaluated on device, then dropped.** A cross-fade/scale on tab entries was tried but reads as imperceptible and, worse, asymmetric — the multi-stack nav keeps Home composed as the base, so entering Vault/Explore animates while returning to My Bomps is a reveal (z-order hides the outgoing tab). Doing it right needs an `AnimatedContent` refactor; deferred to the brand-motion spec (`028`) rather than shipped half-working in the floor. Tabs return to develop's instant switch.
- **Left unchanged on purpose:** predictive back and `SaveSuccessOverlay` (already spring-driven), the AOSP-replica collection highlight, the list-item enter (`None`), and the delete exit (`tween` coupled to the removal delay — see review tips).

### Code review tips

- **Instrumented flake (infra, not a code failure) — please re-run before merge.** `RecorderResumeDraftTest#resumingADraftReopensTheRecorderInReview` timed out (`TestTimedOutException`, 300s) inside its `runBlocking { draftStore.save(...) }` **setup** — which runs *before* `ActivityScenario.launch`, i.e. before any code in this diff executes. It reproduced only under host I/O load; the AVD then stopped cold-booting. This is the cold-boot AVD degradation ADR 0001 documents as re-runnable, not a regression. On a healthy AVD the suite is 134/134.
- **`MotionScheme` is internal in material3 1.4.0** — confirmed against the library sources. This is why the change uses `spring()` directly rather than the scheme; the delta is functionally equivalent for the floor.
- **Search overlay exit is `None` by design** — dismissal already animates through `predictiveBackTransition`. Closing via the X / tap-out is an instant unmount (as before); only the *entry* was the 0ms gap this fixes.
- **`playTint` fades toward the same hue at alpha 0**, not `Color.Transparent` — the latter would dip the tint toward black in sRGB while the alpha drops.
- **Manual verification suggested (device-only):** with "Remove animations" ON, the search entry and the tints should be instant.

### Already tested

Instrumented UI suite (CircleCI does not run it — ADR 0001), via `./scripts/run-instrumented-tests.sh` (cold-boot AVD): **133/134 green** on the prior revision, including `SearchOverlayTest` (the wrapped overlay), `WelcomeStickerFlowTest` and the navigation tests. This revision only *removes* the tab-switch motion (tabs return to develop's instant behaviour); the animated surfaces (search/tint/pin) are unchanged from that run. The one non-green — `RecorderResumeDraftTest` — is a DataStore-setup timeout unrelated to this diff (triage above). Unit + lint are green locally and re-run by CI.
